### PR TITLE
upgrade solid to rc3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: ^0.3.124
       version: 0.3.124
     '@solidjs/web':
-      specifier: 2.0.0-beta.15
-      version: 2.0.0-beta.15
+      specifier: 2.0.0-rc.3
+      version: 2.0.0-rc.3
     '@sveltejs/acorn-typescript':
       specifier: ^1.0.13
       version: 1.0.13
@@ -145,8 +145,8 @@ catalogs:
       specifier: 4.0.1
       version: 4.0.1
     solid-js:
-      specifier: 2.0.0-beta.15
-      version: 2.0.0-beta.15
+      specifier: 2.0.0-rc.3
+      version: 2.0.0-rc.3
     source-map:
       specifier: ^0.7.6
       version: 0.7.6
@@ -207,7 +207,7 @@ catalogs:
 overrides:
   esrap: ^2.3.2
   semver: ^7.7.4
-  babel-preset-solid: 2.0.0-beta.15
+  babel-preset-solid: 2.0.0-rc.2
   babel-plugin-jsx-dom-expressions: 0.50.0-next.14
 
 importers:
@@ -222,7 +222,7 @@ importers:
         version: 2.31.0(@types/node@24.11.0)
       '@solidjs/web':
         specifier: catalog:default
-        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@tsrx/preact':
         specifier: workspace:*
         version: link:packages/tsrx-preact
@@ -264,7 +264,7 @@ importers:
         version: 8.17.0(supports-color@7.2.0)(valibot@1.4.2(typescript@5.9.3))
       solid-js:
         specifier: catalog:default
-        version: 2.0.0-beta.15
+        version: 2.0.0-rc.3
       source-map:
         specifier: catalog:default
         version: 0.7.6
