### PR TITLE
fix(core): parse lazy arrow parameters

### DIFF
--- a/.changeset/support-lazy-arrow-parameters.md
+++ b/.changeset/support-lazy-arrow-parameters.md
@@ -1,0 +1,5 @@
+---
+"@tsrx/core": patch
+---
+
+Support lazy object and array binding patterns in synchronous and asynchronous arrow function parameters.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -314,6 +314,8 @@ export function TSRXPlugin(config) {
 			#closingNativeTemplateNode = false;
 			#readingJSXControlFlowDirectiveKeyword = false;
 			#readingJSXControlFlowHeader = false;
+			/** @type {(AST.ObjectPattern | AST.ArrayPattern)[][]} */
+			#potentialLazyArrowPatterns = [];
 
 			/**
 			 * @type {Parse.Parser['finishNode']}
@@ -1514,6 +1516,19 @@ export function TSRXPlugin(config) {
 			 * @type {Parse.Parser['parseExprAtom']}
 			 */
 			parseExprAtom(refDestructuringErrors, forInit, forNew) {
+				const lazy_arrow_patterns = this.#potentialLazyArrowPatterns.at(-1);
+				if (
+					lazy_arrow_patterns &&
+					this.type === tt.bitwiseAND &&
+					(this.input.charCodeAt(this.end) === CharCode.openBrace ||
+						this.input.charCodeAt(this.end) === CharCode.openBracket)
+				) {
+					const pattern = /** @type {AST.ObjectPattern | AST.ArrayPattern} */ (
+						this.parseBindingAtom()
+					);
+					lazy_arrow_patterns.push(pattern);
+					return /** @type {AST.Expression} */ (/** @type {unknown} */ (pattern));
+				}
 				// A token already consumed as JSX text (a script-mode element child) must
 				// stay text even when it happens to begin at an `@` — otherwise whether
 				// `@if` parses as a directive would depend on leading whitespace.
@@ -3224,7 +3239,16 @@ export function TSRXPlugin(config) {
 			 */
 			parseParenAndDistinguishExpression(canBeArrow, forInit) {
 				const startPos = this.start;
-				const expr = super.parseParenAndDistinguishExpression(canBeArrow, forInit);
+				const lazy_arrow_patterns = canBeArrow ? [] : null;
+				if (lazy_arrow_patterns) this.#potentialLazyArrowPatterns.push(lazy_arrow_patterns);
+				let expr;
+				try {
+					expr = super.parseParenAndDistinguishExpression(canBeArrow, forInit);
+				} finally {
+					if (lazy_arrow_patterns) this.#potentialLazyArrowPatterns.pop();
+				}
+
+				if (lazy_arrow_patterns) this.#validateLazyArrowPatterns(expr, lazy_arrow_patterns);
 
 				// If the expression's start position is after the opening paren,
 				// it means it was wrapped in parentheses. Mark it in metadata.
@@ -3234,6 +3258,79 @@ export function TSRXPlugin(config) {
 				}
 
 				return expr;
+			}
+
+			/**
+			 * Acorn parses `async (x) => …` through its call-subscript lane rather
+			 * than `parseParenAndDistinguishExpression`, so expose the same lazy
+			 * binding candidate context around that parameter list.
+			 *
+			 * @type {Parse.Parser['parseSubscript']}
+			 */
+			parseSubscript(base, startPos, startLoc, noCalls, maybeAsyncArrow, optionalChained, forInit) {
+				const lazy_arrow_patterns = maybeAsyncArrow && this.type === tt.parenL ? [] : null;
+				if (lazy_arrow_patterns) this.#potentialLazyArrowPatterns.push(lazy_arrow_patterns);
+				let expression;
+				try {
+					expression = super.parseSubscript(
+						base,
+						startPos,
+						startLoc,
+						noCalls,
+						maybeAsyncArrow,
+						optionalChained,
+						forInit,
+					);
+				} finally {
+					if (lazy_arrow_patterns) this.#potentialLazyArrowPatterns.pop();
+				}
+				if (lazy_arrow_patterns) this.#validateLazyArrowPatterns(expression, lazy_arrow_patterns);
+				return expression;
+			}
+
+			/**
+			 * @param {AST.Expression} expression
+			 * @param {(AST.ObjectPattern | AST.ArrayPattern)[]} patterns
+			 */
+			#validateLazyArrowPatterns(expression, patterns) {
+				const misplaced = patterns.find(
+					(pattern) =>
+						expression.type !== 'ArrowFunctionExpression' ||
+						!expression.params.some((param) => this.#bindingPatternContains(param, pattern)),
+				);
+				if (misplaced) {
+					this.raise(
+						/** @type {number} */ (misplaced.start) - 1,
+						'Lazy binding patterns are only valid as arrow parameters in this context',
+					);
+				}
+			}
+
+			/**
+			 * @param {AST.Pattern | AST.AssignmentProperty} pattern
+			 * @param {AST.ObjectPattern | AST.ArrayPattern} target
+			 * @returns {boolean}
+			 */
+			#bindingPatternContains(pattern, target) {
+				if (pattern === target) return true;
+				switch (pattern.type) {
+					case 'AssignmentPattern':
+						return this.#bindingPatternContains(pattern.left, target);
+					case 'RestElement':
+						return this.#bindingPatternContains(pattern.argument, target);
+					case 'ObjectPattern':
+						return pattern.properties.some((property) =>
+							this.#bindingPatternContains(property, target),
+						);
+					case 'Property':
+						return this.#bindingPatternContains(/** @type {AST.Pattern} */ (pattern.value), target);
+					case 'ArrayPattern':
+						return pattern.elements.some(
+							(element) => element && this.#bindingPatternContains(element, target),
+						);
+					default:
+						return false;
+				}
 			}
 
 			/**

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -708,6 +708,25 @@ export function runSharedTsxExpressionTsrxTests({ compile, name, classAttrName }
  */
 export function runSharedNestedLazyDestructuringTests({ compile, name }) {
 	describe(`[${name}] nested lazy destructuring`, () => {
+		it('transforms typed lazy object parameters in arrow components', () => {
+			const { code } = compile(
+				`export const App = (&{ name }: Props) => <div>{name}</div>;`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('(__lazy0: Props) =>');
+			expect(code).toContain('__lazy0.name');
+		});
+
+		it('transforms lazy array parameters in async arrows', () => {
+			const { code } = compile(
+				`export const first = async (&[value]: [number]) => value;`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('const first = async (__lazy0: [number]) => __lazy0[0]');
+		});
+
 		it('transforms nested lazy object inside lazy object in component params', () => {
 			const { code } = compile(
 				`export function App(&{ outer: &{ inner } }: { outer: { inner: number } }) @{

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -3148,6 +3148,58 @@ foo();`;
 		]);
 	});
 
+	it('parses a typed lazy object pattern in an arrow component parameter', () => {
+		const ast = parseModule(
+			`const Something = (&{ name, title = name }: Props) => @{
+				<h1>{title}</h1>
+			};`,
+			'App.tsrx',
+		);
+		const arrow = as_type(
+			declaratorInit(firstStatement(ast, 'VariableDeclaration')),
+			'ArrowFunctionExpression',
+		);
+		const pattern = as_type(arrow.params[0], 'ObjectPattern');
+		expect(pattern.lazy).toBe(true);
+		expect(pattern.typeAnnotation?.typeAnnotation.type).toBe('TSTypeReference');
+		expect(arrow.body.type).toBe('JSXCodeBlock');
+	});
+
+	it('parses lazy array patterns in async and multi-parameter arrows', () => {
+		const ast = parseModule(
+			`const select = async (prefix: string, &[first, ...rest]: Items = items) =>
+				[prefix, first, rest];`,
+			'App.tsrx',
+		);
+		const arrow = as_type(
+			declaratorInit(firstStatement(ast, 'VariableDeclaration')),
+			'ArrowFunctionExpression',
+		);
+		expect(arrow.async).toBe(true);
+		const parameter = as_type(arrow.params[1], 'AssignmentPattern');
+		expect(as_type(parameter.left, 'ArrayPattern').lazy).toBe(true);
+	});
+
+	it('parses lazy patterns in generic arrow parameters', () => {
+		const ast = parseModule(`const select = <T,>(&{ value }: { value: T }) => value;`, 'App.tsrx');
+		const arrow = as_type(
+			declaratorInit(firstStatement(ast, 'VariableDeclaration')),
+			'ArrowFunctionExpression',
+		);
+		expect(as_type(arrow.params[0], 'ObjectPattern').lazy).toBe(true);
+		expect(arrow.typeParameters?.type).toBe('TSTypeParameterDeclaration');
+	});
+
+	it('keeps lazy binding patterns out of non-arrow expression positions', () => {
+		expect(() => parseModule(`const value = (&{ name });`, 'App.tsrx')).toThrow(
+			/Lazy binding patterns are only valid as arrow parameters/,
+		);
+		expect(() => parseModule(`const value = &{ name };`, 'App.tsrx')).toThrow(/Unexpected token/);
+		expect(() => parseModule(`const value = (& { name }) => name;`, 'App.tsrx')).toThrow(
+			/Unexpected token/,
+		);
+	});
+
 	it('parses a function declaration whose whole body is a `@{ }` block', () => {
 		const ast = parseModule(
 			`function Something() @{


### PR DESCRIPTION
## Summary
- parse lazy object and array bindings in synchronous, asynchronous, typed, defaulted, multi-parameter, and generic arrow functions
- validate speculative lazy patterns so parenthesized expressions and call arguments remain invalid
- exercise the existing lazy lowering across every framework target

## Test plan
- [x] `pnpm exec tsgo --noEmit -p packages/tsrx/tsconfig.json`
- [x] `pnpm test --project tsrx-utils --project tsrx-react --project tsrx-preact --project tsrx-solid --project tsrx-vue`
- [x] verify the Prettier plugin preserves lazy arrow syntax

Made with [Cursor](https://cursor.com)