### PR TITLE
perf(tsrx): avoid reparsing CSS declarations

### DIFF
--- a/.changeset/fast-css-declarations.md
+++ b/.changeset/fast-css-declarations.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Speed up declaration-heavy CSS parsing by parsing declarations once and returning ordinary values directly from source slices.

--- a/packages/tsrx/src/parse/style.js
+++ b/packages/tsrx/src/parse/style.js
@@ -11,7 +11,6 @@ const REGEX_PERCENTAGE = /^\d+(\.\d+)?%/;
 const REGEX_COMBINATOR = /^(\+|~|>|\|\|)/;
 const REGEX_VALID_IDENTIFIER_CHAR = /[a-zA-Z0-9_-]/;
 const REGEX_LEADING_HYPHEN_OR_DIGIT = /-?\d/;
-const REGEX_WHITESPACE_OR_COLON = /[\s:]/;
 const REGEX_NTH_OF =
 	/^(even|odd|\+?(\d+|\d*n(\s*[+-]\s*\d+)?)|-\d*n(\s*\+\s*\d+))((?=\s*[,)])|\s+of\s+)/;
 
@@ -272,30 +271,40 @@ function read_block_item(parser) {
 		return read_at_rule(parser);
 	}
 
-	// read ahead to understand whether we're dealing with a declaration or a nested rule.
-	// this involves some duplicated work, but avoids a try-catch that would disguise errors
+	// Parse the common declaration path once. A nested rule is the exceptional
+	// shape, so only that path rewinds and parses its selector after seeing `{`.
 	const start = parser.index;
-	read_value(parser);
-	const char = parser.template[parser.index];
-	parser.index = start;
+	const declaration = read_declaration(parser);
+	if (declaration) {
+		return declaration;
+	}
 
