### PR TITLE
perf(tsrx): speed up local export scope lookups

### DIFF
--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -276,6 +276,7 @@ export function TSRXPlugin(config) {
 			#errors = undefined;
 			/** @type {string | null} */
 			#filename = null;
+			#localExportNamesByScope = new WeakMap();
 			#functionBodyDepth = 0;
 			#allowExpressionContainerTrailingSemicolon = false;
 			#jsxAttributeValueExpressionDepth = 0;
@@ -3249,7 +3250,30 @@ export function TSRXPlugin(config) {
 				// Check all scopes in the scope stack, not just the top-level scope
 				for (let i = this.scopeStack.length - 1; i >= 0; i--) {
 					const scope = this.scopeStack[i];
-					if (scope.lexical.indexOf(name) !== -1 || scope.var.indexOf(name) !== -1) {
+					let cached = this.#localExportNamesByScope.get(scope);
+					if (
+						!cached ||
+						cached.lexicalLength > scope.lexical.length ||
+						cached.varLength > scope.var.length
+					) {
+						cached = {
+							names: new Set(),
+							lexicalLength: 0,
+							varLength: 0,
+						};
+						this.#localExportNamesByScope.set(scope, cached);
+					}
+
+					for (let j = cached.lexicalLength; j < scope.lexical.length; j++) {
+						cached.names.add(scope.lexical[j]);
+					}
+					for (let j = cached.varLength; j < scope.var.length; j++) {
+						cached.names.add(scope.var[j]);
+					}
+					cached.lexicalLength = scope.lexical.length;
+					cached.varLength = scope.var.length;
+
+					if (cached.names.has(name)) {
 						// Found in a scope, remove from undefinedExports if it was added
 						delete this.undefinedExports[name];
 						return;

--- a/packages/tsrx/tests/utils/export-scope-cache.test.js
+++ b/packages/tsrx/tests/utils/export-scope-cache.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { parseModule } from '../../src/index.js';
+
+describe('local export scope lookup', () => {
+	it('sees names appended after the scope cache is created', () => {
+		const ast = parseModule(
+			`const first = 1;
+export { first };
+const second = 2;
+export { second };`,
+			'export-scope-cache.tsrx',
+		);
+
+		expect(ast.body.filter((node) => node.type === 'ExportNamedDeclaration')).toHaveLength(2);
+	});
+
+	it('still rejects missing local exports', () => {
+		expect(() => parseModule('export { missing };', 'export-scope-cache.tsrx')).toThrow(
+			/Export 'missing' is not defined/,
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Modules with many named local exports no longer rescan every declaration for every exported name. Parser behavior remains unchanged while local export validation now scales linearly with the number of declarations and exports.

## Performance

The benchmark parses a module with 6,000 `const` declarations and one export list containing all 6,000 names. Each result is the median of five runs with the same semantic digest.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Parse time | 229.98 ms | 71.21 ms | 69.0% lower (~3.2× faster) |

## Validation

- TSRX utility suite: 19 files and 472 tests passed
- Focused export-cache regression tests: 2 tests passed
- `tsgo --noEmit -p packages/tsrx/tsconfig.json` passed
- Prettier and `git diff --check` passed
- The benchmark preserved declaration count, export count, and semantic digest

This is an internal parser performance change with no public API, compiler-output, dependency, or changeset impact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal parser caching in export validation only; behavior is covered by new regression tests and existing suites, with no public API change.
> 
> **Overview**
> **Speeds up named `export { … }` validation** when a module has many local bindings and export lists, without changing parse results or diagnostics.
> 
> `checkLocalExport` in the TSRX parser no longer scans each scope’s full `lexical` / `var` arrays on every exported identifier. It keeps a **per-scope incremental cache** (`WeakMap` → `Set` of names plus array lengths) and only merges new entries when those arrays grow, so work scales with declarations plus exports instead of exports × declarations.
> 
> Regression tests cover **late declarations** (e.g. `export { first }` then `const second` then `export { second }`) and **unchanged errors** for undefined exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9c65e1c9859cbb2c5a05b1530dda13bb992aedc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->