### PR TITLE
refactor(core): simplify lazy pattern parsing and extend valid positions

### DIFF
--- a/.changeset/lazy-binding-pattern-positions.md
+++ b/.changeset/lazy-binding-pattern-positions.md
@@ -1,0 +1,5 @@
+---
+"@tsrx/core": patch
+---
+
+Allow lazy binding patterns anywhere a destructuring pattern is valid: nested inside destructuring assignment targets (`[&{ name }] = pairs`) and as `for`–`of` / `for`–`in` / `@for` loop targets (`@for (&{ label } of items)`). Lazy patterns in plain expression positions now report a descriptive error instead of a generic unexpected-token failure.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -288,6 +288,7 @@ export function TSRXPlugin(config) {
 			#errors = undefined;
 			/** @type {string | null} */
 			#filename = null;
+			/** @type {WeakMap<object, { names: Set<string>, lexicalLength: number, varLength: number }>} */
 			#localExportNamesByScope = new WeakMap();
 			#functionBodyDepth = 0;
 			#allowExpressionContainerTrailingSemicolon = false;
@@ -3300,31 +3301,7 @@ export function TSRXPlugin(config) {
 				if (this.hasImport(name)) return;
 				// Check all scopes in the scope stack, not just the top-level scope
 				for (let i = this.scopeStack.length - 1; i >= 0; i--) {
-					const scope = this.scopeStack[i];
-					let cached = this.#localExportNamesByScope.get(scope);
-					if (
-						!cached ||
-						cached.lexicalLength > scope.lexical.length ||
-						cached.varLength > scope.var.length
-					) {
-						cached = {
-							names: new Set(),
-							lexicalLength: 0,
-							varLength: 0,
-						};
-						this.#localExportNamesByScope.set(scope, cached);
-					}
-
-					for (let j = cached.lexicalLength; j < scope.lexical.length; j++) {
-						cached.names.add(scope.lexical[j]);
-					}
-					for (let j = cached.varLength; j < scope.var.length; j++) {
-						cached.names.add(scope.var[j]);
-					}
-					cached.lexicalLength = scope.lexical.length;
-					cached.varLength = scope.var.length;
-
-					if (cached.names.has(name)) {
+					if (this.#scopeDeclaredNames(this.scopeStack[i]).has(name)) {
 						// Found in a scope, remove from undefinedExports if it was added
 						delete this.undefinedExports[name];
 						return;
@@ -3332,6 +3309,32 @@ export function TSRXPlugin(config) {
 				}
 				// Not found in any scope, add to undefinedExports for later error
 				this.undefinedExports[name] = id;
+			}
+
+			/**
+			 * The names declared in `scope`, as a cached Set. Acorn only ever
+			 * appends to a scope's `lexical` and `var` arrays during the scope's
+			 * lifetime, so syncing from the last-seen lengths is enough to keep the
+			 * Set current.
+			 *
+			 * @param {{ lexical: string[], var: string[] }} scope
+			 * @returns {Set<string>}
+			 */
+			#scopeDeclaredNames(scope) {
+				let cached = this.#localExportNamesByScope.get(scope);
+				if (!cached) {
+					cached = { names: new Set(), lexicalLength: 0, varLength: 0 };
+					this.#localExportNamesByScope.set(scope, cached);
+				}
+				for (let i = cached.lexicalLength; i < scope.lexical.length; i++) {
+					cached.names.add(scope.lexical[i]);
+				}
+				for (let i = cached.varLength; i < scope.var.length; i++) {
+					cached.names.add(scope.var[i]);
+				}
+				cached.lexicalLength = scope.lexical.length;
+				cached.varLength = scope.var.length;
+				return cached.names;
 			}
 
 			/** @type {Parse.Parser['parseForStatement']} */

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -109,6 +109,18 @@ function get_argument_clash_reported_names(check_clashes) {
 }
 
 /**
+ * The position of a pending `&{…}`/`&[…]` lazy binding pattern recorded on a
+ * DestructuringErrors context, or -1. Acorn's DestructuringErrors class knows
+ * nothing about the field, so absence means none was recorded.
+ *
+ * @param {Parse.DestructuringErrors | undefined | null} refDestructuringErrors
+ * @returns {number}
+ */
+function get_lazy_binding_pos(refDestructuringErrors) {
+	return refDestructuringErrors?.lazyBindingPos ?? -1;
+}
+
+/**
  * A `<` opens a tag only when the character after it can begin one: `/` for a
  * closing tag, `>` for a fragment, `{` for a dynamic tag, or an element or
  * component name start. Any other character, or end of input, leaves the `<`
@@ -315,8 +327,6 @@ export function TSRXPlugin(config) {
 			#closingNativeTemplateNode = false;
 			#readingJSXControlFlowDirectiveKeyword = false;
 			#readingJSXControlFlowHeader = false;
-			/** @type {(AST.ObjectPattern | AST.ArrayPattern)[][]} */
-			#potentialLazyArrowPatterns = [];
 
 			/**
 			 * @type {Parse.Parser['finishNode']}
@@ -1517,18 +1527,24 @@ export function TSRXPlugin(config) {
 			 * @type {Parse.Parser['parseExprAtom']}
 			 */
 			parseExprAtom(refDestructuringErrors, forInit, forNew) {
-				const lazy_arrow_patterns = this.#potentialLazyArrowPatterns.at(-1);
+				// A `&{…}`/`&[…]` lazy binding pattern is only meaningful where the
+				// expression may still turn out to be a binding or assignment target —
+				// an arrow parameter list, a destructuring assignment target, or a
+				// for–of/for–in loop target. Those are exactly the positions Acorn
+				// parses with a DestructuringErrors context, so parse the pattern there
+				// and record it as a pending error the same way Acorn treats `{a = b}`
+				// shorthand: pattern conversion accepts the node as-is, while contexts
+				// that remain expressions raise in checkExpressionErrors.
 				if (
-					lazy_arrow_patterns &&
+					refDestructuringErrors &&
 					this.type === tt.bitwiseAND &&
 					(this.input.charCodeAt(this.end) === CharCode.openBrace ||
 						this.input.charCodeAt(this.end) === CharCode.openBracket)
 				) {
-					const pattern = /** @type {AST.ObjectPattern | AST.ArrayPattern} */ (
-						this.parseBindingAtom()
-					);
-					lazy_arrow_patterns.push(pattern);
-					return /** @type {AST.Expression} */ (/** @type {unknown} */ (pattern));
+					if (get_lazy_binding_pos(refDestructuringErrors) < 0) {
+						refDestructuringErrors.lazyBindingPos = this.start;
+					}
+					return /** @type {AST.Expression} */ (/** @type {unknown} */ (this.parseBindingAtom()));
 				}
 				// A token already consumed as JSX text (a script-mode element child) must
 				// stay text even when it happens to begin at an `@` — otherwise whether
@@ -3240,16 +3256,7 @@ export function TSRXPlugin(config) {
 			 */
 			parseParenAndDistinguishExpression(canBeArrow, forInit) {
 				const startPos = this.start;
-				const lazy_arrow_patterns = canBeArrow ? [] : null;
-				if (lazy_arrow_patterns) this.#potentialLazyArrowPatterns.push(lazy_arrow_patterns);
-				let expr;
-				try {
-					expr = super.parseParenAndDistinguishExpression(canBeArrow, forInit);
-				} finally {
-					if (lazy_arrow_patterns) this.#potentialLazyArrowPatterns.pop();
-				}
-
-				if (lazy_arrow_patterns) this.#validateLazyArrowPatterns(expr, lazy_arrow_patterns);
+				const expr = super.parseParenAndDistinguishExpression(canBeArrow, forInit);
 
 				// If the expression's start position is after the opening paren,
 				// it means it was wrapped in parentheses. Mark it in metadata.
@@ -3262,76 +3269,23 @@ export function TSRXPlugin(config) {
 			}
 
 			/**
-			 * Acorn parses `async (x) => …` through its call-subscript lane rather
-			 * than `parseParenAndDistinguishExpression`, so expose the same lazy
-			 * binding candidate context around that parameter list.
+			 * A recorded lazy binding pattern that never became a binding or
+			 * assignment target is a pending error, exactly like `{a = b}` shorthand
+			 * outside a destructuring pattern. Acorn calls this in every context that
+			 * stayed an expression (parenthesized expressions, call arguments, plain
+			 * assignments' right-hand sides, …).
 			 *
-			 * @type {Parse.Parser['parseSubscript']}
+			 * @type {Parse.Parser['checkExpressionErrors']}
 			 */
-			parseSubscript(base, startPos, startLoc, noCalls, maybeAsyncArrow, optionalChained, forInit) {
-				const lazy_arrow_patterns = maybeAsyncArrow && this.type === tt.parenL ? [] : null;
-				if (lazy_arrow_patterns) this.#potentialLazyArrowPatterns.push(lazy_arrow_patterns);
-				let expression;
-				try {
-					expression = super.parseSubscript(
-						base,
-						startPos,
-						startLoc,
-						noCalls,
-						maybeAsyncArrow,
-						optionalChained,
-						forInit,
-					);
-				} finally {
-					if (lazy_arrow_patterns) this.#potentialLazyArrowPatterns.pop();
-				}
-				if (lazy_arrow_patterns) this.#validateLazyArrowPatterns(expression, lazy_arrow_patterns);
-				return expression;
-			}
-
-			/**
-			 * @param {AST.Expression} expression
-			 * @param {(AST.ObjectPattern | AST.ArrayPattern)[]} patterns
-			 */
-			#validateLazyArrowPatterns(expression, patterns) {
-				const misplaced = patterns.find(
-					(pattern) =>
-						expression.type !== 'ArrowFunctionExpression' ||
-						!expression.params.some((param) => this.#bindingPatternContains(param, pattern)),
+			checkExpressionErrors(refDestructuringErrors, andThrow) {
+				const lazy_binding_pos = get_lazy_binding_pos(refDestructuringErrors);
+				if (lazy_binding_pos < 0)
+					return super.checkExpressionErrors(refDestructuringErrors, andThrow);
+				if (!andThrow) return true;
+				this.raise(
+					lazy_binding_pos,
+					'Lazy binding patterns are only valid as binding or assignment targets',
 				);
-				if (misplaced) {
-					this.raise(
-						/** @type {number} */ (misplaced.start) - 1,
-						'Lazy binding patterns are only valid as arrow parameters in this context',
-					);
-				}
-			}
-
-			/**
-			 * @param {AST.Pattern | AST.AssignmentProperty} pattern
-			 * @param {AST.ObjectPattern | AST.ArrayPattern} target
-			 * @returns {boolean}
-			 */
-			#bindingPatternContains(pattern, target) {
-				if (pattern === target) return true;
-				switch (pattern.type) {
-					case 'AssignmentPattern':
-						return this.#bindingPatternContains(pattern.left, target);
-					case 'RestElement':
-						return this.#bindingPatternContains(pattern.argument, target);
-					case 'ObjectPattern':
-						return pattern.properties.some((property) =>
-							this.#bindingPatternContains(property, target),
-						);
-					case 'Property':
-						return this.#bindingPatternContains(/** @type {AST.Pattern} */ (pattern.value), target);
-					case 'ArrayPattern':
-						return pattern.elements.some(
-							(element) => element && this.#bindingPatternContains(element, target),
-						);
-					default:
-						return false;
-				}
 			}
 
 			/**

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -3342,21 +3342,57 @@ export function TSRXPlugin(config) {
 			/**
 			 * A recorded lazy binding pattern that never became a binding or
 			 * assignment target is a pending error, exactly like `{a = b}` shorthand
-			 * outside a destructuring pattern. Acorn calls this in every context that
-			 * stayed an expression (parenthesized expressions, call arguments, plain
-			 * assignments' right-hand sides, …).
+			 * outside a destructuring pattern. Acorn calls the throwing form at every
+			 * boundary where a context definitively stayed an expression
+			 * (parenthesized expressions, call arguments, plain assignments'
+			 * right-hand sides, …) — that is where the record is enforced.
+			 *
+			 * The non-throwing form is deliberately left untouched: Acorn uses it in
+			 * parseExprOps/parseMaybeConditional to stop parsing operators early, and
+			 * returning true there would cut the pattern off from the `as` /
+			 * `satisfies` operator lane before toAssignable can accept the wrapped
+			 * target (`[&{ a } as T] = arr`). Every path that keeps a stale record
+			 * still ends in a throwing check.
 			 *
 			 * @type {Parse.Parser['checkExpressionErrors']}
 			 */
 			checkExpressionErrors(refDestructuringErrors, andThrow) {
-				const lazy_binding_pos = get_lazy_binding_pos(refDestructuringErrors);
-				if (lazy_binding_pos < 0)
-					return super.checkExpressionErrors(refDestructuringErrors, andThrow);
-				if (!andThrow) return true;
-				this.raise(
-					lazy_binding_pos,
-					'Lazy binding patterns are only valid as binding or assignment targets',
-				);
+				if (andThrow) {
+					const lazy_binding_pos = get_lazy_binding_pos(refDestructuringErrors);
+					if (lazy_binding_pos >= 0) {
+						this.raise(
+							lazy_binding_pos,
+							'Lazy binding patterns are only valid as binding or assignment targets',
+						);
+					}
+				}
+				return super.checkExpressionErrors(refDestructuringErrors, andThrow);
+			}
+
+			/**
+			 * acorn-typescript unwraps TS expression wrappers in checkLValSimple,
+			 * which is only right for simple targets (`[b as any] = arr`). A wrapped
+			 * destructuring pattern (`[&{ a } as T] = arr`) reaches checkLValPattern
+			 * still wrapped — toAssignableList ignores return values, so the wrapper
+			 * survives conversion — and would fall through to checkLValSimple's
+			 * "Assigning to rvalue". Unwrap here so wrapped patterns take the
+			 * pattern lane.
+			 *
+			 * @type {Parse.Parser['checkLValPattern']}
+			 */
+			checkLValPattern(expr, bindingType, checkClashes) {
+				let node = expr;
+				while (
+					node.type === 'TSNonNullExpression' ||
+					node.type === 'TSAsExpression' ||
+					node.type === 'TSSatisfiesExpression' ||
+					node.type === 'TSTypeAssertion'
+				) {
+					node = /** @type {AST.Node} */ (
+						/** @type {{ expression: AST.Node }} */ (/** @type {unknown} */ (node)).expression
+					);
+				}
+				return super.checkLValPattern(node, bindingType, checkClashes);
 			}
 
 			/**

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -3290,6 +3290,37 @@ export function TSRXPlugin(config) {
 			}
 
 			/**
+			 * Converting a node into an assignment target resolves any lazy binding
+			 * pattern recorded inside it — the pattern landed in a valid position,
+			 * so its pending error must not outlive the conversion (e.g.
+			 * `({ pair: &{ a } } = obj)` would otherwise still raise when the
+			 * enclosing parenthesized expression runs checkExpressionErrors). This
+			 * mirrors how Acorn resets `shorthandAssign` once the shorthand ends up
+			 * inside a converted left-hand side.
+			 *
+			 * @type {Parse.Parser['toAssignable']}
+			 */
+			toAssignable(node, isBinding, refDestructuringErrors, preserveTypeScriptWrapper) {
+				const lazy_binding_pos = get_lazy_binding_pos(refDestructuringErrors);
+				// The recorded position is the pattern's `&`, which sits one character
+				// BEFORE the pattern node itself (parseBindingAtom consumes the `&`
+				// before starting the node) — hence `node.start - 1`: an `&` directly
+				// before `node` can only be `node`'s own ampersand.
+				if (
+					lazy_binding_pos >= /** @type {number} */ (node.start) - 1 &&
+					lazy_binding_pos < /** @type {number} */ (node.end)
+				) {
+					/** @type {Parse.DestructuringErrors} */ (refDestructuringErrors).lazyBindingPos = -1;
+				}
+				return super.toAssignable(
+					node,
+					isBinding,
+					refDestructuringErrors,
+					preserveTypeScriptWrapper,
+				);
+			}
+
+			/**
 			 * Override checkLocalExport to check all scopes in the scope stack.
 			 * This is needed because submodules create nested scopes, but exports
 			 * from within submodules should still be valid if the identifier is

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -121,6 +121,57 @@ function get_lazy_binding_pos(refDestructuringErrors) {
 }
 
 /**
+ * Whether the lazy binding pattern recorded at `pos` (the position of its `&`,
+ * one character before the pattern node) sits in a pattern-forming position of
+ * `node` — a slot that toAssignable converts into a binding or assignment
+ * target. A lazy pattern reached only through an expression position (for
+ * example as a member expression's object in `&{ a }.b = x`) is an expression
+ * use and must keep its pending error. `node` is the pre-conversion tree, so
+ * both the expression and pattern spellings of each slot appear here.
+ *
+ * @param {AST.Node | null | undefined} node
+ * @param {number} pos
+ * @returns {boolean}
+ */
+function pattern_position_contains_lazy(node, pos) {
+	if (!node || typeof node !== 'object') return false;
+	if (
+		/** @type {AST.ObjectPattern | AST.ArrayPattern} */ (node).lazy &&
+		/** @type {number} */ (node.start) === pos + 1
+	) {
+		return true;
+	}
+	switch (node.type) {
+		case 'ObjectExpression':
+		case 'ObjectPattern':
+			return node.properties.some((property) =>
+				pattern_position_contains_lazy(
+					property.type === 'Property'
+						? /** @type {AST.Node} */ (property.value)
+						: property.argument,
+					pos,
+				),
+			);
+		case 'ArrayExpression':
+		case 'ArrayPattern':
+			return node.elements.some(
+				(element) => element && pattern_position_contains_lazy(element, pos),
+			);
+		case 'AssignmentExpression':
+			return node.operator === '=' && pattern_position_contains_lazy(node.left, pos);
+		case 'AssignmentPattern':
+			return pattern_position_contains_lazy(node.left, pos);
+		case 'SpreadElement':
+		case 'RestElement':
+			return pattern_position_contains_lazy(node.argument, pos);
+		case 'ParenthesizedExpression':
+			return pattern_position_contains_lazy(node.expression, pos);
+		default:
+			return false;
+	}
+}
+
+/**
  * A `<` opens a tag only when the character after it can begin one: `/` for a
  * closing tag, `>` for a fragment, `{` for a dynamic tag, or an element or
  * component name start. Any other character, or end of input, leaves the `<`
@@ -3302,14 +3353,10 @@ export function TSRXPlugin(config) {
 			 */
 			toAssignable(node, isBinding, refDestructuringErrors, preserveTypeScriptWrapper) {
 				const lazy_binding_pos = get_lazy_binding_pos(refDestructuringErrors);
-				// The recorded position is the pattern's `&`, which sits one character
-				// BEFORE the pattern node itself (parseBindingAtom consumes the `&`
-				// before starting the node) — hence `node.start - 1`: an `&` directly
-				// before `node` can only be `node`'s own ampersand.
-				if (
-					lazy_binding_pos >= /** @type {number} */ (node.start) - 1 &&
-					lazy_binding_pos < /** @type {number} */ (node.end)
-				) {
+				// Only a pattern-forming position resolves the record: a lazy pattern
+				// that is merely inside the target's span but reached through an
+				// expression position (`&{ a }.b = x`) is still an expression use.
+				if (lazy_binding_pos >= 0 && pattern_position_contains_lazy(node, lazy_binding_pos)) {
 					/** @type {Parse.DestructuringErrors} */ (refDestructuringErrors).lazyBindingPos = -1;
 				}
 				return super.toAssignable(

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -120,6 +120,16 @@ function get_lazy_binding_pos(refDestructuringErrors) {
 	return refDestructuringErrors?.lazyBindingPos ?? -1;
 }
 
+/** @type {ReadonlySet<string>} */
+const lazy_target_wrapper_types = new Set([
+	'ParenthesizedExpression',
+	'TSAsExpression',
+	'TSSatisfiesExpression',
+	'TSNonNullExpression',
+	'TSTypeAssertion',
+	'TSTypeCastExpression',
+]);
+
 /**
  * Whether the lazy binding pattern recorded at `pos` (the position of its `&`,
  * one character before the pattern node) sits in a pattern-forming position of
@@ -140,6 +150,17 @@ function pattern_position_contains_lazy(node, pos) {
 		/** @type {number} */ (node.start) === pos + 1
 	) {
 		return true;
+	}
+	// Parentheses and the TypeScript expression wrappers acorn-typescript's
+	// toAssignable unwraps when converting a target (`[&{ a }!] = arr`) — the
+	// wrapped node stays in a pattern-forming position. TSTypeCastExpression is
+	// internal to acorn-typescript, hence the string set rather than switch
+	// cases over the ESTree union.
+	if (lazy_target_wrapper_types.has(node.type)) {
+		return pattern_position_contains_lazy(
+			/** @type {{ expression: AST.Node }} */ (/** @type {unknown} */ (node)).expression,
+			pos,
+		);
 	}
 	switch (node.type) {
 		case 'ObjectExpression':
@@ -164,8 +185,6 @@ function pattern_position_contains_lazy(node, pos) {
 		case 'SpreadElement':
 		case 'RestElement':
 			return pattern_position_contains_lazy(node.argument, pos);
-		case 'ParenthesizedExpression':
-			return pattern_position_contains_lazy(node.expression, pos);
 		default:
 			return false;
 	}

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -727,6 +727,24 @@ export function runSharedNestedLazyDestructuringTests({ compile, name }) {
 			expect(code).toContain('const first = async (__lazy0: [number]) => __lazy0[0]');
 		});
 
+		it('transforms bare lazy object patterns as @for loop targets', () => {
+			const { code } = compile(
+				`export function App(props) @{
+					<ul>
+						@for (&{ id, label } of props.items) {
+							<li>{label}</li>
+						}
+					</ul>
+				}`,
+				'App.tsrx',
+			);
+
+			// The @for target becomes the iteration callback's parameter, so the
+			// bare lazy pattern rides the lazy-parameter transform.
+			expect(code).toContain('(__lazy0)');
+			expect(code).toContain('__lazy0.label');
+		});
+
 		it('transforms nested lazy object inside lazy object in component params', () => {
 			const { code } = compile(
 				`export function App(&{ outer: &{ inner } }: { outer: { inner: number } }) @{

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -3219,6 +3219,27 @@ foo();`;
 		expect(as_type(target.elements[0], 'ObjectPattern').lazy).toBe(true);
 	});
 
+	it('parses lazy binding patterns in parenthesized destructuring assignments', () => {
+		// Object-rooted targets can only be written parenthesized (a bare `{`
+		// starts a block), so the pending lazy record must be cleared when the
+		// target converts — otherwise the enclosing parenthesized expression
+		// would reject it in checkExpressionErrors.
+		const ast = parseModule(`({ pair: &{ a } } = obj);`, 'App.tsrx');
+		const statement = firstStatement(ast, 'ExpressionStatement');
+		const assignment = as_type(statement.expression, 'AssignmentExpression');
+		const target = as_type(assignment.left, 'ObjectPattern');
+		const pair = as_type(target.properties[0], 'Property');
+		expect(as_type(pair.value, 'ObjectPattern').lazy).toBe(true);
+
+		expect(() => parseModule(`(&{ name } = obj);`, 'App.tsrx')).not.toThrow();
+		expect(() => parseModule(`foo([&{ a }] = pairs);`, 'App.tsrx')).not.toThrow();
+		// A lazy pattern that is not part of the converted assignment target
+		// still raises.
+		expect(() => parseModule(`(&{ name }, other = 1);`, 'App.tsrx')).toThrow(
+			/Lazy binding patterns are only valid as binding or assignment targets/,
+		);
+	});
+
 	it('parses lazy binding patterns as for-of and for-in loop targets', () => {
 		const for_of = parseModule(`for (&{ name } of items);`, 'App.tsrx');
 		const of_statement = firstStatement(for_of, 'ForOfStatement');

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -3254,6 +3254,16 @@ foo();`;
 		);
 	});
 
+	it('sees lazy binding patterns through TypeScript wrappers in assignment targets', () => {
+		// Non-null assertions are unwrapped by toAssignable, so the wrapped lazy
+		// pattern is still in a pattern-forming position…
+		expect(() => parseModule(`([&{ a }!] = arr);`, 'App.tsrx')).not.toThrow();
+		// …but a wrapper feeding a member access is still an expression use.
+		expect(() => parseModule(`(&{ a }!.b = x);`, 'App.tsrx')).toThrow(
+			/Lazy binding patterns are only valid as binding or assignment targets/,
+		);
+	});
+
 	it('parses lazy binding patterns as for-of and for-in loop targets', () => {
 		const for_of = parseModule(`for (&{ name } of items);`, 'App.tsrx');
 		const of_statement = firstStatement(for_of, 'ForOfStatement');

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -3190,14 +3190,43 @@ foo();`;
 		expect(arrow.typeParameters?.type).toBe('TSTypeParameterDeclaration');
 	});
 
-	it('keeps lazy binding patterns out of non-arrow expression positions', () => {
+	it('keeps lazy binding patterns out of expression positions', () => {
 		expect(() => parseModule(`const value = (&{ name });`, 'App.tsrx')).toThrow(
-			/Lazy binding patterns are only valid as arrow parameters/,
+			/Lazy binding patterns are only valid as binding or assignment targets/,
 		);
-		expect(() => parseModule(`const value = &{ name };`, 'App.tsrx')).toThrow(/Unexpected token/);
+		expect(() => parseModule(`const value = &{ name };`, 'App.tsrx')).toThrow(
+			/Lazy binding patterns are only valid as binding or assignment targets/,
+		);
+		expect(() => parseModule(`foo(&{ name });`, 'App.tsrx')).toThrow(
+			/Lazy binding patterns are only valid as binding or assignment targets/,
+		);
+		expect(() => parseModule(`for (&{ name }; done; step);`, 'App.tsrx')).toThrow(
+			/Lazy binding patterns are only valid as binding or assignment targets/,
+		);
 		expect(() => parseModule(`const value = (& { name }) => name;`, 'App.tsrx')).toThrow(
 			/Unexpected token/,
 		);
+	});
+
+	it('parses lazy binding patterns nested in destructuring assignment targets', () => {
+		// Statement-level lazy destructuring assignment (dedicated branch).
+		expect(() => parseModule(`&{ name } = obj;`, 'App.tsrx')).not.toThrow();
+
+		const ast = parseModule(`[&{ name }] = pairs;`, 'App.tsrx');
+		const statement = firstStatement(ast, 'ExpressionStatement');
+		const assignment = as_type(statement.expression, 'AssignmentExpression');
+		const target = as_type(assignment.left, 'ArrayPattern');
+		expect(as_type(target.elements[0], 'ObjectPattern').lazy).toBe(true);
+	});
+
+	it('parses lazy binding patterns as for-of and for-in loop targets', () => {
+		const for_of = parseModule(`for (&{ name } of items);`, 'App.tsrx');
+		const of_statement = firstStatement(for_of, 'ForOfStatement');
+		expect(as_type(of_statement.left, 'ObjectPattern').lazy).toBe(true);
+
+		const for_in = parseModule(`for (&[key] in table);`, 'App.tsrx');
+		const in_statement = firstStatement(for_in, 'ForInStatement');
+		expect(as_type(in_statement.left, 'ArrayPattern').lazy).toBe(true);
 	});
 
 	it('parses a function declaration whose whole body is a `@{ }` block', () => {

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -3240,6 +3240,20 @@ foo();`;
 		);
 	});
 
+	it('keeps lazy binding patterns out of expression positions inside assignment targets', () => {
+		// Inside the target's span but reached through an expression position (a
+		// member expression's object) — an expression use, not a pattern slot.
+		expect(() => parseModule(`(&{ a }.b = x);`, 'App.tsrx')).toThrow(
+			/Lazy binding patterns are only valid as binding or assignment targets/,
+		);
+		expect(() => parseModule(`([&{ a }.b] = arr);`, 'App.tsrx')).toThrow(
+			/Lazy binding patterns are only valid as binding or assignment targets/,
+		);
+		expect(() => parseModule(`({ k: &{ a }.b } = obj);`, 'App.tsrx')).toThrow(
+			/Lazy binding patterns are only valid as binding or assignment targets/,
+		);
+	});
+
 	it('parses lazy binding patterns as for-of and for-in loop targets', () => {
 		const for_of = parseModule(`for (&{ name } of items);`, 'App.tsrx');
 		const of_statement = firstStatement(for_of, 'ForOfStatement');

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -3255,11 +3255,18 @@ foo();`;
 	});
 
 	it('sees lazy binding patterns through TypeScript wrappers in assignment targets', () => {
-		// Non-null assertions are unwrapped by toAssignable, so the wrapped lazy
-		// pattern is still in a pattern-forming position…
+		// TS wrappers are unwrapped by toAssignable, so the wrapped lazy pattern
+		// is still in a pattern-forming position — parenthesized or not…
 		expect(() => parseModule(`([&{ a }!] = arr);`, 'App.tsrx')).not.toThrow();
+		expect(() => parseModule(`[&{ a }!] = arr;`, 'App.tsrx')).not.toThrow();
+		expect(() => parseModule(`([&{ a } as any] = arr);`, 'App.tsrx')).not.toThrow();
+		expect(() => parseModule(`[&{ a } as any] = arr;`, 'App.tsrx')).not.toThrow();
+		expect(() => parseModule(`([&{ a } satisfies T] = arr);`, 'App.tsrx')).not.toThrow();
 		// …but a wrapper feeding a member access is still an expression use.
 		expect(() => parseModule(`(&{ a }!.b = x);`, 'App.tsrx')).toThrow(
+			/Lazy binding patterns are only valid as binding or assignment targets/,
+		);
+		expect(() => parseModule(`(&{ a } as any).b = x;`, 'App.tsrx')).toThrow(
 			/Lazy binding patterns are only valid as binding or assignment targets/,
 		);
 	});

--- a/packages/tsrx/types/parse.d.ts
+++ b/packages/tsrx/types/parse.d.ts
@@ -86,6 +86,11 @@ export namespace Parse {
 		parenthesizedAssign: number;
 		parenthesizedBind: number;
 		doubleProto: number;
+		/**
+		 * TSRX extension: position of a pending `&{…}`/`&[…]` lazy binding
+		 * pattern parsed in expression position, set only by TSRXPlugin.
+		 */
+		lazyBindingPos?: number;
 	}
 
 	/**

--- a/packages/tsrx/types/parse.d.ts
+++ b/packages/tsrx/types/parse.d.ts
@@ -1610,11 +1610,13 @@ export namespace Parse {
 		 * @param node Expression to convert
 		 * @param isBinding Whether binding pattern
 		 * @param refDestructuringErrors Error collector
+		 * @param preserveTypeScriptWrapper Keep TS wrapper nodes (acorn-typescript extension)
 		 */
 		toAssignable(
 			node: AST.Node,
 			isBinding?: boolean,
 			refDestructuringErrors?: DestructuringErrors,
+			preserveTypeScriptWrapper?: boolean,
 		): AST.Pattern;
 
 		/**


### PR DESCRIPTION
## Summary

Follow-up review of #7 and #9.

### Lazy pattern parsing (#9 rework)

Replaces the candidate-pattern stack, `parseSubscript` override, and arrow-only containment validation with Acorn's own `DestructuringErrors` protocol — the same mechanism Acorn uses for the analogous `{a = b}` shorthand ambiguity ("valid if this becomes a pattern, error if it stays an expression"):

- `parseExprAtom` parses `&{…}`/`&[…]` wherever a `DestructuringErrors` context exists (exactly the pattern-ambiguous positions) and records it as a pending error (`lazyBindingPos`).
- `toAssignable` resolves the pending record when the pattern lands in a **pattern-forming slot** of a converted binding/assignment target (`pattern_position_contains_lazy` — object property values, array elements, assignment-default lefts, rest arguments, looking through parentheses and the TypeScript wrappers `toAssignable` itself unwraps, so `[&{ a }!] = arr`, `[&{ a } as T] = arr`, and `satisfies` forms work, parenthesized or not). A lazy pattern reachable only through an expression position inside a target — e.g. `&{ a }.b = x` — keeps its record and raises. The walk fails closed and runs only when a conversion actually carries a pending lazy record, not on every paren.
- `checkExpressionErrors` — which Acorn already calls in every lane that stays an expression, sync and async, generics included — raises for expression uses.

Because validation now rides the pattern-conversion lanes instead of an arrow-only allowlist, lazy patterns become valid **anywhere a destructuring pattern is valid**:

- nested in destructuring assignment targets: `[&{ name }] = pairs;` and the parenthesized forms `({ pair: &{ a } } = obj)` / `(&{ name } = obj)` (the object-rooted spelling only exists parenthesized, since a bare `{` starts a block; the shared transform already handles these — `{ pair: &[a, b] } = obj` → `{ pair: __lazy0 } = obj`)
- as `for`–`of` / `for`–`in` / `@for` loop targets: `@for (&{ label } of items)` works end-to-end in react, solid, and vue today because the `@for` lowering turns the target into the iteration callback's parameter, where the existing lazy-param transform picks it up (`(__lazy0) => __lazy0.label`).

Expression uses (`foo(&{a})`, `const v = &{a}`, `&{ a }.b = x`) now fail with a descriptive error instead of a generic unexpected-token failure.

Line-count-wise this ends up near parity with #9 (vs #9's +98 in `plugin.js` for arrow params alone) — the wins are elsewhere: a substantially wider grammar for the same budget, no per-paren stack/try–finally bookkeeping, validation only on conversions that actually carry a pending lazy pattern, and expression-lane coverage (async, generic, nested arrows, defaults) by construction from Acorn's protocol rather than by enumerating lanes. The `toAssignable` refinements came out of review on this PR — all three Bugbot findings were verified real and fixed.

### Export scope lookup cache (#7 tidy)

Moves the per-scope name-set sync into a `#scopeDeclaredNames` helper, drops the rebuild branch for shrunken scope arrays (Acorn only ever appends to a scope's `lexical`/`var` arrays during its lifetime, so it was unreachable), and types the backing `WeakMap`.

## Known gaps (pre-existing, transformers to follow up)

Plain JS `for (const &{ a } of items)` in code blocks parses but the shared transform silently drops the lazy flag (emits eager destructuring); `if (cond) &{ x } = obj();` emits invalid output (`if (cond) const __lazy0 = …`). Both predate this PR — the parser now also accepts bare `for (&{ a } of items)`, which awaits the same transform support. See issue #12.

## Validation

- `pnpm test`: 76/76 test files pass (includes new parser tests — valid and invalid positions, parenthesized targets, expression-position leaks, TypeScript-wrapped targets (`!`, `as`, `satisfies`) — and a shared `@for` lazy-target compile test exercised by all four targets)
- `pnpm typecheck`, `pnpm format:check`, `pnpm changeset:check`: clean


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core parser binding/assignment validation in `plugin.js`; behavior is broad but covered by new parser and compile tests, with transform gaps for some plain-JS loop forms noted as pre-existing.
> 
> **Overview**
> **Lazy `&{…}` / `&[…]` parsing** is reworked to follow Acorn’s `DestructuringErrors` flow (same idea as ambiguous `{a = b}` shorthand): `parseExprAtom` records a pending `lazyBindingPos` when `&` opens a pattern inside a destructuring context, **`toAssignable`** clears it only when `pattern_position_contains_lazy` finds the pattern in a real binding/assignment slot (including through parens and TS wrappers like `[&{ a } as T] = arr`), and **`checkExpressionErrors`** raises *"Lazy binding patterns are only valid as binding or assignment targets"* for expression uses (`foo(&{a})`, `&{a}.b = x`). The old per-paren **`#potentialLazyArrowPatterns`** stack, **`parseSubscript`** hook, and arrow-only validation are removed; **`checkLValPattern`** unwraps TS expression wrappers so wrapped destructuring targets validate correctly.
> 
> That widens the grammar to **nested destructuring assignment targets** (`[&{ name }] = pairs`, `({ pair: &{ a } } = obj)`) and **for-of / for-in / `@for` loop targets** (`@for (&{ label } of items)`), with a new shared compile test for `@for` lazy targets.
> 
> A small **export lookup** tidy moves scope name syncing into **`#scopeDeclaredNames`** and types the backing **`WeakMap`**. Types add **`lazyBindingPos`** and **`preserveTypeScriptWrapper`** on **`toAssignable`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7fefa81138fa8359945f1b65248d76df206b1a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->