-	return char === '{' ? read_rule(parser) : read_declaration(parser);
+	parser.index = start;
+	return read_rule(parser);
 }
 
 /**
  * @param {Parser} parser
- * @returns {AST.CSS.Declaration}
+ * @returns {AST.CSS.Declaration | null}
  */
 function read_declaration(parser) {
 	const start = parser.index;
 
-	const property = parser.read_until(REGEX_WHITESPACE_OR_COLON);
+	while (parser.index < parser.template.length) {
+		const char = parser.template[parser.index];
+		if (char === ':' || char === '{' || regex_whitespace.test(char)) break;
+		parser.index++;
+	}
+	const property = parser.template.slice(start, parser.index);
+
 	parser.allow_whitespace();
+	if (parser.match('{')) return null;
+
 	parser.eat(':');
-	let index = parser.index;
 	parser.allow_whitespace();
 
 	const value = read_value(parser);
+	if (parser.match('{')) return null;
 
 	if (!value && !property.startsWith('--') && !parser.loose) {
 		throw new Error('CSS Declaration cannot be empty');
@@ -321,6 +330,42 @@ function read_declaration(parser) {
  * @returns {string}
  */
 function read_value(parser) {
+	const start = parser.index;
+	let in_url = false;
+
+	/** @type {null | '"' | "'"} */
+	let quote_mark = null;
+
+	while (parser.index < parser.template.length) {
+		const char = parser.template[parser.index];
+
+		if (char === '\\') {
+			parser.index = start;
+			return read_escaped_value(parser);
+		} else if (char === quote_mark) {
+			quote_mark = null;
+		} else if (char === ')') {
+			in_url = false;
+		} else if (quote_mark === null && (char === '"' || char === "'")) {
+			quote_mark = char;
+		} else if (char === '(' && parser.template.slice(parser.index - 3, parser.index) === 'url') {
+			in_url = true;
+		} else if ((char === ';' || char === '{' || char === '}') && !in_url && !quote_mark) {
+			return parser.template.slice(start, parser.index).trim();
+		}
+
+		parser.index++;
+	}
+
+	throw new Error('Unexpected end of input');
+}
+
+/**
+ * Preserve the existing escaped-value normalization on the uncommon path that
+ * cannot return a direct slice of the source.
+ * @param {Parser} parser
+ */
+function read_escaped_value(parser) {
 	let value = '';
 	let escaped = false;
 	let in_url = false;

--- a/packages/tsrx/src/parse/style.js
+++ b/packages/tsrx/src/parse/style.js
@@ -11,6 +11,7 @@ const REGEX_PERCENTAGE = /^\d+(\.\d+)?%/;
 const REGEX_COMBINATOR = /^(\+|~|>|\|\|)/;
 const REGEX_VALID_IDENTIFIER_CHAR = /[a-zA-Z0-9_-]/;
 const REGEX_LEADING_HYPHEN_OR_DIGIT = /-?\d/;
+const REGEX_WHITESPACE_OR_COLON = /[\s:]/;
 const REGEX_NTH_OF =
 	/^(even|odd|\+?(\d+|\d*n(\s*[+-]\s*\d+)?)|-\d*n(\s*\+\s*\d+))((?=\s*[,)])|\s+of\s+)/;
 
@@ -271,32 +272,39 @@ function read_block_item(parser) {
 		return read_at_rule(parser);
 	}
 
-	// Parse the common declaration path once. A nested rule is the exceptional
-	// shape, so only that path rewinds and parses its selector after seeing `{`.
 	const start = parser.index;
-	const declaration = read_declaration(parser);
+	const declaration = try_read_declaration(parser);
 	if (declaration) {
 		return declaration;
 	}
 
 	parser.index = start;
+	if (declaration === undefined) {
+		read_value(parser);
+		const char = parser.template[parser.index];
+		parser.index = start;
+		return char === '{' ? read_rule(parser) : read_declaration(parser);
+	}
+
 	return read_rule(parser);
 }
 
 /**
+ * Parse an ordinary declaration once while leaving bracketed selector prefixes
+ * to the exact lookahead fallback in {@link read_block_item}.
  * @param {Parser} parser
- * @returns {AST.CSS.Declaration | null}
+ * @returns {AST.CSS.Declaration | null | undefined}
  */
-function read_declaration(parser) {
+function try_read_declaration(parser) {
 	const start = parser.index;
 
 	while (parser.index < parser.template.length) {
 		const char = parser.template[parser.index];
+		if (char === '[') return undefined;
 		if (char === ':' || char === '{' || regex_whitespace.test(char)) break;
 		parser.index++;
 	}
 	const property = parser.template.slice(start, parser.index);
-
 	parser.allow_whitespace();
 	if (parser.match('{')) return null;
 
@@ -306,12 +314,22 @@ function read_declaration(parser) {
 	const value = read_value(parser);
 	if (parser.match('{')) return null;
 
+	return create_declaration(parser, start, property, value);
+}
+
+/**
+ * @param {Parser} parser
+ * @param {number} start
+ * @param {string} property
+ * @param {string} value
+ * @returns {AST.CSS.Declaration}
+ */
+function create_declaration(parser, start, property, value) {
 	if (!value && !property.startsWith('--') && !parser.loose) {
 		throw new Error('CSS Declaration cannot be empty');
 	}
 
 	const end = parser.index;
-
 	if (!parser.match('}')) {
 		parser.eat(';', true);
 	}
@@ -323,6 +341,22 @@ function read_declaration(parser) {
 		property,
 		value,
 	};
+}
+
+/**
+ * @param {Parser} parser
+ * @returns {AST.CSS.Declaration}
+ */
+function read_declaration(parser) {
+	const start = parser.index;
+
+	const property = parser.read_until(REGEX_WHITESPACE_OR_COLON);
+	parser.allow_whitespace();
+	parser.eat(':');
+	parser.allow_whitespace();
+
+	const value = read_value(parser);
+	return create_declaration(parser, start, property, value);
 }
 
 /**
@@ -348,7 +382,13 @@ function read_value(parser) {
 			in_url = false;
 		} else if (quote_mark === null && (char === '"' || char === "'")) {
 			quote_mark = char;
-		} else if (char === '(' && parser.template.slice(parser.index - 3, parser.index) === 'url') {
+		} else if (
+			char === '(' &&
+			parser.index - start >= 3 &&
+			parser.template[parser.index - 3] === 'u' &&
+			parser.template[parser.index - 2] === 'r' &&
+			parser.template[parser.index - 1] === 'l'
+		) {
 			in_url = true;
 		} else if ((char === ';' || char === '{' || char === '}') && !in_url && !quote_mark) {
 			return parser.template.slice(start, parser.index).trim();

--- a/packages/tsrx/tests/utils/style-parser.test.js
+++ b/packages/tsrx/tests/utils/style-parser.test.js
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { parseStyle } from '../../src/index.js';
+
+const location = {
+	filename: 'App.tsrx',
+	line: 1,
+	column: 1,
+};
+
+describe('CSS parser', () => {
+	it('preserves matcher results and offsets after comments and selector prefixes', () => {
+		const source =
+			'/* before */ <!-- old --> .root + span > a ~ button || input, ' +
+			'[data-kind^="hero" i]:nth-child(2n + 1 of .item) { color : red; }';
+
+		const stylesheet = parseStyle(source, location, {});
+
+		expect(stylesheet.children).toMatchObject([
+			{
+				type: 'Rule',
+				start: 26,
+				end: 127,
+				prelude: {
+					start: 26,
+					end: 110,
+					children: [
+						{
+							children: [
+								{
+									selectors: [{ type: 'ClassSelector', name: 'root', start: 26, end: 31 }],
+								},
+								{ combinator: { name: '+', start: 32, end: 33 } },
+								{ combinator: { name: '>', start: 39, end: 40 } },
+								{ combinator: { name: '~', start: 43, end: 44 } },
+								{ combinator: { name: '||', start: 52, end: 54 } },
+							],
+						},
+						{
+							children: [
+								{
+									selectors: [
+										{
+											type: 'AttributeSelector',
+											name: 'data-kind',
+											matcher: '^=',
+											value: 'hero',
+											flags: 'i',
+											start: 62,
+											end: 83,
+										},
+										{
+											type: 'PseudoClassSelector',
+											name: 'nth-child',
+											start: 83,
+											end: 110,
+											args: {
+												children: [
+													{
+														children: [
+															{
+																selectors: [
+																	{
+																		type: 'Nth',
+																		value: '2n + 1 of ',
+																		start: 94,
+																		end: 104,
+																	},
+																	{
+																		type: 'ClassSelector',
+																		name: 'item',
+																		start: 104,
+																		end: 109,
+																	},
+																],
+															},
+														],
+													},
+												],
+											},
+										},
+									],
+								},
+							],
+						},
+					],
+				},
+				block: {
+					children: [
+						{ type: 'Declaration', property: 'color', value: 'red', start: 113, end: 124 },
+					],
+				},
+			},
+		]);
+	});
+
+	it('matches percentages at a nonzero source offset', () => {
+		const stylesheet = parseStyle('/* lead */ 50% { opacity: 0.5; }', location, {});
+
+		expect(stylesheet.children).toMatchObject([
+			{
+				prelude: {
+					start: 11,
+					children: [
+						{
+							children: [
+								{
+									selectors: [{ type: 'Percentage', value: '50%', start: 11, end: 14 }],
+								},
+							],
+						},
+					],
+				},
+			},
+		]);
+	});
+
+	it('produces identical public results in strict and loose mode for valid styles', () => {
+		const source =
+			'<!-- legacy --> .card[data-size$="large" s] > img { width: calc(100% - 1rem); }';
+
+		expect(parseStyle(source, location, { loose: true })).toEqual(parseStyle(source, location, {}));
+	});
+
+	it('does not leak matcher state between parser invocations', () => {
+		const sources = [
+			'[data-state~="active" i] { color: green; }',
+			'/* longer prefix */ :nth-child(odd of .row) { display: grid; }',
+			'75.5% { opacity: 0.75; }',
+		];
+
+		for (const source of sources) {
+			const first = parseStyle(source, location, {});
+			parseStyle('.interleaved > span { color: blue; }', location, {});
+			expect(parseStyle(source, location, {})).toEqual(first);
+		}
+	});
+});

