### PR TITLE
Version Packages: republish TSRX runtimes

### DIFF
--- a/packages/tsrx-preact-runtime/CHANGELOG.md
+++ b/packages/tsrx-preact-runtime/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @tsrx/preact-runtime
 
+## 0.1.2
+
+### Patch Changes
+
+- Republish the TSRX runtime packages from the dedicated TSRX repository so their
+  npm metadata and provenance identify `tsrx-org/tsrx`.
+
+- Updated dependencies:
+  - @tsrx/runtime@0.1.2
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/tsrx-preact-runtime/package.json
+++ b/packages/tsrx-preact-runtime/package.json
@@ -3,7 +3,7 @@
   "description": "Runtime helpers for TSRX Preact compiled output",
   "license": "MIT",
   "author": "Dominic Gannaway",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/tsrx-react-runtime/CHANGELOG.md
+++ b/packages/tsrx-react-runtime/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @tsrx/react-runtime
 
+## 0.1.2
+
+### Patch Changes
+
+- Republish the TSRX runtime packages from the dedicated TSRX repository so their
+  npm metadata and provenance identify `tsrx-org/tsrx`.
+
+- Updated dependencies:
+  - @tsrx/runtime@0.1.2
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/tsrx-react-runtime/package.json
+++ b/packages/tsrx-react-runtime/package.json
@@ -3,7 +3,7 @@
   "description": "Runtime helpers for TSRX React compiled output",
   "license": "MIT",
   "author": "Dominic Gannaway",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/tsrx-runtime/CHANGELOG.md
+++ b/packages/tsrx-runtime/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tsrx/runtime
 
+## 0.1.2
+
+### Patch Changes
+
+- Republish the TSRX runtime packages from the dedicated TSRX repository so their
+  npm metadata and provenance identify `tsrx-org/tsrx`.
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/tsrx-runtime/package.json
+++ b/packages/tsrx-runtime/package.json
@@ -3,7 +3,7 @@
   "description": "Renderer-neutral runtime helpers for TSRX compiled output",
   "license": "MIT",
   "author": "Dominic Gannaway",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/tsrx-solid-runtime/CHANGELOG.md
+++ b/packages/tsrx-solid-runtime/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @tsrx/solid-runtime
 
+## 0.1.2
+
+### Patch Changes
+
+- Republish the TSRX runtime packages from the dedicated TSRX repository so their
+  npm metadata and provenance identify `tsrx-org/tsrx`.
+
+- Updated dependencies:
+  - @tsrx/runtime@0.1.2
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/tsrx-solid-runtime/package.json
+++ b/packages/tsrx-solid-runtime/package.json
@@ -3,7 +3,7 @@
   "description": "Runtime helpers for TSRX Solid compiled output",
   "license": "MIT",
   "author": "Dominic Gannaway",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/tsrx-vue-runtime/CHANGELOG.md
+++ b/packages/tsrx-vue-runtime/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @tsrx/vue-runtime
 
+## 0.1.2
+
+### Patch Changes
+
+- Republish the TSRX runtime packages from the dedicated TSRX repository so their
+  npm metadata and provenance identify `tsrx-org/tsrx`.
+
+- Updated dependencies:
+  - @tsrx/runtime@0.1.2
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/tsrx-vue-runtime/package.json
+++ b/packages/tsrx-vue-runtime/package.json
@@ -3,7 +3,7 @@
   "description": "Runtime helpers for TSRX Vue compiled output",
   "license": "MIT",
   "author": "Dominic Gannaway",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

- bump the five unchanged TSRX runtime packages from 0.1.1 to 0.1.2
- publish their new tsrx-org/tsrx repository metadata and npm provenance
- update renderer-runtime dependencies to the packed @tsrx/runtime 0.1.2 version
- avoid unrelated compiler, tooling, and VS Code version bumps

## Packages

- @tsrx/runtime
- @tsrx/preact-runtime
- @tsrx/react-runtime
- @tsrx/solid-runtime
- @tsrx/vue-runtime

## Validation

- pnpm changeset:check
- Prettier checks for all changed manifests and changelogs
- 216 targeted runtime tests
- packed all five packages and verified versions, repository URLs, and internal runtime dependency versions

Merging this Version Packages PR triggers the guarded npm trusted-publishing workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch version and changelog-only changes with no runtime code modifications; risk is limited to publish metadata and npm release process.
> 
> **Overview**
> This **Version Packages** release bumps all five TSRX runtime npm packages from **0.1.1** to **0.1.2** with no runtime source changes in the diff.
> 
> Each package gets a new changelog entry documenting a **republish** so npm metadata and provenance point at **`tsrx-org/tsrx`**. The four renderer runtimes (`@tsrx/preact-runtime`, `@tsrx/react-runtime`, `@tsrx/solid-runtime`, `@tsrx/vue-runtime`) also record an updated dependency on **`@tsrx/runtime@0.1.2`**.
> 
> Merging is intended to trigger the guarded npm trusted-publishing workflow for these packages only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95c27dbc8ab007a2a95fc5c0bbbbfc6313451928. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->