### PR TITLE
fix(website): links to repo

### DIFF
--- a/website-tsrx/public/llms.txt
+++ b/website-tsrx/public/llms.txt
@@ -926,7 +926,7 @@ const List = <T,>({ items, render }: Props<T>) =>
 - **Features**: https://tsrx.dev/features
 - **Getting Started**: https://tsrx.dev/getting-started
 - **Playground**: https://tsrx.dev/playground
-- **Source**: https://github.com/tsrx-org/tsrx/tree/main/packages/tsrx
+- **Source**: https://github.com/tsrx-org/tsrx
 - **Ripple target (runtime APIs)**: https://www.ripple-ts.com/llms.txt
 - **Octane target (runtime and build tools)**: https://octanejs.dev/llms.txt
 

--- a/website-tsrx/src/pages/blog-rethinking-tsrx.tsrx
+++ b/website-tsrx/src/pages/blog-rethinking-tsrx.tsrx
@@ -231,11 +231,9 @@ export function BlogRethinkingTsrxPage() @{
 						<a href="https://discord.gg/HCYpT5QHQR" target="_blank" rel="noopener noreferrer">
 							Discord
 						</a>
-						<a
-							href="https://github.com/tsrx-org/tsrx/tree/main/packages/tsrx"
-							target="_blank"
-							rel="noopener noreferrer"
-						>GitHub</a>
+						<a href="https://github.com/tsrx-org/tsrx" target="_blank" rel="noopener noreferrer">
+							GitHub
+						</a>
 						<a href="/llms.txt" target="_blank" rel="noopener noreferrer">llms.txt</a>
 					</nav>
 				</header>

--- a/website-tsrx/src/pages/blog-simplifying-tsrx-after-feedback.tsrx
+++ b/website-tsrx/src/pages/blog-simplifying-tsrx-after-feedback.tsrx
@@ -195,11 +195,9 @@ export function BlogSimplifyingTsrxAfterFeedbackPage() @{
 						<a href="https://discord.gg/HCYpT5QHQR" target="_blank" rel="noopener noreferrer">
 							Discord
 						</a>
-						<a
-							href="https://github.com/tsrx-org/tsrx/tree/main/packages/tsrx"
-							target="_blank"
-							rel="noopener noreferrer"
-						>GitHub</a>
+						<a href="https://github.com/tsrx-org/tsrx" target="_blank" rel="noopener noreferrer">
+							GitHub
+						</a>
 						<a href="/llms.txt" target="_blank" rel="noopener noreferrer">llms.txt</a>
 					</nav>
 				</header>

--- a/website-tsrx/src/pages/blog.tsrx
+++ b/website-tsrx/src/pages/blog.tsrx
@@ -22,11 +22,9 @@ export function BlogPage() @{
 						<a href="https://discord.gg/HCYpT5QHQR" target="_blank" rel="noopener noreferrer">
 							Discord
 						</a>
-						<a
-							href="https://github.com/tsrx-org/tsrx/tree/main/packages/tsrx"
-							target="_blank"
-							rel="noopener noreferrer"
-						>GitHub</a>
+						<a href="https://github.com/tsrx-org/tsrx" target="_blank" rel="noopener noreferrer">
+							GitHub
+						</a>
 						<a href="/llms.txt" target="_blank" rel="noopener noreferrer">llms.txt</a>
 					</nav>
 				</header>

--- a/website-tsrx/src/pages/features.tsrx
+++ b/website-tsrx/src/pages/features.tsrx
@@ -342,11 +342,9 @@ export const FeaturesPage = () => @{
 						<a href="https://discord.gg/HCYpT5QHQR" target="_blank" rel="noopener noreferrer">
 							Discord
 						</a>
-						<a
-							href="https://github.com/tsrx-org/tsrx/tree/main/packages/tsrx"
-							target="_blank"
-							rel="noopener noreferrer"
-						>GitHub</a>
+						<a href="https://github.com/tsrx-org/tsrx" target="_blank" rel="noopener noreferrer">
+							GitHub
+						</a>
 						<a href="/llms.txt" target="_blank" rel="noopener noreferrer">llms.txt</a>
 					</nav>
 				</header>

--- a/website-tsrx/src/pages/getting-started.tsrx
+++ b/website-tsrx/src/pages/getting-started.tsrx
@@ -332,11 +332,9 @@ export function GettingStartedPage() @{
 						<a href="https://discord.gg/HCYpT5QHQR" target="_blank" rel="noopener noreferrer">
 							Discord
 						</a>
-						<a
-							href="https://github.com/tsrx-org/tsrx/tree/main/packages/tsrx"
-							target="_blank"
-							rel="noopener noreferrer"
-						>GitHub</a>
+						<a href="https://github.com/tsrx-org/tsrx" target="_blank" rel="noopener noreferrer">
+							GitHub
+						</a>
 						<a href="/llms.txt" target="_blank" rel="noopener noreferrer">llms.txt</a>
 					</nav>
 				</header>

--- a/website-tsrx/src/pages/index.tsrx
+++ b/website-tsrx/src/pages/index.tsrx
@@ -89,11 +89,9 @@ export const IndexPage = () => @{
 						<a href="https://discord.gg/HCYpT5QHQR" target="_blank" rel="noopener noreferrer">
 							Discord
 						</a>
-						<a
-							href="https://github.com/tsrx-org/tsrx/tree/main/packages/tsrx"
-							target="_blank"
-							rel="noopener noreferrer"
-						>GitHub</a>
+						<a href="https://github.com/tsrx-org/tsrx" target="_blank" rel="noopener noreferrer">
+							GitHub
+						</a>
 						<a href="/llms.txt" target="_blank" rel="noopener noreferrer">llms.txt</a>
 					</nav>
 				</header>
@@ -131,7 +129,7 @@ export const IndexPage = () => @{
 						<a class="cta-link" href="/getting-started">Get started →</a>
 						<a
 							class="secondary-cta-link"
-							href="https://github.com/tsrx-org/tsrx/tree/main/packages/tsrx"
+							href="https://github.com/tsrx-org/tsrx"
 							target="_blank"
 							rel="noopener noreferrer"
 						>View Source</a>

--- a/website-tsrx/src/pages/playground.tsrx
+++ b/website-tsrx/src/pages/playground.tsrx
@@ -23,11 +23,9 @@ export function PlaygroundPage() @{
 					<a href="https://discord.gg/HCYpT5QHQR" target="_blank" rel="noopener noreferrer">
 						Discord
 					</a>
-					<a
-						href="https://github.com/tsrx-org/tsrx/tree/main/packages/tsrx"
-						target="_blank"
-						rel="noopener noreferrer"
-					>GitHub</a>
+					<a href="https://github.com/tsrx-org/tsrx" target="_blank" rel="noopener noreferrer">
+						GitHub
+					</a>
 					<a href="/llms.txt" target="_blank" rel="noopener noreferrer">llms.txt</a>
 				</nav>
 			</header>

--- a/website-tsrx/src/pages/specification.tsrx
+++ b/website-tsrx/src/pages/specification.tsrx
@@ -373,11 +373,9 @@ export function SpecificationPage() @{
 						<a href="https://discord.gg/HCYpT5QHQR" target="_blank" rel="noopener noreferrer">
 							Discord
 						</a>
-						<a
-							href="https://github.com/tsrx-org/tsrx/tree/main/packages/tsrx"
-							target="_blank"
-							rel="noopener noreferrer"
-						>GitHub</a>
+						<a href="https://github.com/tsrx-org/tsrx" target="_blank" rel="noopener noreferrer">
+							GitHub
+						</a>
 						<a href="/llms.txt" target="_blank" rel="noopener noreferrer">llms.txt</a>
 					</nav>
 				</header>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and navigation URL changes only; no runtime or build logic is affected.
> 
> **Overview**
> Updates **GitHub** and **source** URLs across the TSRX site so they open the monorepo root (`https://github.com/tsrx-org/tsrx`) instead of the deep path `.../tree/main/packages/tsrx`.
> 
> **`public/llms.txt`** — the Resources **Source** entry uses the root URL.
> 
> **Site pages** — masthead **GitHub** nav links on blog posts, blog index, features, getting started, playground, and specification are aligned to the same target (with minor anchor formatting). **`index.tsrx`** also updates the hero **View Source** secondary CTA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb1f1b70de219ca622ea2d517ee0359b42b1f556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->