### PR TITLE
perf(tsrx): speed up parameter comment attachment

### DIFF
--- a/packages/tsrx/src/parse/index.js
+++ b/packages/tsrx/src/parse/index.js
@@ -809,6 +809,10 @@ export function get_comment_handlers(source, comments, index = 0) {
 								const hasBlankLine = /\n\s*\n/.test(slice);
 								const nodeEndLine = node.loc?.end?.line ?? null;
 								const commentStartLine = comments[0].loc?.start?.line ?? null;
+								const commentOnSameLine =
+									nodeEndLine !== null &&
+									commentStartLine !== null &&
+									nodeEndLine === commentStartLine;
 								const isImmediateNextLine =
 									nodeEndLine !== null &&
 									commentStartLine !== null &&
@@ -853,10 +857,7 @@ export function get_comment_handlers(source, comments, index = 0) {
 									// For function parameters, only attach as trailing comment if it's on the same line
 									// Comments on next line after comma should be leading comments of next parameter
 									if (isParam) {
-										// Check if comment is on same line as the node
-										const nodeEndLine = source.slice(0, node.end).split('\n').length;
-										const commentStartLine = source.slice(0, comments[0].start).split('\n').length;
-										if (nodeEndLine === commentStartLine) {
+										if (commentOnSameLine) {
 											node.trailingComments = [
 												/** @type {AST.CommentWithLocation} */ (comments.shift()),
 											];
@@ -868,11 +869,6 @@ export function get_comment_handlers(source, comments, index = 0) {
 										// Only attach as trailing if:
 										// 1. It's on the same line as this node, OR
 										// 2. This is the last item in the array (no next sibling to attach to)
-										const commentOnSameLine =
-											nodeEndLine !== null &&
-											commentStartLine !== null &&
-											nodeEndLine === commentStartLine;
-
 										if (commentOnSameLine || is_last_in_array) {
 											node.trailingComments = [
 												/** @type {AST.CommentWithLocation} */ (comments.shift()),

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -4238,6 +4238,26 @@ const p: Point = { x: 1 }; // trailing`,
 		expect(new Set(starts).size).toBe(starts.length);
 		expect(comments.length).toBe(3);
 	});
+
+	it('attaches parameter comments according to their parser locations', () => {
+		const ast = parseModule(
+			`function f(
+	a /* a */,
+	b,
+	/* before c */ c /* c */
+) {}`,
+			'App.ts',
+		);
+		const [declaration] = ast.body;
+		assert_type(declaration, 'FunctionDeclaration');
+		const [a, b, c] = declaration.params;
+
+		expect(a.trailingComments?.map((comment) => comment.value)).toEqual([' a ']);
+		expect(b.leadingComments).toBeUndefined();
+		expect(b.trailingComments).toBeUndefined();
+		expect(c.leadingComments?.map((comment) => comment.value)).toEqual([' before c ']);
+		expect(c.trailingComments?.map((comment) => comment.value)).toEqual([' c ']);
+	});
 });
 
 describe('keywordTokens parse option', () => {


### PR DESCRIPTION
## Summary

Parameter-heavy functions with comments no longer make the parser rebuild line numbers from complete source prefixes. Parser output remains unchanged because comment attachment now reuses the exact locations already emitted by Acorn.

## Performance

The benchmark parses a function with 2,000 line-separated, commented parameters and compares the candidate against a frozen control parser. Each result is the median of five isolated runs.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Candidate/control ratio | 1.0013 | 0.1518 | 84.8% lower (~6.6× faster) |

## Validation

- `pnpm exec vitest run --project tsrx-utils`: 18 files and 470 tests passed
- `pnpm exec tsgo --noEmit -p packages/tsrx/tsconfig.json` passed
- Prettier passed for the two changed files
- Five benchmark confirmation runs preserved the full comment-attachment digest and attached all 2,000 expected comments

This is an internal parser performance change with no public API, compiler-output, dependency, or changeset impact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal parser performance refactor with behavior pinned by tests; no public API or output contract change beyond matching existing comment attachment rules.
> 
> **Overview**
> **Speeds up comment attachment** for heavily commented function parameter lists by dropping per-comment line math that walked the full source prefix (`source.slice(0, …).split('\n')`).
> 
> Trailing vs leading attachment for parameters (and siblings) now uses a single **`commentOnSameLine`** check from **`node.loc`** and **`comments[0].loc`**, shared for the `isParam` branch and the general trailing-comment path.
> 
> A parser test locks in parameter comment placement (inline trailing on `a`, leading on `c`, no stray comments on `b`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27db54e610834fd9dcd734e3a4999bff8fb181ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->