### PR TITLE
docs: ignore agent-generated plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,5 @@ temp/
 # differential test rig precompile cache
 **/.react-cache/
 
-# Generated agent artifacts
-/docs/
+# Agent-generated plans are local working artifacts, not repository content.
+/plans/

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ temp/
 
 # Agent-generated plans are local working artifacts, not repository content.
 /plans/
+/docs/plans/


### PR DESCRIPTION
## Summary

- Allow repository documentation under root `docs/`.
- Ignore agent-generated working plans under both root `plans/` and `docs/plans/`.
- Replace the over-broad `/docs/` rule introduced on `main`.

## Validation

- `git check-ignore -v plans/example.md docs/plans/example.md`
- verified `docs/example.md` is not ignored
- verified no current `plans/` or `docs/plans/` directory exists
- `git diff --check`

## Notes

- The unrelated local `.pnpm-store/` directory was left untouched and is not part of this PR.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `.gitignore` changes; no runtime, auth, or data-path behavior is affected.
> 
> **Overview**
> **Gitignore policy** no longer ignores the entire root `docs/` tree. That broad `/docs/` rule is replaced with ignores aimed at **agent-generated working plans** only: root `plans/` and `docs/plans/`, with a short comment explaining they are local artifacts.
> 
> Repository documentation under `docs/` (outside `docs/plans/`) can be tracked again, while agent plan output stays out of version control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8e93b0f06015f0b7158d746480769acbcce4a04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->