### PR TITLE
perf(tsrx): collect helper bindings in one pass

### DIFF
--- a/.changeset/faster-helper-binding-discovery.md
+++ b/.changeset/faster-helper-binding-discovery.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Speed up hook-helper binding discovery by collecting referenced bindings in one helper-body traversal.

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -3084,27 +3084,35 @@ function collect_pattern_bindings(pattern, bindings) {
 /**
  * Check if a node references any of the given scope bindings.
  * Used to determine if a JSX element is static and can be hoisted to module level.
+ * When a result set is provided, records every referenced binding instead of
+ * stopping after the first match.
  *
  * @param {AST.Node | null | undefined} node
  * @param {Map<string, AST.Identifier>} scope_bindings
+ * @param {Set<string>} [referenced_bindings]
  * @returns {boolean}
  */
-function references_scope_bindings(node, scope_bindings) {
+function references_scope_bindings(node, scope_bindings, referenced_bindings) {
 	if (!node) return false;
 	if (scope_bindings.size === 0) return false;
 
 	if (node.type === 'Identifier') {
-		return scope_bindings.has(node.name);
+		const references_binding = scope_bindings.has(node.name);
+		if (references_binding) referenced_bindings?.add(node.name);
+		return references_binding;
 	}
 
 	// JSXIdentifier is a variable reference when capitalized (tag name like <MyComponent />)
 	// or when it's the object of a JSXMemberExpression (e.g. ui in <ui.Button />)
 	if (node.type === 'JSXIdentifier') {
-		return scope_bindings.has(node.name);
+		const references_binding = scope_bindings.has(node.name);
+		if (references_binding) referenced_bindings?.add(node.name);
+		return references_binding;
 	}
 
 	// Not `child_nodes`: several keys are labels rather than references and must
 	// be skipped based on the owning node's type.
+	let references_binding = false;
 	const entries = /** @type {AST.TraversableAstNode} */ (node);
 	for (const key of Object.keys(entries)) {
 		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') continue;
@@ -3123,16 +3131,25 @@ function references_scope_bindings(node, scope_bindings) {
 
 		const value = entries[key];
 		if (Array.isArray(value)) {
-			if (
-				value.some((item) => is_ast_node(item) && references_scope_bindings(item, scope_bindings))
-			)
-				return true;
-		} else if (is_ast_node(value) && references_scope_bindings(value, scope_bindings)) {
-			return true;
+			for (const item of value) {
+				if (
+					is_ast_node(item) &&
+					references_scope_bindings(item, scope_bindings, referenced_bindings)
+				) {
+					if (!referenced_bindings) return true;
+					references_binding = true;
+				}
+			}
+		} else if (
+			is_ast_node(value) &&
+			references_scope_bindings(value, scope_bindings, referenced_bindings)
+		) {
+			if (!referenced_bindings) return true;
+			references_binding = true;
 		}
 	}
 
-	return false;
+	return references_binding;
 }
 
 /**
@@ -4081,18 +4098,25 @@ function get_referenced_helper_bindings(body_nodes, available_bindings) {
 	const helper_bindings = [];
 	/** @type {Map<string, AST.Identifier>} */
 	const local_bindings = new Map();
+	/** @type {Map<string, AST.Identifier>} */
+	const candidate_bindings = new Map();
+	/** @type {Set<string>} */
+	const referenced_bindings = new Set();
 
 	for (const node of body_nodes) {
 		collect_statement_bindings(node, local_bindings);
 	}
 
 	for (const [name, binding] of available_bindings) {
-		if (local_bindings.has(name)) continue;
+		if (!local_bindings.has(name)) candidate_bindings.set(name, binding);
+	}
 
-		const scope = new Map([[name, binding]]);
-		if (body_nodes.some((node) => references_scope_bindings(node, scope))) {
-			helper_bindings.push(binding);
-		}
+	for (const node of body_nodes) {
+		references_scope_bindings(node, candidate_bindings, referenced_bindings);
+	}
+
+	for (const [name, binding] of available_bindings) {
+		if (referenced_bindings.has(name)) helper_bindings.push(binding);
 	}
 
 	return helper_bindings;

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1474,6 +1474,48 @@ export function runSharedSwitchHelperHoistingTests({
 					}
 				}
 			}`;
+		const helper_capture_source = `export function App({ status }: { status: string }) @{
+				const early = 'early';
+				const property_label = 'unused';
+				const member_label = 'unused';
+				const attribute_label = 'unused';
+				const jsx_member_label = 'unused';
+				const local_shadow = 'outer';
+				const unused0 = 0;
+				const unused1 = 1;
+				const unused2 = 2;
+				const unused3 = 3;
+				const unused4 = 4;
+				const unused5 = 5;
+				const unused6 = 6;
+				const unused7 = 7;
+				const late = 'late';
+				@switch (status) {
+					@case "active": {
+						const local_shadow = 'inner';
+						const record = { property_label: 1 };
+						const Local = { jsx_member_label: () => <span /> };
+						const label = useMemo(
+							() => late + early + local_shadow + record.member_label,
+							[],
+						);
+						<Local.jsx_member_label attribute_label={label} />
+					}
+					@default: {
+						<span>{'idle'}</span>
+					}
+				}
+			}`;
+
+		function expect_ordered_helper_capture(code, local_helper) {
+			const helper_name = local_helper ? 'StatementBodyHook1' : 'App__StatementBodyHook1';
+			const helper_signature = local_helper
+				? new RegExp(`function ${helper_name}\\(\\s*\\{ early, late \\}:`)
+				: new RegExp(`function ${helper_name}\\(\\{ early, late \\}\\)`);
+
+			expect(code).toMatch(helper_signature);
+			expect(code).toContain(`<${helper_name} early={early} late={late} />`);
+		}
 
 		it('lifts hook-bearing case bodies in the client transform', () => {
 			const { code } = compile(switch_source, 'App.tsrx');
@@ -1523,6 +1565,18 @@ export function runSharedSwitchHelperHoistingTests({
 			// No top-level helper declarations in either lifted shape.
 			expect(code).not.toMatch(/^function App__StatementBodyHook\d+\(\)/m);
 			expect(code).not.toMatch(/^const App__StatementBodyHook\d+ = defineVaporComponent\(/m);
+		});
+
+		it('captures only outer references in available-binding order for client helpers', () => {
+			const { code } = compile(helper_capture_source, 'App.tsrx');
+
+			expect_ordered_helper_capture(code, false);
+		});
+
+		it('captures only outer references in available-binding order for typeOnly helpers', () => {
+			const { code } = compile_to_volar_mappings(helper_capture_source, 'App.tsrx');
+
+			expect_ordered_helper_capture(code, true);
 		});
 	});
 }

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1507,6 +1507,10 @@ export function runSharedSwitchHelperHoistingTests({
 				}
 			}`;
 
+		/**
+		 * @param {string} code
+		 * @param {boolean} local_helper
+		 */
 		function expect_ordered_helper_capture(code, local_helper) {
 			const helper_name = local_helper ? 'StatementBodyHook1' : 'App__StatementBodyHook1';
 			const helper_signature = local_helper


### PR DESCRIPTION
## Summary

Large TSRX components with hook-lifted branches now discover captured bindings without rescanning the helper AST once per available binding. Generated code, source mappings, diagnostics, helper prop order, shadowing, and identifier-label classification remain unchanged.

## Performance

Each workload used 2 unmeasured pairs and 15 measured pairs. Each side ran in a fresh Node process with 5 warmups and 50 timed compilations. Pair order alternated, all pairs were retained, and confidence bounds use 10,000 paired bootstrap resamples.

| Workload | `origin/main` median | Candidate median | Median result | 95% paired bound |
| --- | ---: | ---: | ---: | ---: |
| Focused: 256 bindings, 24 hook cases | 1107.57 ms | 664.09 ms | 39.97% faster | 39.21% to 40.71% faster |
| Repository-derived hook workload | 9148.82 ms | 8729.02 ms | 4.09% faster | 3.36% to 5.24% faster |
| Mixed compiler corpus | 240.39 ms | 240.23 ms | 0.17% faster | regression upper bound 0.28% |

Generated code, mappings, CSS, CSS hashes, and normalized diagnostic digests matched between baseline and candidate for every workload.

## Compatibility

The shared reference walker keeps its existing short-circuit mode for static-hoist checks. Its collection mode records all helper references in one traversal, then projects them through the existing available-binding order.

Regression coverage includes Solid and Vue client and type-only output, reverse reference order, local shadowing, non-computed property and member labels, JSX attribute labels, JSX member properties, and unrelated available bindings.

## Validation

- Solid, Vue, React, and Preact focused suites: 1,577 passed, 33 skipped
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm changeset:check`
- `git diff --check`
- Root `pnpm test`: 68 files and 3,123 tests passed. Thirteen setup-dependent files were blocked in this fresh worktree because `tsdown` could not load its optional `unrun` peer to build prerequisite packages, and the sandbox denied loopback. The MCP HTTP suite passed 5/5 when rerun with loopback permission.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compiler-internal refactor with parity tests; emitted helper signatures and static-hoist checks are intended to be unchanged.
> 
> **Overview**
> **Hook-helper binding discovery** no longer rescans the lifted helper body once per outer binding. `get_referenced_helper_bindings` now builds candidate outers (available minus locals), walks the body **once** via an extended `references_scope_bindings`, then emits captured props in the original `available_bindings` order.
> 
> `references_scope_bindings` gains an optional `referenced_bindings` set: when omitted, behavior stays **short-circuit** (static JSX hoist). When provided, it records every matched scope name while still traversing the full subtree.
> 
> A **changeset** documents the `@tsrx/core` patch. Shared compile tests assert helpers only capture real outers (`early`, `late`)—not labels, shadows, or unused bindings—for both client and type-only helper shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3efb7e3a2bbb95084b1060aab00121713b902e13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->