--- a/packages/tsrx/tests/utils/style-parser.test.js
+++ b/packages/tsrx/tests/utils/style-parser.test.js
@@ -134,4 +134,34 @@ describe('CSS parser', () => {
 			expect(parseStyle(source, location, {})).toEqual(first);
 		}
 	});
+
+	it('distinguishes declarations from nested rules without losing delimiters', () => {
+		const source = `.card {
+			content: "literal } ; {";
+			background: url("/assets/a;b{c}.svg");
+			escaped: foo\\;bar;
+			&:hover { color: red; }
+			@media (width > 40rem) { .child { display: grid; } }
+			--tone: blue;
+		}`;
+
+		const [rule] = parseStyle(source, location, {}).children;
+		expect(rule).toMatchObject({
+			type: 'Rule',
+			block: {
+				children: [
+					{ type: 'Declaration', property: 'content', value: '"literal } ; {"' },
+					{
+						type: 'Declaration',
+						property: 'background',
+						value: 'url("/assets/a;b{c}.svg")',
+					},
+					{ type: 'Declaration', property: 'escaped', value: 'foo\\\\;;bar' },
+					{ type: 'Rule' },
+					{ type: 'Atrule', name: 'media' },
+					{ type: 'Declaration', property: '--tone', value: 'blue' },
+				],
+			},
+		});
+	});
 });