@@ -276,7 +276,7 @@ importers:
         version: 5.9.3
       vite-plugin-solid:
         specifier: 3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(solid-js@2.0.0-beta.15)(supports-color@7.2.0)(vite@8.1.5(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(supports-color@7.2.0)(vite@8.1.5(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1))
       vitest:
         specifier: catalog:default
         version: 4.1.6(@types/node@24.11.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1))
@@ -353,15 +353,15 @@ importers:
         specifier: workspace:*
         version: link:../tsrx-solid
       babel-preset-solid:
-        specifier: 2.0.0-beta.15
-        version: 2.0.0-beta.15(@babel/core@7.29.0(supports-color@7.2.0))(solid-js@2.0.0-beta.15)
+        specifier: 2.0.0-rc.2
+        version: 2.0.0-rc.2(@babel/core@7.29.0(supports-color@7.2.0))(solid-js@2.0.0-rc.3)
       bun:
         specifier: ^1.0.0
         version: 1.3.10
     devDependencies:
       '@solidjs/web':
         specifier: catalog:default
-        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@types/babel__core':
         specifier: catalog:default
         version: 7.20.5
@@ -370,7 +370,7 @@ importers:
         version: 1.3.10
       solid-js:
         specifier: catalog:default
-        version: 2.0.0-beta.15
+        version: 2.0.0-rc.3
       typescript:
         specifier: catalog:default
         version: 5.9.3
@@ -565,21 +565,21 @@ importers:
         specifier: ^10.1.1
         version: 10.1.1(@babel/core@7.29.0(supports-color@7.2.0))(@rspack/core@2.1.5)
       babel-preset-solid:
-        specifier: 2.0.0-beta.15
-        version: 2.0.0-beta.15(@babel/core@7.29.0(supports-color@7.2.0))(solid-js@2.0.0-beta.15)
+        specifier: 2.0.0-rc.2
+        version: 2.0.0-rc.2(@babel/core@7.29.0(supports-color@7.2.0))(solid-js@2.0.0-rc.3)
       solid-refresh:
         specifier: 0.8.0-next.7
-        version: 0.8.0-next.7(solid-js@2.0.0-beta.15)
+        version: 0.8.0-next.7(solid-js@2.0.0-rc.3)
     devDependencies:
       '@rspack/core':
         specifier: ^2.1.5
         version: 2.1.5
       '@solidjs/web':
         specifier: catalog:default
-        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js:
         specifier: catalog:default
-        version: 2.0.0-beta.15
+        version: 2.0.0-rc.3
       typescript:
         specifier: catalog:default
         version: 5.9.3
@@ -794,7 +794,7 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: catalog:default
-        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@tsrx/core':
         specifier: workspace:*
         version: link:../tsrx
@@ -806,7 +806,7 @@ importers:
         version: 2.3.2(@typescript-eslint/types@8.56.1)
       solid-js:
         specifier: catalog:default
-        version: 2.0.0-beta.15
+        version: 2.0.0-rc.3
       zimmerframe:
         specifier: catalog:default
         version: 1.1.4
@@ -825,13 +825,13 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: catalog:default
-        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@tsrx/runtime':
         specifier: workspace:*
         version: link:../tsrx-runtime
       solid-js:
         specifier: catalog:default
-        version: 2.0.0-beta.15
+        version: 2.0.0-rc.3
 
   packages/tsrx-vue:
     dependencies:
@@ -1002,10 +1002,10 @@ importers:
     devDependencies:
       '@solidjs/web':
         specifier: catalog:default
-        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js:
         specifier: catalog:default
-        version: 2.0.0-beta.15
+        version: 2.0.0-rc.3
       typescript:
         specifier: catalog:default
         version: 5.9.3
@@ -1014,7 +1014,7 @@ importers:
         version: 8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
       vite-plugin-solid:
         specifier: 3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(solid-js@2.0.0-beta.15)(supports-color@7.2.0)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(supports-color@7.2.0)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
 
   packages/vite-plugin-vue:
     dependencies:
@@ -1130,10 +1130,10 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: catalog:default
-        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js:
         specifier: catalog:default
-        version: 2.0.0-beta.15
+        version: 2.0.0-rc.3
     devDependencies:
       '@tsrx/language-server':
         specifier: workspace:*
@@ -1155,7 +1155,7 @@ importers:
         version: 8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
       vite-plugin-solid:
         specifier: 3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(solid-js@2.0.0-beta.15)(supports-color@7.2.0)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(supports-color@7.2.0)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
 
   playground/vue:
     dependencies:
@@ -1638,6 +1638,11 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44':
+    resolution: {integrity: sha512-f1kx6TeMQgaLVkGfuxMn0BkH0+HvsycFf1qPHbYoBqmBQd6Ag/EXOxkSpfcaC+UOBMSaF4BKXegGDchRNTWKrg==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -2809,13 +2814,13 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
-  '@solidjs/signals@2.0.0-beta.15':
-    resolution: {integrity: sha512-lw4a4frNajnmVjILbyfrgJ4ksqU+YKhkepZ8glKK9Q68O3zq7W8qDLOtsz5v1mt0o3TB11/rozJFpgMTmnYegg==}
+  '@solidjs/signals@2.0.0-rc.3':
+    resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
-  '@solidjs/web@2.0.0-beta.15':
-    resolution: {integrity: sha512-+LvmzzN5CHxQ+TeCGgA8DKuB8S4t0EHVlmDUlAp4hkLnh7My3ZGuKYHKWsFMd8w08nPgF6LdBZkH+c5iNcmcSA==}
+  '@solidjs/web@2.0.0-rc.3':
+    resolution: {integrity: sha512-5ckKgOjem1pN5ADycOk6TjHmTtjbbN2fukqxo6RW3Oe3H7z0gaXWAdt8dLISto5/O4Nn8VxprFXFWpfy31+DUg==}
     peerDependencies:
-      solid-js: ^2.0.0-beta.15
+      solid-js: ^2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -3475,16 +3480,11 @@ packages:
       webpack:
         optional: true
 
-  babel-plugin-jsx-dom-expressions@0.50.0-next.14:
-    resolution: {integrity: sha512-eMUq8UuVs5ROCiYmtMBp/TWuRxL7GZ32JUs47CmTzZo8hX9AIayTnNtbsBmQlfEnJla3TaxgBYDvGxNlHCqVcA==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
-
-  babel-preset-solid@2.0.0-beta.15:
-    resolution: {integrity: sha512-nXbT3ZlgHmVcH1VvEFwyrxcMQmpRJ55JoOLy+4wAxpaYtADw5YJh4t5UlT5WyuWfv6VC7URDCkFGEdAOjmTwjw==}
+  babel-preset-solid@2.0.0-rc.2:
+    resolution: {integrity: sha512-Venq++Aa6+RzGIAyS5vSo3kX1fE8zRreEPCh1eTh5DTjlTft9qZGIG14RSZDv/sjVxT8x5Gs9+21PzxuLe8U+g==}
     peerDependencies:
       '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-beta.15
+      solid-js: ^2.0.0-rc.2
     peerDependenciesMeta:
       solid-js:
         optional: true
@@ -5441,14 +5441,14 @@ packages:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
 
-  seroval-plugins@1.5.2:
-    resolution: {integrity: sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==}
+  seroval-plugins@1.5.6:
+    resolution: {integrity: sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ==}
     engines: {node: '>=10'}
     peerDependencies:
       seroval: ^1.0
 
-  seroval@1.5.2:
-    resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
+  seroval@1.5.6:
+    resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
   serve-static@2.2.1:
@@ -5526,8 +5526,8 @@ packages:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
-  solid-js@2.0.0-beta.15:
-    resolution: {integrity: sha512-3hvcmEFUgDlahc++/ulrPhnc5IM7aJbW1P4TUaKsMZpDY5qGcOagtL4nbXGdUPnVP0JsJhMuE9bXEcLdLE+2SA==}
+  solid-js@2.0.0-rc.3:
+    resolution: {integrity: sha512-pmW6bRoTvfp/rN4jN7JmLvSaoIpFt7wm0Hi3j508S/smuJqUbRg3dQEjOPTkAwHW+McYnXrMG7cJ4AMNpLevtQ==}
 
   solid-refresh@0.8.0-next.7:
     resolution: {integrity: sha512-fqkPRAeiE0tqfo2ZljeQBIXwfYssU2w1FmaWFrXmnV33B/CfGfez7BjtOF0Y1/orUNRXI/DZcJlJThHllcCMsA==}
@@ -6923,6 +6923,16 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44(@babel/core@7.29.0(supports-color@7.2.0))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/types': 7.29.0
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -7861,13 +7871,13 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@solidjs/signals@2.0.0-beta.15': {}
+  '@solidjs/signals@2.0.0-rc.3': {}
 
-  '@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15)':
+  '@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3)':
     dependencies:
-      seroval: 1.5.2
-      seroval-plugins: 1.5.2(seroval@1.5.2)
-      solid-js: 2.0.0-beta.15
+      seroval: 1.5.6
+      seroval-plugins: 1.5.6(seroval@1.5.6)
+      solid-js: 2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -8663,22 +8673,12 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 2.1.5
 
-  babel-plugin-jsx-dom-expressions@0.50.0-next.14(@babel/core@7.29.0(supports-color@7.2.0)):
+  babel-preset-solid@2.0.0-rc.2(@babel/core@7.29.0(supports-color@7.2.0))(solid-js@2.0.0-rc.3):
     dependencies:
       '@babel/core': 7.29.0(supports-color@7.2.0)
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0(supports-color@7.2.0))
-      '@babel/types': 7.29.0
-      html-entities: 2.3.3
-      parse5: 7.3.0
-      validate-html-nesting: 1.2.4
-
-  babel-preset-solid@2.0.0-beta.15(@babel/core@7.29.0(supports-color@7.2.0))(solid-js@2.0.0-beta.15):
-    dependencies:
-      '@babel/core': 7.29.0(supports-color@7.2.0)
-      babel-plugin-jsx-dom-expressions: 0.50.0-next.14(@babel/core@7.29.0(supports-color@7.2.0))
+      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.44(@babel/core@7.29.0(supports-color@7.2.0))
     optionalDependencies:
-      solid-js: 2.0.0-beta.15
+      solid-js: 2.0.0-rc.3
 
   balanced-match@1.0.2: {}
 
@@ -10786,11 +10786,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  seroval-plugins@1.5.2(seroval@1.5.2):
+  seroval-plugins@1.5.6(seroval@1.5.6):
     dependencies:
-      seroval: 1.5.2
+      seroval: 1.5.6
 
-  seroval@1.5.2: {}
+  seroval@1.5.6: {}
 
   serve-static@2.2.1(supports-color@7.2.0):
     dependencies:
@@ -10910,18 +10910,18 @@ snapshots:
 
   smol-toml@1.6.1: {}
 
-  solid-js@2.0.0-beta.15:
+  solid-js@2.0.0-rc.3:
     dependencies:
-      '@solidjs/signals': 2.0.0-beta.15
+      '@solidjs/signals': 2.0.0-rc.3
       csstype: 3.2.3
-      seroval: 1.5.2
-      seroval-plugins: 1.5.2(seroval@1.5.2)
+      seroval: 1.5.6
+      seroval-plugins: 1.5.6(seroval@1.5.6)
 
-  solid-refresh@0.8.0-next.7(solid-js@2.0.0-beta.15):
+  solid-refresh@0.8.0-next.7(solid-js@2.0.0-rc.3):
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/types': 7.29.0
-      solid-js: 2.0.0-beta.15
+      solid-js: 2.0.0-rc.3
 
   source-map-js@1.2.1: {}
 
@@ -11325,29 +11325,29 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(solid-js@2.0.0-beta.15)(supports-color@7.2.0)(vite@8.1.5(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1)):
+  vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(supports-color@7.2.0)(vite@8.1.5(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.29.0(supports-color@7.2.0)
-      '@solidjs/web': 2.0.0-beta.15(solid-js@2.0.0-beta.15)
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.15(@babel/core@7.29.0(supports-color@7.2.0))(solid-js@2.0.0-beta.15)
+      babel-preset-solid: 2.0.0-rc.2(@babel/core@7.29.0(supports-color@7.2.0))(solid-js@2.0.0-rc.3)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.15
-      solid-refresh: 0.8.0-next.7(solid-js@2.0.0-beta.15)
+      solid-js: 2.0.0-rc.3
+      solid-refresh: 0.8.0-next.7(solid-js@2.0.0-rc.3)
       vite: 8.1.5(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1)
       vitefu: 1.1.3(vite@8.1.5(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(solid-js@2.0.0-beta.15)(supports-color@7.2.0)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)):
+  vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(supports-color@7.2.0)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.29.0(supports-color@7.2.0)
-      '@solidjs/web': 2.0.0-beta.15(solid-js@2.0.0-beta.15)
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.15(@babel/core@7.29.0(supports-color@7.2.0))(solid-js@2.0.0-beta.15)
+      babel-preset-solid: 2.0.0-rc.2(@babel/core@7.29.0(supports-color@7.2.0))(solid-js@2.0.0-rc.3)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.15
-      solid-refresh: 0.8.0-next.7(solid-js@2.0.0-beta.15)
+      solid-js: 2.0.0-rc.3
+      solid-refresh: 0.8.0-next.7(solid-js@2.0.0-rc.3)
       vite: 8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
       vitefu: 1.1.3(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,14 +40,14 @@ overrides:
   semver: ^7.7.4
   # Solid 2.0 SSR alignment: vite-plugin-solid@3.0.0-next.5 pulls
   # babel-preset-solid@2.0.0-beta.7 transitively (→ babel-plugin-jsx-dom-expressions
-  # 0.41, which still EMITS the `ssrRunInScope` SSR helper), but @solidjs/web@2.0.0-beta.15
+  # 0.41, which still EMITS the `ssrRunInScope` SSR helper), but @solidjs/web@2.0.0-rc.3
   # REMOVED that export (dom-expressions 0.50 stopped emitting it). Force the
   # transform to the 0.50-era preset the catalog already intends so SSR output
   # matches the installed runtime. Without this, SSR throws "does not provide an
   # export named 'ssrRunInScope'". The preset version tracks the solid-js /
   # @solidjs/web beta below; babel-plugin-jsx-dom-expressions tracks the
   # preset's own dependency range.
-  babel-preset-solid: '2.0.0-beta.15'
+  babel-preset-solid: '2.0.0-rc.2'
   babel-plugin-jsx-dom-expressions: '0.50.0-next.14'
 
 catalogs:
@@ -63,7 +63,7 @@ catalogs:
     '@ripple-ts/vite-plugin': ^0.3.124
     '@rollup/pluginutils': ^5.3.0
     '@sveltejs/acorn-typescript': ^1.0.13
-    '@solidjs/web': '2.0.0-beta.15'
+    '@solidjs/web': '2.0.0-rc.3'
     '@tailwindcss/vite': ^4.1.12
     '@types/adm-zip': ^0.5.8
     '@types/babel__core': ^7.20.5
@@ -89,7 +89,7 @@ catalogs:
     '@vscode/vsce': ^3.9.1
     acorn: ^8.17.0
     adm-zip: ^0.5.17
-    babel-preset-solid: '2.0.0-beta.15'
+    babel-preset-solid: '2.0.0-rc.3'
     clsx: ^2.1.1
     commander: ^14.0.3
     degit: ^2.8.4
@@ -118,7 +118,7 @@ catalogs:
     rollup: ^4.59.0
     rulesync: ^8.17.0
     shiki: 4.0.1
-    solid-js: '2.0.0-beta.15'
+    solid-js: '2.0.0-rc.3'
     source-map: ^0.7.6
     tsdown: ^0.22.0
     tsup: ^8.3.5


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> This is a cross-cutting framework and Babel transform upgrade with SSR-sensitive overrides; regressions would show up in Solid builds/SSR rather than in isolated packages, but there is no application logic change in the diff.
> 
> **Overview**
> Bumps the monorepo’s **Solid 2** stack from `2.0.0-beta.15` to **`2.0.0-rc.3`** by updating the shared pnpm catalog for `solid-js`, `@solidjs/web`, and related entries, then refreshing `pnpm-lock.yaml` so every Solid consumer (root, `tsrx-solid`, Bun/Rspack/Vite plugins, playground) resolves the new versions.
> 
> The existing **SSR alignment override** for `babel-preset-solid` is moved to **`2.0.0-rc.2`** (comments still describe matching dom-expressions 0.50 with `@solidjs/web` rc.3). The lockfile also picks up **`babel-preset-solid`’s new JSX plugin** (`@dom-expressions/babel-plugin-jsx@0.50.0-next.44` instead of `babel-plugin-jsx-dom-expressions`) and bumps **`seroval` / `seroval-plugins`** to 1.5.6 as required by the rc runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d80c790258d4c73248ca5c99e1473e729a110c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->