### PR TITLE
perf(tsrx): batch scoped CSS pruning

### DIFF
--- a/.changeset/faster-css-pruning.md
+++ b/.changeset/faster-css-pruning.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Batch scoped CSS pruning into one stylesheet walk per component pass.

--- a/packages/tsrx/src/analyze/prune.js
+++ b/packages/tsrx/src/analyze/prune.js
@@ -1140,14 +1140,14 @@ export function prune_css_elements(
 			const selectors = get_relative_selectors(node);
 			const rule = /** @type {AST.CSS.Rule} */ (node.metadata.rule);
 
-			let used = rule_has_animation(rule);
+			let used = false;
 			for (const element of elements) {
 				if (apply_selector(selectors, rule, element, BACKWARD)) {
 					used = true;
 				}
 			}
 
-			if (used) {
+			if (used || rule_has_animation(rule)) {
 				node.metadata.used = true;
 			}
 

--- a/packages/tsrx/src/analyze/prune.js
+++ b/packages/tsrx/src/analyze/prune.js
@@ -11,7 +11,7 @@ const FORWARD = 0;
 /** @type {CssPruneDirection} */
 const BACKWARD = 1;
 
-// this will be set for every prune_css call
+// this will be set for every pruning pass
 // since the code is synchronous, this is safe
 /** @type {string} */
 let css_hash;
@@ -1107,13 +1107,21 @@ function rule_has_animation(rule) {
 
 /**
  * @param {AST.CSS.StyleSheet} css
- * @param {AST.TSRXElementNode} element
+ * @param {AST.TSRXElementNode[]} elements
  * @param {StyleClasses} styleClasses
  * @param {TopScopedClasses} topScopedClasses
  * @param {string} [regionHash]
  * @return {void}
  */
-export function prune_css(css, element, styleClasses, topScopedClasses, regionHash = css.hash) {
+export function prune_css_elements(
+	css,
+	elements,
+	styleClasses,
+	topScopedClasses,
+	regionHash = css.hash,
+) {
+	if (elements.length === 0) return;
+
 	css_hash = css.hash;
 	css_region_hash = regionHash;
 	style_identifier_classes = styleClasses;
@@ -1130,10 +1138,16 @@ export function prune_css(css, element, styleClasses, topScopedClasses, regionHa
 		},
 		ComplexSelector(node, context) {
 			const selectors = get_relative_selectors(node);
-
 			const rule = /** @type {AST.CSS.Rule} */ (node.metadata.rule);
 
-			if (apply_selector(selectors, rule, element, BACKWARD) || rule_has_animation(rule)) {
+			let used = rule_has_animation(rule);
+			for (const element of elements) {
+				if (apply_selector(selectors, rule, element, BACKWARD)) {
+					used = true;
+				}
+			}
+
+			if (used) {
 				node.metadata.used = true;
 			}
 
@@ -1180,4 +1194,16 @@ export function prune_css(css, element, styleClasses, topScopedClasses, regionHa
 	};
 
 	walk(css, null, visitors);
+}
+
+/**
+ * @param {AST.CSS.StyleSheet} css
+ * @param {AST.TSRXElementNode} element
+ * @param {StyleClasses} styleClasses
+ * @param {TopScopedClasses} topScopedClasses
+ * @param {string} [regionHash]
+ * @return {void}
+ */
+export function prune_css(css, element, styleClasses, topScopedClasses, regionHash = css.hash) {
+	prune_css_elements(css, [element], styleClasses, topScopedClasses, regionHash);
 }

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -7,7 +7,7 @@ import { print } from 'esrap';
 import { error } from '../../errors.js';
 import { is_template_value_position } from '../../analyze/validation.js';
 import { analyze_css } from '../../analyze/css-analyze.js';
-import { prune_css } from '../../analyze/prune.js';
+import { prune_css_elements } from '../../analyze/prune.js';
 import {
 	in_jsx_child_context,
 	is_empty_jsx_fragment,
@@ -1109,9 +1109,7 @@ function apply_css_definition_metadata(
 	const elements = collect_css_prunable_elements(node_children(component), [], transform_context);
 
 	const prune = () => {
-		for (const element of elements) {
-			prune_css(css, element, style_classes, top_scoped_classes, region_hash);
-		}
+		prune_css_elements(css, elements, style_classes, top_scoped_classes, region_hash);
 	};
 
 	prune();
@@ -2361,7 +2359,7 @@ function prepare_tsrx_fragment_styles(node, transform_context) {
 	for (const sheet of sheets) {
 		const region_hash = sheet.hash;
 		sheet.hash = css.hash;
-		// `prune_css` inside marks the matching selectors as used/scoped; selectors
+		// CSS pruning marks the matching selectors as used/scoped; selectors
 		// that match no element render commented out, matching target behavior.
 		apply_css_definition_metadata(
 			node,

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -3893,6 +3893,28 @@ export function optionalFn(bar: string, baz?: string) {
 			expect(count_substring(code, `${generatedClassAttrName}="card ${cssHash}"`)).toBe(2);
 		});
 
+		it('applies selector metadata to every matching element', () => {
+			const { code, css, cssHash } = compile(
+				`export function App() @{
+					<>
+						<div ${generatedClassAttrName}="card">{'First'}</div>
+						<section>
+							<div ${generatedClassAttrName}="card">{'Second'}</div>
+						</section>
+
+						<style>
+							.card { color: red; }
+						</style>
+					</>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(count_substring(code, `${generatedClassAttrName}="card ${cssHash}"`)).toBe(2);
+			expect(css).toContain(`.card.${cssHash}`);
+			expect(css).not.toContain('(unused)');
+		});
+
 		it('applies the scope hash inside fragment shorthand', () => {
 			const { code, css, cssHash } = compile(
 				`function Card() @{

--- a/packages/tsrx/tests/utils/css-prune.test.js
+++ b/packages/tsrx/tests/utils/css-prune.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeCss, parseModule, parseStyle, pruneCss } from '../../src/index.js';
+
+/** @param {string} source */
+function parse_element(source) {
+	const [statement] = parseModule(`const element = ${source};`, 'prune-css.tsrx').body;
+	if (statement.type !== 'VariableDeclaration') throw new Error('Expected a variable declaration');
+
+	const element = statement.declarations[0].init;
+	if (element?.type !== 'JSXElement') throw new Error('Expected a JSX element');
+
+	element.metadata.path = [];
+	return element;
+}
+
+describe('pruneCss', () => {
+	it('preserves the exported single-element pruning contract', () => {
+		const css = parseStyle(
+			'.card { color: red; }',
+			{ filename: 'prune-css.tsrx', line: 1, column: 1 },
+			{},
+		);
+		const element = parse_element('<div class="card" />');
+		const top_scoped_classes = new Map();
+
+		analyzeCss(css);
+		pruneCss(css, element, new Map(), top_scoped_classes);
+
+		const rule = css.children[0];
+		if (rule.type !== 'Rule') throw new Error('Expected a CSS rule');
+		const selector = rule.prelude.children[0];
+
+		expect(selector.metadata.used).toBe(true);
+		expect(element.metadata.scoped).toBe(true);
+		const css_metadata = element.metadata.css;
+		expect(css_metadata).toBeDefined();
+		if (!css_metadata) throw new Error('Expected scoped CSS metadata');
+		expect(css_metadata.hash).toBe(css.hash);
+		expect([...css_metadata.scopedClasses.keys()]).toEqual(['card']);
+		expect(top_scoped_classes.get('card')).toMatchObject({
+			start: 0,
+			end: 5,
+			regionHash: css.hash,
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Scoped CSS pruning now walks each stylesheet once per component pass instead of once per collected element. Selector matching and every per-element scope and language metadata side effect remain unchanged, including the public single-element `pruneCss` API.

## Design

The batch pass still evaluates every selector-element pair because each element needs its own metadata. It shares stylesheet traversal and selector preparation across the elements, skips rule animation scans once a selector has matched, preserves the empty-list no-op, and retains the second style-expression pass.

## Performance

Controlled local benchmark on Node.js 22.14.0:

| Fixture scale | `origin/main` | This branch | Change |
| --- | ---: | ---: | ---: |
| 1 element | 0.548 ms | 0.537 ms | 2.1% faster |
| 12 elements | 16.215 ms | 9.714 ms | 40.1% faster |
| 24 elements | 57.907 ms | 21.695 ms | 62.5% faster |

Each result is the median of 31 samples after 10 warmups, aggregated across three interleaved baseline/candidate rounds.

## Validation

- Full Vitest suite: 78 files passed; 3,160 tests passed and 33 skipped
- Full typecheck
- Full format check
- `@tsrx/core` changeset check
- Exact baseline/candidate differential match for compile output and Volar mappings across four combinator, nesting, and style-expression fixtures

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time CSS analysis refactor with baseline-matched output and new multi-element tests; no runtime auth or data-path changes.
> 
> **Overview**
> Scoped CSS pruning now runs **one stylesheet walk per component pass** instead of repeating the full walk for every prunable element. The new internal `prune_css_elements` API matches each selector against **all** collected elements in that single traversal (still applying per-element scope/class metadata via `apply_selector`), while the exported **`pruneCss` / `prune_css`** single-element contract is unchanged as a thin wrapper.
> 
> The JSX transform’s `apply_css_definition_metadata` path calls the batched API directly, so components with many styled nodes should see much less repeated AST work; the second prune pass for style-expression export is unchanged.
> 
> Tests add coverage that **every** matching element gets scoped metadata (not just the last one walked) and that the public `pruneCss` behavior stays the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78f9ac4b66e97b7c87b9c7a58e702108d14dd0d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->