### PR TITLE
fix(core): tolerate unmapped computed method brackets

### DIFF
--- a/.changeset/calm-computed-maps.md
+++ b/.changeset/calm-computed-maps.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Avoid failing virtual TypeScript generation when a computed object method's bracket positions are absent from the printer source map.

--- a/packages/tsrx/src/transform/segments.js
+++ b/packages/tsrx/src/transform/segments.js
@@ -517,6 +517,11 @@ export function convert_source_map_to_mappings(
 	function set_bracket_computed_mapping(node, mappings) {
 		if (has_location(node.key)) {
 			const key = node.key;
+			const start_key = `${key.loc.start.line}:${key.loc.start.column - 1}`;
+			const end_key = `${key.loc.end.line}:${key.loc.end.column + 1}`;
+			if (!src_to_gen_map.get(start_key)?.length || !src_to_gen_map.get(end_key)?.length) {
+				return;
+			}
 			mappings.push(
 				get_mapping_from_node(
 					/** @type {AST.NodeWithLocation} */ ({

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -54,6 +54,11 @@ function F(props: { n: number }) @{
 			expect_maps(`function F(props: { k: string }) @{
 	const merge = (current: object) => ({ ...current, [props.k]: '' });
 }`));
+		it('computed object method', () =>
+			expect_maps(`const method = 'read';
+function C() @{
+	const value = { [method]() { return 'ok'; } };
+}`));
 		// AssignmentPattern spans reaching into marker-less literal tokens.
 		it('parameter default array literal', () =>
 			expect_maps(`function parse(points = []) {


### PR DESCRIPTION
## Summary

- skip the optional computed-bracket diagnostic mapping when Esrap emits no boundary markers
- retain the key and method mappings
- cover computed object methods in every shared target mapping suite

## Validation

- `pnpm exec vitest run --project tsrx-react --project tsrx-preact --project tsrx-solid --project tsrx-vue packages/tsrx-react/tests/basic.test.js packages/tsrx-preact/tests/basic.test.js packages/tsrx-solid/tests/basic.test.js packages/tsrx-vue/tests/basic.test.js`
- `pnpm exec tsgo --noEmit -p packages/tsrx/tsconfig.json`
- `pnpm changeset:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized guard in source-map mapping logic with a regression test; no auth, data, or runtime behavior changes.
> 
> **Overview**
> **Virtual TypeScript / Volar mapping generation** no longer crashes when Esrap’s printer source map omits markers at the `[` / `]` columns around a **computed object method** (e.g. `{ [method]() { … } }`).
> 
> In `set_bracket_computed_mapping`, the optional diagnostic mapping that widens the span to include computed brackets is **skipped** when `src_to_gen_map` has no entry for the bracket-adjacent positions; mappings for the key and method body are unchanged.
> 
> A shared **source-mappings** regression test covers computed object methods alongside the existing computed object key case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 101b27ee352d1835295ab1afad4873dc8fb7d52f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->