--- a/packages/tsrx/tests/utils/style-parser.test.js
+++ b/packages/tsrx/tests/utils/style-parser.test.js
@@ -141,6 +141,7 @@ describe('CSS parser', () => {
 			background: url("/assets/a;b{c}.svg");
 			escaped: foo\\;bar;
 			&:hover { color: red; }
+			[data-x="a:b;c"] { color: blue; }
 			@media (width > 40rem) { .child { display: grid; } }
 			--tone: blue;
 		}`;
@@ -158,10 +159,15 @@ describe('CSS parser', () => {
 					},
 					{ type: 'Declaration', property: 'escaped', value: 'foo\\\\;;bar' },
 					{ type: 'Rule' },
+					{ type: 'Rule' },
 					{ type: 'Atrule', name: 'media' },
 					{ type: 'Declaration', property: '--tone', value: 'blue' },
 				],
 			},
 		});
+	});
+
+	it('does not read url function state from before the current value', () => {
+		expect(() => parseStyle('@url(foo;bar);', location, {})).toThrow('Expected identifier');
 	});
 });


### PR DESCRIPTION
## Summary

Style-heavy TSRX components now avoid reparsing ordinary CSS declarations. The parser keeps its established behavior for nested selectors, escaped values, URL delimiters, loose mode, source offsets, and diagnostics by retaining exact fallbacks for ambiguous syntax.

## Performance

Node v26.7.0; 10 warmups and 31 samples per run; three interleaved baseline/candidate runs. Values are the median of the run medians for a repeated stylesheet containing comments, compound selectors, attribute and `:nth-child` selectors, URLs, and four declarations per rule.

| Rules | `parseStyle` baseline | `parseStyle` branch | Change | `parseModule` baseline | `parseModule` branch | Change |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 128 | 1.63 ms | 1.09 ms | -32.9% | 1.68 ms | 1.38 ms | -18.0% |
| 512 | 4.70 ms | 3.29 ms | -29.8% | 6.79 ms | 5.30 ms | -21.9% |
| 2,048 | 20.70 ms | 14.12 ms | -31.8% | 28.71 ms | 21.64 ms | -24.6% |

## Validation

- `pnpm test`: 78 files passed; 3,161 tests passed; 33 skipped
- `pnpm test --project tsrx-utils`: 21 files and 491 tests passed
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm changeset:check`
- 39 baseline/branch parser outcomes matched exactly across strict and loose modes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core CSS parsing logic changed with subtle disambiguation and value-extraction paths; behavior is heavily tested but mistakes could affect compile output or diagnostics.
> 
> **Overview**
> **Speeds up declaration-heavy `<style>` parsing** by taking a fast path for ordinary property/value pairs instead of always running `read_value` as lookahead and then parsing the same declaration again.
> 
> `read_block_item` now calls **`try_read_declaration`** first; bracket-prefixed or ambiguous cases still reset and use the previous rule-vs-declaration disambiguation. Declaration construction is shared via **`create_declaration`**, with **`read_declaration`** kept as the fallback.
> 
> **`read_value`** mostly returns trimmed **substrings of the source** (tracking quotes and `url(` so `;`/`{`/`}` inside values do not break), and only delegates to **`read_escaped_value`** when backslashes need the old normalization behavior.
> 
> Adds **`style-parser.test.js`** regressions for source offsets, strict/loose parity, nested rules vs declarations, and parser state isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 860b38a7f6883cfb08c25ca53024be16f6e812e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->