### PR TITLE
perf(typescript-plugin): index diagnostic range mappings

### DIFF
--- a/.changeset/fast-range-diagnostics.md
+++ b/.changeset/fast-range-diagnostics.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/typescript-plugin': patch
+---
+
+Speed up repeated compile-error diagnostic range mapping in large TSRX files.

--- a/packages/language-server/tests/compileErrorDiagnosticPlugin.test.js
+++ b/packages/language-server/tests/compileErrorDiagnosticPlugin.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { URI } from 'vscode-uri';
+import { createCompileErrorDiagnosticPlugin } from '../src/compileErrorDiagnosticPlugin.js';
+
+describe('compile error diagnostic plugin', () => {
+	it('preserves exact, overlapping, and unmapped usage-error ranges', () => {
+		const document = TextDocument.create('file:///App.tsrx', 'tsrx', 1, 'x'.repeat(100));
+		const source_uri = URI.parse(document.uri);
+		const find_exact = vi.fn((start, end) =>
+			start === 10 && end === 12 ? { generatedOffsets: [50], generatedLengths: [3] } : null,
+		);
+		const find_overlapping = vi.fn((start, end) => (start === 20 && end === 24 ? [70, 76] : null));
+		const virtual_code = {
+			languageId: 'tsrx',
+			fatalErrors: [],
+			usageErrors: [
+				{ type: 'usage', message: 'exact', pos: 10, end: 12 },
+				{ type: 'usage', message: 'overlap', pos: 20, end: 24 },
+				{ type: 'usage', message: 'unmapped', pos: 30, end: 34 },
+			],
+			findMappingBySourceRange: find_exact,
+			findGeneratedRangeBySourceRange: find_overlapping,
+		};
+		const source_script = {
+			generated: { embeddedCodes: { get: () => virtual_code } },
+		};
+		const context = /** @type {any} */ ({
+			decodeEmbeddedDocumentUri: () => [source_uri, 'root'],
+			language: {
+				scripts: { get: () => source_script },
+				maps: { get: () => undefined },
+			},
+		});
+		const provider = createCompileErrorDiagnosticPlugin().create(context);
+
+		const diagnostics = provider.provideDiagnostics(document, /** @type {any} */ (undefined));
+
+		expect(diagnostics.map((diagnostic) => diagnostic.range)).toEqual([
+			{ start: { line: 0, character: 50 }, end: { line: 0, character: 53 } },
+			{ start: { line: 0, character: 70 }, end: { line: 0, character: 76 } },
+			{ start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+		]);
+		expect(find_exact).toHaveBeenCalledTimes(3);
+		expect(find_overlapping).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/language-server/tests/compileErrorDiagnosticPlugin.test.js
+++ b/packages/language-server/tests/compileErrorDiagnosticPlugin.test.js
@@ -4,7 +4,10 @@ import { URI } from 'vscode-uri';
 import { createCompileErrorDiagnosticPlugin } from '../src/compileErrorDiagnosticPlugin.js';
 
 describe('compile error diagnostic plugin', () => {
-	it('preserves exact, overlapping, and unmapped usage-error ranges', () => {
+	it('preserves exact, overlapping, and unmapped usage-error ranges', async () => {
+		// utils.js initializes its core helpers through a dynamic import. Await the
+		// same module so Vitest cannot tear down this test environment first.
+		await import('@tsrx/core');
 		const document = TextDocument.create('file:///App.tsrx', 'tsrx', 1, 'x'.repeat(100));
 		const source_uri = URI.parse(document.uri);
 		const find_exact = vi.fn((start, end) =>

--- a/packages/typescript-plugin/src/language.js
+++ b/packages/typescript-plugin/src/language.js
@@ -5,6 +5,7 @@
 /** @typedef {{ compile?: (source: string, filename: string, options?: { loose?: boolean }) => TSRXCompileResult, compile_to_volar_mappings(source: string, filename: string, options?: { loose?: boolean }): VolarMappingsResult }} TSRXCompilerModule */
 
 /** @typedef {Map<string, CodeMapping>} CachedMappings */
+/** @typedef {{ mapping: CodeMapping, sourceStart: number, sourceEnd: number, originalIndex: number, prefixMaxEnd: number }[]} SourceRangeIndex */
 /** @typedef {import('typescript').CompilerOptions} CompilerOptions */
 /** @typedef {import('@volar/language-core').IScriptSnapshot} IScriptSnapshot */
 /** @typedef {import('@volar/language-core').VirtualCode} VirtualCode */
@@ -252,6 +253,10 @@ export class TSRXVirtualCode {
 	#mappingGenToSource = null;
 	/** @type {CachedMappings | null} */
 	#mappingSourceToGen = null;
+	/** @type {SourceRangeIndex | null} */
+	#sourceRangeIndex = null;
+	/** @type {number} */
+	#sourceRangeLookupCount = 0;
 
 	/**
 	 * @param {string} file_name
@@ -290,6 +295,8 @@ export class TSRXVirtualCode {
 		// Only clear mapping index - don't update snapshot/originalCode yet
 		this.#mappingGenToSource = null;
 		this.#mappingSourceToGen = null;
+		this.#sourceRangeIndex = null;
+		this.#sourceRangeLookupCount = 0;
 
 		this.fatalErrors = [];
 		this.usageErrors = [];
@@ -558,40 +565,134 @@ export class TSRXVirtualCode {
 	 *   token overlaps the range
 	 */
 	findGeneratedRangeBySourceRange(start, end) {
-		/** @type {CodeMapping | null} */
-		let first = null;
-		/** @type {CodeMapping | null} */
-		let last = null;
-		for (let i = 0; i < this.mappings.length; i++) {
-			const mapping = this.mappings[i];
-			const sourceStart = mapping.sourceOffsets[0];
-			const sourceEnd = sourceStart + mapping.lengths[0];
-			// Skip tokens that do not overlap the half-open range [start, end).
-			if (sourceEnd <= start || sourceStart >= end) {
-				continue;
-			}
-			if (!first || sourceStart < first.sourceOffsets[0]) {
-				first = mapping;
-			}
-			if (!last || sourceEnd > last.sourceOffsets[0] + last.lengths[0]) {
-				last = mapping;
-			}
-		}
-		if (!first || !last) {
-			return null;
+		// A one-off lookup is cheaper as a linear scan. Compile-error publication
+		// calls this repeatedly, so build the reusable index only after the first
+		// fallback query and keep the single-query path allocation-free.
+		if (this.#sourceRangeLookupCount++ === 0) {
+			return find_generated_range_linearly(this.mappings, start, end);
 		}
 
-		// Offset into the first/last token, clamped so an endpoint that lands
-		// before/after the token (an unmapped keyword or punctuation) snaps to the
-		// token edge rather than escaping its generated span.
-		const generated_start =
-			first.generatedOffsets[0] +
-			clamp_offset(start - first.sourceOffsets[0], first.generatedLengths[0]);
-		const generated_end =
-			last.generatedOffsets[0] +
-			clamp_offset(end - last.sourceOffsets[0], last.generatedLengths[0]);
-		return [generated_start, Math.max(generated_end, generated_start + 1)];
+		if (!this.#sourceRangeIndex) {
+			const index = new Array(this.mappings.length);
+			for (let i = 0; i < this.mappings.length; i++) {
+				const mapping = this.mappings[i];
+				const sourceStart = mapping.sourceOffsets[0];
+				index[i] = {
+					mapping,
+					sourceStart,
+					sourceEnd: sourceStart + mapping.lengths[0],
+					originalIndex: i,
+					prefixMaxEnd: 0,
+				};
+			}
+			index.sort((a, b) => a.sourceStart - b.sourceStart || a.originalIndex - b.originalIndex);
+
+			let prefixMaxEnd = -Infinity;
+			for (const entry of index) {
+				prefixMaxEnd = Math.max(prefixMaxEnd, entry.sourceEnd);
+				entry.prefixMaxEnd = prefixMaxEnd;
+			}
+			this.#sourceRangeIndex = index;
+		}
+
+		const index = this.#sourceRangeIndex;
+		let low = 0;
+		let high = index.length;
+		while (low < high) {
+			const middle = (low + high) >>> 1;
+			if (index[middle].prefixMaxEnd <= start) {
+				low = middle + 1;
+			} else {
+				high = middle;
+			}
+		}
+
+		/** @type {CodeMapping | null} */
+		let first = null;
+		let firstStart = Infinity;
+		let firstIndex = Infinity;
+		/** @type {CodeMapping | null} */
+		let last = null;
+		let lastEnd = -Infinity;
+		let lastIndex = Infinity;
+		for (let i = low; i < index.length; i++) {
+			const entry = index[i];
+			if (entry.sourceStart >= end) {
+				break;
+			}
+			if (entry.sourceEnd <= start) {
+				continue;
+			}
+			if (
+				entry.sourceStart < firstStart ||
+				(entry.sourceStart === firstStart && entry.originalIndex < firstIndex)
+			) {
+				first = entry.mapping;
+				firstStart = entry.sourceStart;
+				firstIndex = entry.originalIndex;
+			}
+			if (
+				entry.sourceEnd > lastEnd ||
+				(entry.sourceEnd === lastEnd && entry.originalIndex < lastIndex)
+			) {
+				last = entry.mapping;
+				lastEnd = entry.sourceEnd;
+				lastIndex = entry.originalIndex;
+			}
+		}
+		return generated_range_from_mappings(first, last, start, end);
 	}
+}
+
+/**
+ * @param {CodeMapping[]} mappings
+ * @param {number} start
+ * @param {number} end
+ * @returns {[number, number] | null}
+ */
+function find_generated_range_linearly(mappings, start, end) {
+	/** @type {CodeMapping | null} */
+	let first = null;
+	/** @type {CodeMapping | null} */
+	let last = null;
+	for (let i = 0; i < mappings.length; i++) {
+		const mapping = mappings[i];
+		const sourceStart = mapping.sourceOffsets[0];
+		const sourceEnd = sourceStart + mapping.lengths[0];
+		if (sourceEnd <= start || sourceStart >= end) {
+			continue;
+		}
+		if (!first || sourceStart < first.sourceOffsets[0]) {
+			first = mapping;
+		}
+		if (!last || sourceEnd > last.sourceOffsets[0] + last.lengths[0]) {
+			last = mapping;
+		}
+	}
+	return generated_range_from_mappings(first, last, start, end);
+}
+
+/**
+ * @param {CodeMapping | null} first
+ * @param {CodeMapping | null} last
+ * @param {number} start
+ * @param {number} end
+ * @returns {[number, number] | null}
+ */
+function generated_range_from_mappings(first, last, start, end) {
+	if (!first || !last) {
+		return null;
+	}
+
+	// Offset into the first/last token, clamped so an endpoint that lands
+	// before/after the token (an unmapped keyword or punctuation) snaps to the
+	// token edge rather than escaping its generated span.
+	const generated_start =
+		first.generatedOffsets[0] +
+		clamp_offset(start - first.sourceOffsets[0], first.generatedLengths[0]);
+	const generated_end =
+		last.generatedOffsets[0] + clamp_offset(end - last.sourceOffsets[0], last.generatedLengths[0]);
+	return [generated_start, Math.max(generated_end, generated_start + 1)];
 }
 
 /**

--- a/packages/typescript-plugin/src/language.js
+++ b/packages/typescript-plugin/src/language.js
@@ -255,8 +255,8 @@ export class TSRXVirtualCode {
 	#mappingSourceToGen = null;
 	/** @type {SourceRangeIndex | null} */
 	#sourceRangeIndex = null;
-	/** @type {number} */
-	#sourceRangeLookupCount = 0;
+	/** @type {boolean} */
+	#hasSourceRangeLookup = false;
 
 	/**
 	 * @param {string} file_name
@@ -296,7 +296,7 @@ export class TSRXVirtualCode {
 		this.#mappingGenToSource = null;
 		this.#mappingSourceToGen = null;
 		this.#sourceRangeIndex = null;
-		this.#sourceRangeLookupCount = 0;
+		this.#hasSourceRangeLookup = false;
 
 		this.fatalErrors = [];
 		this.usageErrors = [];
@@ -523,6 +523,33 @@ export class TSRXVirtualCode {
 		}
 	}
 
+	#buildSourceRangeIndex() {
+		if (this.#sourceRangeIndex) {
+			return;
+		}
+
+		const index = new Array(this.mappings.length);
+		for (let i = 0; i < this.mappings.length; i++) {
+			const mapping = this.mappings[i];
+			const sourceStart = mapping.sourceOffsets[0];
+			index[i] = {
+				mapping,
+				sourceStart,
+				sourceEnd: sourceStart + mapping.lengths[0],
+				originalIndex: i,
+				prefixMaxEnd: 0,
+			};
+		}
+		index.sort((a, b) => a.sourceStart - b.sourceStart || a.originalIndex - b.originalIndex);
+
+		let prefixMaxEnd = -Infinity;
+		for (const entry of index) {
+			prefixMaxEnd = Math.max(prefixMaxEnd, entry.sourceEnd);
+			entry.prefixMaxEnd = prefixMaxEnd;
+		}
+		this.#sourceRangeIndex = index;
+	}
+
 	/**
 	 * Find mapping by generated range
 	 * @param {number} start - The start offset of the range
@@ -568,34 +595,13 @@ export class TSRXVirtualCode {
 		// A one-off lookup is cheaper as a linear scan. Compile-error publication
 		// calls this repeatedly, so build the reusable index only after the first
 		// fallback query and keep the single-query path allocation-free.
-		if (this.#sourceRangeLookupCount++ === 0) {
+		if (!this.#hasSourceRangeLookup) {
+			this.#hasSourceRangeLookup = true;
 			return find_generated_range_linearly(this.mappings, start, end);
 		}
 
-		if (!this.#sourceRangeIndex) {
-			const index = new Array(this.mappings.length);
-			for (let i = 0; i < this.mappings.length; i++) {
-				const mapping = this.mappings[i];
-				const sourceStart = mapping.sourceOffsets[0];
-				index[i] = {
-					mapping,
-					sourceStart,
-					sourceEnd: sourceStart + mapping.lengths[0],
-					originalIndex: i,
-					prefixMaxEnd: 0,
-				};
-			}
-			index.sort((a, b) => a.sourceStart - b.sourceStart || a.originalIndex - b.originalIndex);
-
-			let prefixMaxEnd = -Infinity;
-			for (const entry of index) {
-				prefixMaxEnd = Math.max(prefixMaxEnd, entry.sourceEnd);
-				entry.prefixMaxEnd = prefixMaxEnd;
-			}
-			this.#sourceRangeIndex = index;
-		}
-
-		const index = this.#sourceRangeIndex;
+		this.#buildSourceRangeIndex();
+		const index = /** @type {SourceRangeIndex} */ (this.#sourceRangeIndex);
 		let low = 0;
 		let high = index.length;
 		while (low < high) {

--- a/packages/typescript-plugin/tests/plugin-integration.test.js
+++ b/packages/typescript-plugin/tests/plugin-integration.test.js
@@ -228,6 +228,43 @@ function token_mapping(sourceStart, sourceLength, generatedStart, generatedLengt
 	};
 }
 
+/**
+ * Reference implementation for the source-range fallback. Keep this deliberately
+ * linear so indexed implementations can be checked against the original behavior.
+ * @param {import('@tsrx/core/types').CodeMapping[]} mappings
+ * @param {number} start
+ * @param {number} end
+ * @returns {[number, number] | null}
+ */
+function linear_generated_range(mappings, start, end) {
+	let first = null;
+	let last = null;
+	for (const mapping of mappings) {
+		const source_start = mapping.sourceOffsets[0];
+		const source_end = source_start + mapping.lengths[0];
+		if (source_end <= start || source_start >= end) {
+			continue;
+		}
+		if (!first || source_start < first.sourceOffsets[0]) {
+			first = mapping;
+		}
+		if (!last || source_end > last.sourceOffsets[0] + last.lengths[0]) {
+			last = mapping;
+		}
+	}
+	if (!first || !last) {
+		return null;
+	}
+
+	const generated_start =
+		first.generatedOffsets[0] +
+		Math.min(Math.max(start - first.sourceOffsets[0], 0), first.generatedLengths[0]);
+	const generated_end =
+		last.generatedOffsets[0] +
+		Math.min(Math.max(end - last.sourceOffsets[0], 0), last.generatedLengths[0]);
+	return [generated_start, Math.max(generated_end, generated_start + 1)];
+}
+
 describe('typescript-plugin language plugin integration', () => {
 	beforeEach(() => {
 		_reset_for_test();
@@ -831,6 +868,37 @@ describe('typescript-plugin language plugin integration', () => {
 		// A range that overlaps no token at all stays unresolved (the caller then
 		// falls back to the source map).
 		expect(virtual_code.findGeneratedRangeBySourceRange(0, 5)).toBeNull();
+	});
+
+	it('matches the linear source-range fallback for unordered and nested mappings', () => {
+		const plugin = create_plugin();
+		const workspace = create_fixture_workspace('ripple-only');
+		const file_name = path.join(workspace, 'src', 'App.tsrx');
+		const virtual_code = create_virtual_code(plugin, file_name, '<div/>');
+		const mappings = [
+			token_mapping(12, 8, 212, 8),
+			token_mapping(4, 6, 104, 6),
+			token_mapping(4, 2, 304, 2),
+			token_mapping(1, 19, 401, 19),
+			token_mapping(15, 5, 515, 5),
+			token_mapping(9, 0, 609, 1),
+		];
+		virtual_code.mappings = mappings;
+
+		for (const [start, end] of [
+			[0, 1],
+			[1, 2],
+			[3, 5],
+			[6, 10],
+			[10, 15],
+			[14, 20],
+			[20, 21],
+			[0, 25],
+		]) {
+			expect(virtual_code.findGeneratedRangeBySourceRange(start, end)).toEqual(
+				linear_generated_range(mappings, start, end),
+			);
+		}
 	});
 
 	it('returns undefined for non-tsrx files before compiler resolution', () => {

--- a/packages/typescript-plugin/tests/plugin-integration.test.js
+++ b/packages/typescript-plugin/tests/plugin-integration.test.js
@@ -899,6 +899,76 @@ describe('typescript-plugin language plugin integration', () => {
 				linear_generated_range(mappings, start, end),
 			);
 		}
+
+		let random_state = 0x5eed1234;
+		const random = () => {
+			random_state = (Math.imul(random_state, 1664525) + 1013904223) >>> 0;
+			return random_state;
+		};
+		const random_mappings = Array.from({ length: 128 }, (_, index) => {
+			const source_start = random() % 500;
+			return token_mapping(source_start, random() % 40, index * 7, (random() % 12) + 1);
+		});
+		const random_virtual_code = create_virtual_code(plugin, file_name, '<main/>');
+		random_virtual_code.mappings = random_mappings;
+		for (let index = 0; index < 200; index++) {
+			const start = random() % 520;
+			const end = start + (random() % 50) + 1;
+			expect(random_virtual_code.findGeneratedRangeBySourceRange(start, end)).toEqual(
+				linear_generated_range(random_mappings, start, end),
+			);
+		}
+	});
+
+	it('reuses indexed source ranges after repeated fallback lookups', () => {
+		const plugin = create_plugin();
+		const workspace = create_fixture_workspace('ripple-only');
+		const file_name = path.join(workspace, 'src', 'App.tsrx');
+		const virtual_code = create_virtual_code(plugin, file_name, '<div/>');
+		const mappings = Array.from({ length: 100 }, (_, index) =>
+			token_mapping(index * 4, 2, index * 5, 2),
+		);
+		let mapping_reads = 0;
+		virtual_code.mappings = new Proxy(mappings, {
+			get(target, property, receiver) {
+				if (typeof property === 'string' && /^\d+$/.test(property)) {
+					mapping_reads++;
+				}
+				return Reflect.get(target, property, receiver);
+			},
+		});
+
+		virtual_code.findGeneratedRangeBySourceRange(4, 7);
+		virtual_code.findGeneratedRangeBySourceRange(40, 43);
+		mapping_reads = 0;
+		expect(virtual_code.findGeneratedRangeBySourceRange(360, 363)).toEqual([450, 452]);
+		expect(mapping_reads).toBeLessThan(10);
+	});
+
+	it('invalidates indexed source ranges when virtual code updates', () => {
+		let mappings = [token_mapping(4, 2, 40, 2), token_mapping(12, 2, 120, 2)];
+		const compiler = {
+			/** @param {string} source */
+			compile_to_volar_mappings(source) {
+				return {
+					code: source,
+					mappings,
+					errors: [],
+					cssMappings: [],
+					scriptMappings: [],
+					sourceAst: /** @type {any} */ (null),
+				};
+			},
+		};
+		const virtual_code = new TSRXVirtualCode('App.tsrx', create_snapshot('<div/>'), compiler);
+		virtual_code.findGeneratedRangeBySourceRange(3, 7);
+		expect(virtual_code.findGeneratedRangeBySourceRange(11, 15)).toEqual([120, 122]);
+
+		mappings = [token_mapping(12, 2, 912, 2)];
+		virtual_code.update(create_snapshot('<main/>'));
+
+		expect(virtual_code.findGeneratedRangeBySourceRange(3, 7)).toBeNull();
+		expect(virtual_code.findGeneratedRangeBySourceRange(11, 15)).toEqual([912, 914]);
 	});
 
 	it('returns undefined for non-tsrx files before compiler resolution', () => {


### PR DESCRIPTION
## Summary

Large invalid TSRX files now locate compile diagnostics without rescanning every mapping for each error. Repeated fallback lookups use a lazy overlap index, while the first lookup stays linear to avoid cold-path overhead.

The indexed path preserves unordered and nested mappings, original-array tie breaks, half-open overlap behavior, clamping, and update invalidation. Diagnostic messages, severity, public APIs, generated code, and unmapped fallbacks do not change.

## Performance

Fresh-process runs alternated baseline and candidate order, included warmups and repeated samples, and verified identical semantic digests.

| Workload | Baseline median | Optimized median | Ratio | Result |
| --- | ---: | ---: | ---: | --- |
| 12,000 mappings, 1,500 repeated queries | 66.479 ms | 2.045 ms | 0.03068 | 96.9% faster; 95% upper paired ratio 0.03211 |
| 4,501 compiled mappings, 750 queries | 14.631 ms | 1.307 ms | 0.09030 | 91.0% faster |
| 12,000 mappings, one query per fresh instance | 48.060 ms | 47.280 ms | 0.98867 | No material cold-path regression; 95% upper paired ratio 1.01469 |

Measured on Node.js 22.14.0. The synthetic digest was `82026037`; the compiled-mapping digest was `3356609148`; the cold-path digest was `2350541973`.

## Validation

- Focused TypeScript-plugin and language-server coverage: 10 files, 173 tests passed.
- Full Vitest suite: 78 files passed; 3,159 tests passed; 33 skipped.
- Workspace typecheck, Prettier check, changeset check, grammar-revision check, and `git diff --check` passed.
- Browser testing was skipped because this changes language tooling and has no rendered route or interaction surface.

## New concepts

### Prefix-max interval index

A prefix-max interval index sorts ranges by start offset and stores the largest end offset seen at every position. A query can binary-search past ranges that certainly end before its start, then inspect only the remaining possible overlaps.

This fits diagnostic publication because one virtual file can receive many overlap queries against the same mapping set. A plain binary search on start offsets would miss long or nested ranges that begin earlier, while the prefix maximum keeps those candidates reachable.

The first fallback lookup remains a linear scan because building and sorting an index costs more than one scan. This technique is most useful when the same interval set receives repeated queries; it is not useful for one-off lookups.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path editor mapping semantics for compile diagnostics; behavior is heavily regression-tested against the prior linear algorithm and invalidation paths.
> 
> **Overview**
> Speeds up **compile-error diagnostic squiggle placement** in large `.tsrx` files by optimizing `findGeneratedRangeBySourceRange` on `TSRXVirtualCode`, which the language server calls for every usage error after an exact mapping miss.
> 
> The **first** overlap lookup still uses a linear scan (no index build). **Later** lookups on the same virtual file build a lazy **prefix-max source-range index** (sorted by start, with cumulative max end) so queries binary-search past non-overlapping ranges instead of scanning all token mappings. Shared clamping/overlap logic moves into `generated_range_from_mappings`; the index is cleared on virtual-code `update`.
> 
> Adds integration tests that indexed results match a linear reference (including random cases), that repeated lookups touch far fewer mappings, and that updates invalidate the cache. Adds a language-server test that the compile-error diagnostic plugin still maps exact, overlapping, and unmapped usage-error ranges correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 634bed669e900d8dac8b07308ea01bb17f580219. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->