### PR TITLE
fix(tsrx): lower lazy destructuring in loop headers

### DIFF
--- a/.changeset/lazy-loops-report.md
+++ b/.changeset/lazy-loops-report.md
@@ -1,0 +1,5 @@
+---
+"@tsrx/core": patch
+---
+
+Lower lazy destructuring in JavaScript loop headers and report unsupported lazy assignment positions with a target-neutral diagnostic.

--- a/packages/tsrx/src/analyze/index.js
+++ b/packages/tsrx/src/analyze/index.js
@@ -7,8 +7,8 @@ import { walk } from 'zimmerframe';
 import {
 	child_nodes,
 	is_code_block_function_body,
-	is_statement_list_item,
 	is_statement_position,
+	is_supported_lazy_assignment_position,
 	is_tsrx_render_output_node,
 } from '../utils/ast.js';
 import {
@@ -60,44 +60,13 @@ function find_first_lazy_pattern(node) {
 }
 
 /**
- * A supported lazy assignment may be parenthesized, but it must otherwise be
- * the entire expression statement and that statement must be a list item.
- *
- * @param {AST.AssignmentExpression} node
- * @param {AST.Node[]} path
- * @returns {boolean}
- */
-function is_complete_statement_list_assignment(node, path) {
-	/** @type {AST.Node} */
-	let child = node;
-
-	for (let i = path.length - 1; i >= 0; i -= 1) {
-		const parent = path[i];
-
-		if (is_transparent_expression_wrapper(parent, child)) {
-			child = parent;
-			continue;
-		}
-
-		if (parent.type !== 'ExpressionStatement' || parent.expression !== child) return false;
-
-		const container = path[i - 1];
-		return !!container && is_statement_list_item(container, parent);
-	}
-
-	return false;
-}
-
-/**
  * @param {AST.AssignmentExpression} node
  * @param {{ next: () => unknown, path: AST.Node[], state: TSRXAnalysisState }} context
  */
 function visit_assignment_expression(node, { next, path, state }) {
 	const lazy = find_first_lazy_pattern(node.left);
-	const directly_lazy =
-		(node.left.type === 'ObjectPattern' || node.left.type === 'ArrayPattern') && node.left.lazy;
 
-	if (lazy && (!directly_lazy || !is_complete_statement_list_assignment(node, path))) {
+	if (lazy && !is_supported_lazy_assignment_position(node, path)) {
 		validate_unsupported_lazy_assignment_position(
 			lazy,
 			state.filename,

--- a/packages/tsrx/src/analyze/index.js
+++ b/packages/tsrx/src/analyze/index.js
@@ -9,34 +9,13 @@ import {
 	is_code_block_function_body,
 	is_statement_position,
 	is_supported_lazy_assignment_position,
+	is_transparent_expression_wrapper,
 	is_tsrx_render_output_node,
 } from '../utils/ast.js';
 import {
 	validate_forgotten_statement_container,
 	validate_unsupported_lazy_assignment_position,
 } from './validation.js';
-
-/**
- * Wrappers that preserve an expression's value and therefore do not turn a
- * template into a used value on their own. Looking through them keeps strict
- * builds and `preserveParens` type-only builds on the same diagnostic path.
- *
- * @param {AST.Node} parent
- * @param {AST.Node} child
- * @returns {boolean}
- */
-function is_transparent_expression_wrapper(parent, child) {
-	return (
-		(parent.type === 'ParenthesizedExpression' ||
-			parent.type === 'TSAsExpression' ||
-			parent.type === 'TSSatisfiesExpression' ||
-			parent.type === 'TSNonNullExpression' ||
-			parent.type === 'TSInstantiationExpression' ||
-			parent.type === 'TSTypeAssertion' ||
-			parent.type === 'ChainExpression') &&
-		/** @type {{ expression?: AST.Node }} */ (parent).expression === child
-	);
-}
 
 /**
  * Find the first authored lazy pattern in a node's subtree. Assignment

--- a/packages/tsrx/src/analyze/index.js
+++ b/packages/tsrx/src/analyze/index.js
@@ -5,7 +5,6 @@
 
 import { walk } from 'zimmerframe';
 import {
-	child_nodes,
 	is_code_block_function_body,
 	is_statement_position,
 	is_supported_lazy_assignment_position,
@@ -18,9 +17,9 @@ import {
 } from './validation.js';
 
 /**
- * Find the first authored lazy pattern in a node's subtree. Assignment
- * validation calls this once for the whole target so an unsupported outer
- * target reports one diagnostic even when it contains several lazy patterns.
+ * Find the first authored lazy pattern along an assignment target's binding
+ * edges. Default-value expressions and computed keys are evaluated
+ * expressions, so nested assignments there own their own diagnostics.
  *
  * @param {AST.Node} node
  * @returns {import('../../types/index').LazyPattern | null}
@@ -30,12 +29,34 @@ function find_first_lazy_pattern(node) {
 		return node;
 	}
 
-	for (const child of child_nodes(node)) {
-		const lazy = find_first_lazy_pattern(child);
-		if (lazy) return lazy;
+	switch (node.type) {
+		case 'AssignmentPattern':
+			return find_first_lazy_pattern(node.left);
+		case 'RestElement':
+			return find_first_lazy_pattern(node.argument);
+		case 'ObjectPattern':
+			for (const property of node.properties) {
+				const lazy =
+					property.type === 'Property'
+						? find_first_lazy_pattern(property.value)
+						: find_first_lazy_pattern(property.argument);
+				if (lazy) return lazy;
+			}
+			return null;
+		case 'ArrayPattern':
+			for (const element of node.elements) {
+				if (!element) continue;
+				const lazy = find_first_lazy_pattern(element);
+				if (lazy) return lazy;
+			}
+			return null;
+		default: {
+			const expression = /** @type {{ expression?: AST.Node }} */ (node).expression;
+			return expression && is_transparent_expression_wrapper(node, expression)
+				? find_first_lazy_pattern(expression)
+				: null;
+		}
 	}
-
-	return null;
 }
 
 /**

--- a/packages/tsrx/src/analyze/index.js
+++ b/packages/tsrx/src/analyze/index.js
@@ -5,11 +5,16 @@
 
 import { walk } from 'zimmerframe';
 import {
+	child_nodes,
 	is_code_block_function_body,
+	is_statement_list_item,
 	is_statement_position,
 	is_tsrx_render_output_node,
 } from '../utils/ast.js';
-import { validate_forgotten_statement_container } from './validation.js';
+import {
+	validate_forgotten_statement_container,
+	validate_unsupported_lazy_assignment_position,
+} from './validation.js';
 
 /**
  * Wrappers that preserve an expression's value and therefore do not turn a
@@ -31,6 +36,77 @@ function is_transparent_expression_wrapper(parent, child) {
 			parent.type === 'ChainExpression') &&
 		/** @type {{ expression?: AST.Node }} */ (parent).expression === child
 	);
+}
+
+/**
+ * Find the first authored lazy pattern in a node's subtree. Assignment
+ * validation calls this once for the whole target so an unsupported outer
+ * target reports one diagnostic even when it contains several lazy patterns.
+ *
+ * @param {AST.Node} node
+ * @returns {import('../../types/index').LazyPattern | null}
+ */
+function find_first_lazy_pattern(node) {
+	if ((node.type === 'ObjectPattern' || node.type === 'ArrayPattern') && node.lazy) {
+		return node;
+	}
+
+	for (const child of child_nodes(node)) {
+		const lazy = find_first_lazy_pattern(child);
+		if (lazy) return lazy;
+	}
+
+	return null;
+}
+
+/**
+ * A supported lazy assignment may be parenthesized, but it must otherwise be
+ * the entire expression statement and that statement must be a list item.
+ *
+ * @param {AST.AssignmentExpression} node
+ * @param {AST.Node[]} path
+ * @returns {boolean}
+ */
+function is_complete_statement_list_assignment(node, path) {
+	/** @type {AST.Node} */
+	let child = node;
+
+	for (let i = path.length - 1; i >= 0; i -= 1) {
+		const parent = path[i];
+
+		if (is_transparent_expression_wrapper(parent, child)) {
+			child = parent;
+			continue;
+		}
+
+		if (parent.type !== 'ExpressionStatement' || parent.expression !== child) return false;
+
+		const container = path[i - 1];
+		return !!container && is_statement_list_item(container, parent);
+	}
+
+	return false;
+}
+
+/**
+ * @param {AST.AssignmentExpression} node
+ * @param {{ next: () => unknown, path: AST.Node[], state: TSRXAnalysisState }} context
+ */
+function visit_assignment_expression(node, { next, path, state }) {
+	const lazy = find_first_lazy_pattern(node.left);
+	const directly_lazy =
+		(node.left.type === 'ObjectPattern' || node.left.type === 'ArrayPattern') && node.left.lazy;
+
+	if (lazy && (!directly_lazy || !is_complete_statement_list_assignment(node, path))) {
+		validate_unsupported_lazy_assignment_position(
+			lazy,
+			state.filename,
+			state.collect ? state.errors : undefined,
+			state.comments,
+		);
+	}
+
+	next();
 }
 
 /**
@@ -126,6 +202,8 @@ function visit_class(_node, { next, state }) {
 }
 
 const visitors = {
+	AssignmentExpression: visit_assignment_expression,
+
 	FunctionDeclaration: visit_function,
 	FunctionExpression: visit_function,
 	ArrowFunctionExpression: visit_function,

--- a/packages/tsrx/src/analyze/validation.js
+++ b/packages/tsrx/src/analyze/validation.js
@@ -30,6 +30,8 @@ export const TSRX_DO_WHILE_STATEMENT_ERROR =
 	'Do...while loops are not supported in TSRX templates. Move the do...while loop into a function.';
 export const TSRX_FORGOTTEN_STATEMENT_CONTAINER_ERROR =
 	"This TSRX template output is unused. Return it, assign it to a value that is rendered, or make it part of the rendered output of a function '@{...}' body.";
+export const TSRX_UNSUPPORTED_LAZY_ASSIGNMENT_POSITION_ERROR =
+	'Lazy destructuring assignments require a directly lazy target as a standalone statement inside a program, block, TSRX code block, or switch case.';
 
 const invalid_nestings = {
 	// <p> cannot contain block-level elements
@@ -217,6 +219,23 @@ export function validate_forgotten_statement_container(node, filename, errors, c
 		errors,
 		comments,
 		DIAGNOSTIC_CODES.FORGOTTEN_STATEMENT_CONTAINER,
+	);
+}
+
+/**
+ * @param {import('../../types/index').LazyPattern} node
+ * @param {string | null | undefined} filename
+ * @param {CompileError[]} [errors]
+ * @param {AST.CommentWithLocation[]} [comments]
+ */
+export function validate_unsupported_lazy_assignment_position(node, filename, errors, comments) {
+	error(
+		TSRX_UNSUPPORTED_LAZY_ASSIGNMENT_POSITION_ERROR,
+		filename ?? null,
+		node,
+		errors,
+		comments,
+		DIAGNOSTIC_CODES.UNSUPPORTED_LAZY_ASSIGNMENT_POSITION,
 	);
 }
 

--- a/packages/tsrx/src/diagnostics.js
+++ b/packages/tsrx/src/diagnostics.js
@@ -5,4 +5,5 @@ export const DIAGNOSTIC_CODES = {
 	TEMPLATE_EXPRESSION_TRAILING_SEMICOLON: 'tsrx-template-expression-trailing-semicolon',
 	TEMPLATE_RETURN_STATEMENT: 'tsrx-template-return-statement',
 	FORGOTTEN_STATEMENT_CONTAINER: 'tsrx-forgotten-statement-container',
+	UNSUPPORTED_LAZY_ASSIGNMENT_POSITION: 'tsrx-unsupported-lazy-assignment-position',
 };

--- a/packages/tsrx/src/index.js
+++ b/packages/tsrx/src/index.js
@@ -94,6 +94,7 @@ export {
 	is_template_directive as isTemplateDirective,
 	is_tsrx_render_output_node as isTsrxRenderOutputNode,
 	is_code_block_function_body as isCodeBlockFunctionBody,
+	is_statement_list_item as isStatementListItem,
 	is_statement_position as isStatementPosition,
 } from './utils/ast.js';
 
@@ -262,6 +263,7 @@ export {
 	TSRX_LOOP_CONTINUE_ERROR,
 	TSRX_LOOP_RETURN_ERROR,
 	TSRX_RETURN_STATEMENT_ERROR,
+	TSRX_UNSUPPORTED_LAZY_ASSIGNMENT_POSITION_ERROR,
 	TSRX_WHILE_STATEMENT_ERROR,
 	get_return_keyword_node as getReturnKeywordNode,
 	get_statement_keyword_node as getStatementKeywordNode,
@@ -272,6 +274,7 @@ export {
 	validate_tsrx_loop_continue_statement as validateTsrxLoopContinueStatement,
 	validate_tsrx_loop_return_statement as validateTsrxLoopReturnStatement,
 	validate_tsrx_return_statement as validateTsrxReturnStatement,
+	validate_unsupported_lazy_assignment_position as validateUnsupportedLazyAssignmentPosition,
 	validate_tsrx_unsupported_loop_statement as validateTsrxUnsupportedLoopStatement,
 	validate_forgotten_statement_container as validateForgottenStatementContainer,
 	validate_nesting as validateNesting,

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -858,11 +858,13 @@ export function createJsxTransform(platform) {
 
 		// Apply lazy destructuring transforms to module-level code (top-level function
 		// declarations, arrow functions, etc.).
-		// In type-only mode, the lazy patterns survive untouched: esrap ignores the
+		// In type-only mode, ordinary lazy patterns survive untouched: esrap ignores the
 		// non-standard `lazy` flag, so `&{ a, b }` prints as `{ a, b }`, `let &[a]
 		// = expr` prints as `let [a] = expr`, and the bare statement-level form
-		// `&[x] = expr;` (used when `x` is already declared) prints as `[x] =
-		// expr;` — a valid destructuring assignment to the existing binding.
+		// `&[x] = expr;` standalone assignment is the exception: it must take the
+		// same declaration path as runtime output so transparent editor-only wrappers
+		// cannot turn it into an eager destructure. The assignment-only preallocation
+		// below leaves params and declarations on their existing type-only path.
 		//
 		// Re-run `preallocate_lazy_ids` first. The initial pre-walk pass stamps
 		// `metadata.has_lazy_descendants` (the fast-path gate that tells
@@ -874,12 +876,10 @@ export function createJsxTransform(platform) {
 		// stamps them too (it is idempotent: already-allocated `lazy_id`s are kept),
 		// so lazy bindings declared inside a nested block or directive body are
 		// rewritten just like a flat function body.
-		if (!transform_context.typeOnly) {
-			preallocate_lazy_ids(lowered_program, transform_context);
-		}
-		const final_program = transform_context.typeOnly
-			? lowered_program
-			: /** @type {AST.Program} */ (apply_lazy_transforms(lowered_program, new Map()));
+		preallocate_lazy_ids(lowered_program, transform_context, transform_context.typeOnly);
+		const final_program = /** @type {AST.Program} */ (
+			apply_lazy_transforms(lowered_program, new Map())
+		);
 
 		const result = print(
 			final_program,

--- a/packages/tsrx/src/transform/lazy.js
+++ b/packages/tsrx/src/transform/lazy.js
@@ -4,6 +4,7 @@
 
 import * as b from '../utils/builders.js';
 import {
+	child_nodes,
 	has_location,
 	is_ast_node,
 	is_function_or_component_node,
@@ -426,6 +427,11 @@ function replace_lazy_in_pattern(pattern, is_top = true) {
  * @param {LazyContext} context
  */
 export function preallocate_lazy_ids(root, context) {
+	const HAS_LAZY = 1;
+	const HAS_VAR_LOOP = 2;
+	/** @type {AST.Node[]} */
+	const path = [];
+
 	/** @param {AST.Node | null | undefined} pattern */
 	const assign_id = (pattern) => {
 		visit_topmost_lazy_patterns(pattern, (lazy) => {
@@ -434,21 +440,29 @@ export function preallocate_lazy_ids(root, context) {
 		});
 	};
 
+	/** @param {AST.Node | null | undefined} pattern */
+	const has_preallocated_lazy_binding = (pattern) => {
+		let found = false;
+		visit_topmost_lazy_patterns(pattern, (lazy) => {
+			if (lazy.metadata?.lazy_id) found = true;
+		});
+		return found;
+	};
+
 	/**
 	 * @param {unknown} value
-	 * @param {AST.Node[]} path
-	 * @returns {boolean} true if `value`'s subtree contains any lazy pattern.
+	 * @returns {number} bit flags for lazy syntax and current-scope lazy var loops.
 	 */
-	const visit = (value, path) => {
-		if (!value || typeof value !== 'object') return false;
+	const visit = (value) => {
+		if (!value || typeof value !== 'object') return 0;
 		if (Array.isArray(value)) {
-			let found = false;
+			let flags = 0;
 			for (const child of value) {
-				if (visit(child, path)) found = true;
+				flags |= visit(child);
 			}
-			return found;
+			return flags;
 		}
-		if (!is_ast_node(value)) return false;
+		if (!is_ast_node(value)) return 0;
 
 		const node = value;
 		const is_function_like = is_function_or_component_node(node);
@@ -474,24 +488,54 @@ export function preallocate_lazy_ids(root, context) {
 			assign_id(node.left);
 		}
 
-		let found =
-			(node.type === 'ObjectPattern' || node.type === 'ArrayPattern') && node.lazy === true;
+		let flags =
+			(node.type === 'ObjectPattern' || node.type === 'ArrayPattern') && node.lazy === true
+				? HAS_LAZY
+				: 0;
 
 		const entries = /** @type {AST.TraversableAstNode} */ (node);
-		const child_path = [...path, node];
+		path.push(node);
 		for (const key of Object.keys(entries)) {
 			if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') continue;
-			if (visit(entries[key], child_path)) found = true;
+			flags |= visit(entries[key]);
+		}
+		path.pop();
+
+		const loop_declaration =
+			node.type === 'ForStatement'
+				? node.init
+				: node.type === 'ForOfStatement' || node.type === 'ForInStatement'
+					? node.left
+					: null;
+		if (
+			loop_declaration?.type === 'VariableDeclaration' &&
+			loop_declaration.kind === 'var' &&
+			loop_declaration.declarations.some((declarator) =>
+				has_preallocated_lazy_binding(declarator.id),
+			)
+		) {
+			flags |= HAS_VAR_LOOP;
 		}
 
-		if (is_function_like && found) {
-			node.metadata = { ...node.metadata, has_lazy_descendants: true };
+		if (is_function_like) {
+			if (flags & HAS_LAZY) {
+				node.metadata = { ...node.metadata, has_lazy_descendants: true };
+			}
+			if (flags & HAS_VAR_LOOP) {
+				node.metadata = { ...node.metadata, has_lazy_var_loop_descendants: true };
+			}
+			// A nested function owns its own var environment. Its caller still
+			// needs the general lazy-descendant signal so traversal reaches it,
+			// but must not scan for the nested function's loop bindings.
+			flags &= ~HAS_VAR_LOOP;
+		} else if (node.type === 'Program' && flags & HAS_VAR_LOOP) {
+			node.metadata = { ...node.metadata, has_lazy_var_loop_descendants: true };
 		}
 
-		return found;
+		return flags;
 	};
 
-	visit(root, []);
+	visit(root);
 }
 
 /**
@@ -608,18 +652,10 @@ function collect_preallocated_lazy_bindings(pattern, lazy_bindings) {
  * as the source binding, including when the loop is nested in ordinary control
  * flow. Nested functions own a different var environment and are not visited.
  *
- * @param {unknown} value
+ * @param {AST.Node} node
  * @param {Map<string, LazyBinding>} lazy_bindings
  */
-function collect_function_var_loop_bindings(value, lazy_bindings) {
-	if (!value || typeof value !== 'object') return;
-	if (Array.isArray(value)) {
-		for (const child of value) collect_function_var_loop_bindings(child, lazy_bindings);
-		return;
-	}
-	if (!is_ast_node(value)) return;
-
-	const node = value;
+function collect_function_var_loop_bindings(node, lazy_bindings) {
 	if (is_function_or_component_node(node)) return;
 
 	if (
@@ -640,10 +676,8 @@ function collect_function_var_loop_bindings(value, lazy_bindings) {
 		}
 	}
 
-	const entries = /** @type {AST.TraversableAstNode} */ (node);
-	for (const key of Object.keys(entries)) {
-		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') continue;
-		collect_function_var_loop_bindings(entries[key], lazy_bindings);
+	for (const child of child_nodes(node)) {
+		collect_function_var_loop_bindings(child, lazy_bindings);
 	}
 }
 
@@ -659,6 +693,8 @@ function collect_function_var_loop_bindings(value, lazy_bindings) {
  */
 function transform_classic_for_declaration(declaration, lazy_bindings) {
 	let effective_bindings = lazy_bindings;
+	/** @type {Map<string, LazyBinding> | null} */
+	let mutable_bindings = null;
 	let changed = false;
 	const declarations = declaration.declarations.map((declarator) => {
 		const new_init =
@@ -670,7 +706,9 @@ function transform_classic_for_declaration(declaration, lazy_bindings) {
 		const own_bindings = new Map();
 		collect_preallocated_lazy_bindings(declarator.id, own_bindings);
 		if (own_bindings.size > 0) {
-			effective_bindings = new Map([...effective_bindings, ...own_bindings]);
+			mutable_bindings ??= new Map(effective_bindings);
+			for (const [name, binding] of own_bindings) mutable_bindings.set(name, binding);
+			effective_bindings = mutable_bindings;
 		}
 
 		return new_init !== declarator.init || new_id !== declarator.id
@@ -771,7 +809,7 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 				: outer_minus_shadow;
 		/** @type {Map<string, LazyBinding>} */
 		const function_var_bindings = new Map();
-		if (node.metadata?.has_lazy_descendants) {
+		if (node.metadata?.has_lazy_var_loop_descendants) {
 			collect_function_var_loop_bindings(node.body, function_var_bindings);
 		}
 		const function_bindings =
@@ -806,9 +844,18 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 	if (node.type === 'BlockStatement' || node.type === 'Program') {
 		/** @type {AST.Program['body']} */
 		const body = node.body;
-		const block_bindings = collect_block_shadowed_names(body, lazy_bindings);
+		/** @type {Map<string, LazyBinding>} */
+		const program_var_bindings = new Map();
+		if (node.type === 'Program' && node.metadata?.has_lazy_var_loop_descendants) {
+			collect_function_var_loop_bindings(node, program_var_bindings);
+		}
+		const scope_bindings =
+			program_var_bindings.size > 0
+				? new Map([...lazy_bindings, ...program_var_bindings])
+				: lazy_bindings;
+		const block_bindings = collect_block_shadowed_names(body, scope_bindings);
 		const after_shadow =
-			block_bindings.size > 0 ? remove_shadowed(lazy_bindings, block_bindings) : lazy_bindings;
+			block_bindings.size > 0 ? remove_shadowed(scope_bindings, block_bindings) : scope_bindings;
 
 		/** @type {Map<string, LazyBinding>} */
 		const block_lazy = new Map();

--- a/packages/tsrx/src/transform/lazy.js
+++ b/packages/tsrx/src/transform/lazy.js
@@ -3,7 +3,12 @@
 /** @import { BaseNodeMetaData, LazyBinding, LazyContext, LazyPattern, MaybeLocated } from '../../types/index' */
 
 import * as b from '../utils/builders.js';
-import { has_location, is_ast_node, is_function_or_component_node } from '../utils/ast.js';
+import {
+	has_location,
+	is_ast_node,
+	is_function_or_component_node,
+	is_supported_lazy_assignment_position,
+} from '../utils/ast.js';
 
 /**
  * Lazy destructuring transform — framework-agnostic.
@@ -408,7 +413,7 @@ function replace_lazy_in_pattern(pattern, is_top = true) {
 
 /**
  * Walk the AST and pre-allocate `lazy_id` metadata on every lazy destructuring
- * pattern: function params, variable declarator ids, and statement-level
+ * pattern: function params, variable declarator ids, and supported standalone
  * assignment LHS. Walks into non-lazy outer patterns to
  * find nested lazy ones, e.g. `{ pair: &[a, b] }` allocates an id for the inner
  * `&[a, b]`. Idempotent: skips patterns that already have a `lazy_id`.
@@ -431,14 +436,15 @@ export function preallocate_lazy_ids(root, context) {
 
 	/**
 	 * @param {unknown} value
+	 * @param {AST.Node[]} path
 	 * @returns {boolean} true if `value`'s subtree contains any lazy pattern.
 	 */
-	const visit = (value) => {
+	const visit = (value, path) => {
 		if (!value || typeof value !== 'object') return false;
 		if (Array.isArray(value)) {
 			let found = false;
 			for (const child of value) {
-				if (visit(child)) found = true;
+				if (visit(child, path)) found = true;
 			}
 			return found;
 		}
@@ -457,21 +463,18 @@ export function preallocate_lazy_ids(root, context) {
 			assign_id(node.id);
 		}
 
-		if (
-			node.type === 'ExpressionStatement' &&
-			node.expression.type === 'AssignmentExpression' &&
-			node.expression.operator === '='
-		) {
-			assign_id(node.expression.left);
+		if (node.type === 'AssignmentExpression' && is_supported_lazy_assignment_position(node, path)) {
+			assign_id(node.left);
 		}
 
 		let found =
 			(node.type === 'ObjectPattern' || node.type === 'ArrayPattern') && node.lazy === true;
 
 		const entries = /** @type {AST.TraversableAstNode} */ (node);
+		const child_path = [...path, node];
 		for (const key of Object.keys(entries)) {
 			if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') continue;
-			if (visit(entries[key])) found = true;
+			if (visit(entries[key], child_path)) found = true;
 		}
 
 		if (is_function_like && found) {
@@ -481,7 +484,7 @@ export function preallocate_lazy_ids(root, context) {
 		return found;
 	};
 
-	visit(root);
+	visit(root, []);
 }
 
 /**
@@ -826,6 +829,24 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 				},
 			};
 		}
+	}
+
+	// Diagnosed lazy assignments remain ordinary destructuring assignments in
+	// best-effort output. Wrapping the recovery expression is valid in every
+	// expression slot, including braceless statement bodies and nested
+	// assignments where an object-pattern target would otherwise be ambiguous.
+	// Supported standalone assignments have a preallocated ID and are handled
+	// by the declaration branch above before traversal reaches this node.
+	if (
+		node.type === 'AssignmentExpression' &&
+		node.operator === '=' &&
+		(node.left.type === 'ObjectPattern' || node.left.type === 'ArrayPattern') &&
+		node.left.lazy &&
+		!node.left.metadata?.lazy_id
+	) {
+		const new_right = apply_lazy_transforms_to_slot(node.right, lazy_bindings);
+		const recovered = new_right === node.right ? node : { ...node, right: new_right };
+		return b.parenthesized(recovered, has_location(node) ? node : undefined);
 	}
 
 	// AssignmentExpression / UpdateExpression whose target is a lazy identifier.

--- a/packages/tsrx/src/transform/lazy.js
+++ b/packages/tsrx/src/transform/lazy.js
@@ -9,6 +9,7 @@ import {
 	is_ast_node,
 	is_function_or_component_node,
 	is_supported_lazy_assignment_position,
+	is_transparent_expression_wrapper,
 } from '../utils/ast.js';
 
 /**
@@ -268,17 +269,36 @@ export function collect_lazy_bindings_from_statements(statements, lazy_bindings)
 					collect_lazy_bindings(lazy, lazy.metadata.lazy_id, lazy_bindings);
 				});
 			}
-		} else if (
-			stmt.type === 'ExpressionStatement' &&
-			stmt.expression?.type === 'AssignmentExpression' &&
-			stmt.expression.operator === '='
-		) {
-			visit_topmost_lazy_patterns(stmt.expression.left, (lazy) => {
+		} else if (stmt.type === 'ExpressionStatement') {
+			const assignment = get_standalone_assignment(stmt);
+			if (!assignment || assignment.operator !== '=') continue;
+			visit_topmost_lazy_patterns(assignment.left, (lazy) => {
 				if (!lazy.metadata?.lazy_id) return;
 				collect_lazy_bindings(lazy, lazy.metadata.lazy_id, lazy_bindings);
 			});
 		}
 	}
+}
+
+/**
+ * Unwrap the expression-only wrappers accepted by the lazy-assignment
+ * eligibility check and return the standalone assignment they contain.
+ * Keeping collection and lowering on the same wrapper definition prevents
+ * editor ASTs (`preserveParens`) from silently taking the eager path.
+ *
+ * @param {AST.ExpressionStatement} statement
+ * @returns {AST.AssignmentExpression | null}
+ */
+function get_standalone_assignment(statement) {
+	/** @type {AST.Node} */
+	let expression = statement.expression;
+	while (expression.type !== 'AssignmentExpression') {
+		/** @type {AST.Node | undefined} */
+		const child = /** @type {{ expression?: AST.Node }} */ (expression).expression;
+		if (!child || !is_transparent_expression_wrapper(expression, child)) return null;
+		expression = child;
+	}
+	return expression;
 }
 
 /**
@@ -425,8 +445,9 @@ function replace_lazy_in_pattern(pattern, is_top = true) {
  *
  * @param {AST.Node} root
  * @param {LazyContext} context
+ * @param {boolean} [assignments_only]
  */
-export function preallocate_lazy_ids(root, context) {
+export function preallocate_lazy_ids(root, context, assignments_only = false) {
 	const HAS_LAZY = 1;
 	const HAS_VAR_LOOP = 2;
 	/** @type {AST.Node[]} */
@@ -467,17 +488,18 @@ export function preallocate_lazy_ids(root, context) {
 		const node = value;
 		const is_function_like = is_function_or_component_node(node);
 
-		if (is_function_like) {
+		if (is_function_like && !assignments_only) {
 			for (const param of node.params) {
 				assign_id(param.type === 'AssignmentPattern' ? param.left : param);
 			}
 		}
 
-		if (node.type === 'VariableDeclarator') {
+		if (node.type === 'VariableDeclarator' && !assignments_only) {
 			assign_id(node.id);
 		}
 
 		if (
+			!assignments_only &&
 			(node.type === 'ForOfStatement' || node.type === 'ForInStatement') &&
 			node.left.type !== 'VariableDeclaration'
 		) {
@@ -527,6 +549,13 @@ export function preallocate_lazy_ids(root, context) {
 			// A nested function owns its own var environment. Its caller still
 			// needs the general lazy-descendant signal so traversal reaches it,
 			// but must not scan for the nested function's loop bindings.
+			flags &= ~HAS_VAR_LOOP;
+		} else if (node.type === 'StaticBlock') {
+			if (flags & HAS_VAR_LOOP) {
+				node.metadata = { ...node.metadata, has_lazy_var_loop_descendants: true };
+			}
+			// Class static blocks own a distinct var environment. Their loop
+			// bindings must not be collected by the surrounding function/module.
 			flags &= ~HAS_VAR_LOOP;
 		} else if (node.type === 'Program' && flags & HAS_VAR_LOOP) {
 			node.metadata = { ...node.metadata, has_lazy_var_loop_descendants: true };
@@ -656,7 +685,7 @@ function collect_preallocated_lazy_bindings(pattern, lazy_bindings) {
  * @param {Map<string, LazyBinding>} lazy_bindings
  */
 function collect_function_var_loop_bindings(node, lazy_bindings) {
-	if (is_function_or_component_node(node)) return;
+	if (is_function_or_component_node(node) || node.type === 'StaticBlock') return;
 
 	if (
 		node.type === 'ForStatement' &&
@@ -841,17 +870,23 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 		return node;
 	}
 
-	if (node.type === 'BlockStatement' || node.type === 'Program') {
+	if (node.type === 'BlockStatement' || node.type === 'Program' || node.type === 'StaticBlock') {
 		/** @type {AST.Program['body']} */
 		const body = node.body;
 		/** @type {Map<string, LazyBinding>} */
-		const program_var_bindings = new Map();
-		if (node.type === 'Program' && node.metadata?.has_lazy_var_loop_descendants) {
-			collect_function_var_loop_bindings(node, program_var_bindings);
+		const var_scope_bindings = new Map();
+		if (node.metadata?.has_lazy_var_loop_descendants) {
+			if (node.type === 'Program') {
+				collect_function_var_loop_bindings(node, var_scope_bindings);
+			} else if (node.type === 'StaticBlock') {
+				for (const statement of node.body) {
+					collect_function_var_loop_bindings(statement, var_scope_bindings);
+				}
+			}
 		}
 		const scope_bindings =
-			program_var_bindings.size > 0
-				? new Map([...lazy_bindings, ...program_var_bindings])
+			var_scope_bindings.size > 0
+				? new Map([...lazy_bindings, ...var_scope_bindings])
 				: lazy_bindings;
 		const block_bindings = collect_block_shadowed_names(body, scope_bindings);
 		const after_shadow =
@@ -889,7 +924,7 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 		const shadowed = new Set();
 		if (node.init?.type === 'VariableDeclaration') {
 			for (const decl of node.init.declarations) {
-				if (decl.id) collect_shadowed_names(decl.id, lazy_bindings, shadowed);
+				if (decl.id) collect_non_lazy_shadowed_names(decl.id, lazy_bindings, shadowed);
 			}
 		}
 		let effective_bindings =
@@ -923,6 +958,8 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 			for (const decl of node.left.declarations) {
 				if (decl.id) collect_shadowed_names(decl.id, lazy_bindings, shadowed);
 			}
+		} else {
+			collect_shadowed_names(node.left, lazy_bindings, shadowed);
 		}
 		const after_shadow =
 			shadowed.size > 0 ? remove_shadowed(lazy_bindings, shadowed) : lazy_bindings;
@@ -992,21 +1029,21 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 	// Standalone lazy destructuring assignment: `&[data] = track(0);` becomes
 	// `const __lazy0 = track(0);`. Individual name bindings are already in scope
 	// via the enclosing BlockStatement handler.
-	if (
-		node.type === 'ExpressionStatement' &&
-		node.expression.type === 'AssignmentExpression' &&
-		node.expression.operator === '=' &&
-		(node.expression.left.type === 'ObjectPattern' ||
-			node.expression.left.type === 'ArrayPattern') &&
-		node.expression.left.lazy
-	) {
-		const pattern = node.expression.left;
-		const lazy_id_name = pattern.metadata?.lazy_id;
-		if (lazy_id_name !== undefined) {
-			const lazy_id = create_generated_identifier(lazy_id_name);
-			if (pattern.typeAnnotation) lazy_id.typeAnnotation = pattern.typeAnnotation;
-			const init = apply_lazy_transforms_to_slot(node.expression.right, lazy_bindings);
-			return b.const(lazy_id, init);
+	if (node.type === 'ExpressionStatement') {
+		const assignment = get_standalone_assignment(node);
+		const pattern = assignment?.left;
+		if (
+			assignment?.operator === '=' &&
+			(pattern?.type === 'ObjectPattern' || pattern?.type === 'ArrayPattern') &&
+			pattern.lazy
+		) {
+			const lazy_id_name = pattern.metadata?.lazy_id;
+			if (lazy_id_name !== undefined) {
+				const lazy_id = build_lazy_id_for_pattern(pattern, lazy_id_name, false);
+				if (pattern.typeAnnotation) lazy_id.typeAnnotation = pattern.typeAnnotation;
+				const init = apply_lazy_transforms_to_slot(assignment.right, lazy_bindings);
+				return b.const(lazy_id, init);
+			}
 		}
 	}
 
@@ -1208,6 +1245,49 @@ function collect_shadowed_names(pattern, lazy_bindings, shadowed) {
 	if (pattern.type === 'ArrayPattern') {
 		for (const element of pattern.elements) {
 			if (element) collect_shadowed_names(element, lazy_bindings, shadowed);
+		}
+	}
+}
+
+/**
+ * Collect only ordinary bindings from a declaration pattern. Lazy bindings
+ * remain mapped while their own initializer runs and are installed afterward
+ * by `transform_classic_for_declaration` in declarator source order.
+ *
+ * @param {AST.Node | null | undefined} pattern
+ * @param {Map<string, LazyBinding>} lazy_bindings
+ * @param {Set<string>} shadowed
+ */
+function collect_non_lazy_shadowed_names(pattern, lazy_bindings, shadowed) {
+	if (!pattern || typeof pattern !== 'object') return;
+	if ((pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') && pattern.lazy) {
+		return;
+	}
+	if (pattern.type === 'Identifier' && lazy_bindings.has(pattern.name)) {
+		shadowed.add(pattern.name);
+		return;
+	}
+	if (pattern.type === 'AssignmentPattern') {
+		collect_non_lazy_shadowed_names(pattern.left, lazy_bindings, shadowed);
+		return;
+	}
+	if (pattern.type === 'RestElement') {
+		collect_non_lazy_shadowed_names(pattern.argument, lazy_bindings, shadowed);
+		return;
+	}
+	if (pattern.type === 'ObjectPattern') {
+		for (const prop of pattern.properties) {
+			collect_non_lazy_shadowed_names(
+				prop.type === 'RestElement' ? prop.argument : prop.value,
+				lazy_bindings,
+				shadowed,
+			);
+		}
+		return;
+	}
+	if (pattern.type === 'ArrayPattern') {
+		for (const element of pattern.elements) {
+			if (element) collect_non_lazy_shadowed_names(element, lazy_bindings, shadowed);
 		}
 	}
 }

--- a/packages/tsrx/src/transform/lazy.js
+++ b/packages/tsrx/src/transform/lazy.js
@@ -463,6 +463,13 @@ export function preallocate_lazy_ids(root, context) {
 			assign_id(node.id);
 		}
 
+		if (
+			(node.type === 'ForOfStatement' || node.type === 'ForInStatement') &&
+			node.left.type !== 'VariableDeclaration'
+		) {
+			assign_id(node.left);
+		}
+
 		if (node.type === 'AssignmentExpression' && is_supported_lazy_assignment_position(node, path)) {
 			assign_id(node.left);
 		}
@@ -583,6 +590,138 @@ function apply_lazy_transforms_to_slot(node, lazy_bindings) {
 }
 
 /**
+ * Add every preallocated lazy binding below a binding pattern to `lazy_bindings`.
+ *
+ * @param {AST.Node | null | undefined} pattern
+ * @param {Map<string, LazyBinding>} lazy_bindings
+ */
+function collect_preallocated_lazy_bindings(pattern, lazy_bindings) {
+	visit_topmost_lazy_patterns(pattern, (lazy) => {
+		if (!lazy.metadata?.lazy_id) return;
+		collect_lazy_bindings(lazy, lazy.metadata.lazy_id, lazy_bindings);
+	});
+}
+
+/**
+ * Collect lazy `var` bindings introduced by JavaScript loop headers in the
+ * current function. A generated `var __lazyN` has the same function lifetime
+ * as the source binding, including when the loop is nested in ordinary control
+ * flow. Nested functions own a different var environment and are not visited.
+ *
+ * @param {unknown} value
+ * @param {Map<string, LazyBinding>} lazy_bindings
+ */
+function collect_function_var_loop_bindings(value, lazy_bindings) {
+	if (!value || typeof value !== 'object') return;
+	if (Array.isArray(value)) {
+		for (const child of value) collect_function_var_loop_bindings(child, lazy_bindings);
+		return;
+	}
+	if (!is_ast_node(value)) return;
+
+	const node = value;
+	if (is_function_or_component_node(node)) return;
+
+	if (
+		node.type === 'ForStatement' &&
+		node.init?.type === 'VariableDeclaration' &&
+		node.init.kind === 'var'
+	) {
+		for (const declarator of node.init.declarations) {
+			collect_preallocated_lazy_bindings(declarator.id, lazy_bindings);
+		}
+	} else if (
+		(node.type === 'ForOfStatement' || node.type === 'ForInStatement') &&
+		node.left.type === 'VariableDeclaration' &&
+		node.left.kind === 'var'
+	) {
+		for (const declarator of node.left.declarations) {
+			collect_preallocated_lazy_bindings(declarator.id, lazy_bindings);
+		}
+	}
+
+	const entries = /** @type {AST.TraversableAstNode} */ (node);
+	for (const key of Object.keys(entries)) {
+		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') continue;
+		collect_function_var_loop_bindings(entries[key], lazy_bindings);
+	}
+}
+
+/**
+ * Rewrite a classic-for declaration in source order. Later initializers can
+ * read lazy names introduced by earlier declarators, while the initializer of
+ * each declarator is evaluated before that declarator's own lazy bindings are
+ * installed.
+ *
+ * @param {AST.VariableDeclaration} declaration
+ * @param {Map<string, LazyBinding>} lazy_bindings
+ * @returns {{ declaration: AST.VariableDeclaration, lazy_bindings: Map<string, LazyBinding> }}
+ */
+function transform_classic_for_declaration(declaration, lazy_bindings) {
+	let effective_bindings = lazy_bindings;
+	let changed = false;
+	const declarations = declaration.declarations.map((declarator) => {
+		const new_init =
+			declarator.init && apply_lazy_transforms_to_slot(declarator.init, effective_bindings);
+		const new_id = replace_lazy_in_pattern(declarator.id);
+		if (new_init !== declarator.init || new_id !== declarator.id) changed = true;
+
+		/** @type {Map<string, LazyBinding>} */
+		const own_bindings = new Map();
+		collect_preallocated_lazy_bindings(declarator.id, own_bindings);
+		if (own_bindings.size > 0) {
+			effective_bindings = new Map([...effective_bindings, ...own_bindings]);
+		}
+
+		return new_init !== declarator.init || new_id !== declarator.id
+			? rebuild(declarator, { id: new_id, init: new_init })
+			: declarator;
+	});
+
+	return {
+		declaration: changed ? rebuild(declaration, { declarations }) : declaration,
+		lazy_bindings: effective_bindings,
+	};
+}
+
+/**
+ * Rewrite a for-of/in binding target and return the lazy bindings visible in
+ * the loop body. Bare targets become per-iteration `const` declarations so all
+ * generated source identifiers have an owning declaration.
+ *
+ * @param {AST.ForOfStatement['left'] | AST.ForInStatement['left']} left
+ * @returns {{ left: AST.VariableDeclaration, lazy_bindings: Map<string, LazyBinding> } | { left: AST.ForOfStatement['left'] | AST.ForInStatement['left'], lazy_bindings: Map<string, LazyBinding> }}
+ */
+function transform_for_each_left(left) {
+	/** @type {Map<string, LazyBinding>} */
+	const own_bindings = new Map();
+
+	if (left.type === 'VariableDeclaration') {
+		let changed = false;
+		const declarations = left.declarations.map((declarator) => {
+			collect_preallocated_lazy_bindings(declarator.id, own_bindings);
+			const new_id = replace_lazy_in_pattern(declarator.id);
+			if (new_id === declarator.id) return declarator;
+			changed = true;
+			return rebuild(declarator, { id: new_id });
+		});
+		return {
+			left: changed ? rebuild(left, { declarations }) : left,
+			lazy_bindings: own_bindings,
+		};
+	}
+
+	collect_preallocated_lazy_bindings(left, own_bindings);
+	if (own_bindings.size === 0) return { left, lazy_bindings: own_bindings };
+
+	const new_id = replace_lazy_in_pattern(left);
+	return {
+		left: b.declaration('const', [b.declarator(new_id)]),
+		lazy_bindings: own_bindings,
+	};
+}
+
+/**
  * Recursively rewrite lazy-binding references in `node`.
  *
  * @param {AST.Node} node
@@ -630,9 +769,18 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 			own_bindings.size > 0
 				? new Map([...outer_minus_shadow, ...own_bindings])
 				: outer_minus_shadow;
+		/** @type {Map<string, LazyBinding>} */
+		const function_var_bindings = new Map();
+		if (node.metadata?.has_lazy_descendants) {
+			collect_function_var_loop_bindings(node.body, function_var_bindings);
+		}
+		const function_bindings =
+			function_var_bindings.size > 0
+				? new Map([...inner_bindings, ...function_var_bindings])
+				: inner_bindings;
 
 		if (
-			inner_bindings.size === 0 &&
+			function_bindings.size === 0 &&
 			!params_changed &&
 			!had_lazy_param &&
 			!node.metadata?.has_lazy_descendants
@@ -644,7 +792,7 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 		// params to replace, defaults referencing outer lazy, or the body
 		// contains lazy descendants the BlockStatement handler will collect.
 		// In every case the body needs to be walked.
-		const new_body = apply_lazy_transforms_to_slot(node.body, inner_bindings);
+		const new_body = apply_lazy_transforms_to_slot(node.body, function_bindings);
 
 		const final_params_src = params_changed ? new_params : node.params;
 		const final_params = had_lazy_param ? replace_lazy_params(final_params_src) : final_params_src;
@@ -697,10 +845,17 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 				if (decl.id) collect_shadowed_names(decl.id, lazy_bindings, shadowed);
 			}
 		}
-		const effective_bindings =
+		let effective_bindings =
 			shadowed.size > 0 ? remove_shadowed(lazy_bindings, shadowed) : lazy_bindings;
 		let changed = false;
-		const new_init = node.init && apply_lazy_transforms_to_slot(node.init, effective_bindings);
+		let new_init = node.init;
+		if (node.init?.type === 'VariableDeclaration') {
+			const transformed = transform_classic_for_declaration(node.init, effective_bindings);
+			new_init = transformed.declaration;
+			effective_bindings = transformed.lazy_bindings;
+		} else if (node.init) {
+			new_init = apply_lazy_transforms_to_slot(node.init, effective_bindings);
+		}
 		if (new_init !== node.init) changed = true;
 		const new_test = node.test && apply_lazy_transforms_to_slot(node.test, effective_bindings);
 		if (new_test !== node.test) changed = true;
@@ -722,23 +877,24 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 				if (decl.id) collect_shadowed_names(decl.id, lazy_bindings, shadowed);
 			}
 		}
-		const effective_bindings =
+		const after_shadow =
 			shadowed.size > 0 ? remove_shadowed(lazy_bindings, shadowed) : lazy_bindings;
-		// `node.left` is a binding site, not an expression context: a declaration
-		// like `const x` or `const [a, b]` has no outer references to rewrite,
-		// and recursing here would hit the VariableDeclarator handler and
-		// rewrite a lazy declarator id that `preallocate_lazy_ids` already
-		// tagged — double-processing the loop variable. Leave `node.left`
-		// untouched; the body and right-hand side are the only scopes with
-		// live references.
+		const transformed_left = transform_for_each_left(node.left);
+		const effective_bindings =
+			transformed_left.lazy_bindings.size > 0
+				? new Map([...after_shadow, ...transformed_left.lazy_bindings])
+				: after_shadow;
 		let changed = false;
+		if (transformed_left.left !== node.left) changed = true;
 		// The right-hand side is evaluated in the outer scope (before the loop
 		// variable is bound), so use the unshadowed bindings there.
 		const new_right = apply_lazy_transforms_to_slot(node.right, lazy_bindings);
 		if (new_right !== node.right) changed = true;
 		const new_body = apply_lazy_transforms_to_slot(node.body, effective_bindings);
 		if (new_body !== node.body) changed = true;
-		return changed ? rebuild(node, { right: new_right, body: new_body }) : node;
+		return changed
+			? rebuild(node, { left: transformed_left.left, right: new_right, body: new_body })
+			: node;
 	}
 
 	if (node.type === 'SwitchStatement') {

--- a/packages/tsrx/src/utils/ast.js
+++ b/packages/tsrx/src/utils/ast.js
@@ -209,6 +209,58 @@ export function is_statement_list_item(parent, child) {
 }
 
 /**
+ * Whether a lazy destructuring assignment can be lowered from an expression
+ * statement into a declaration without changing the syntactic category of its
+ * parent slot. Transparent expression wrappers are allowed, but the assignment
+ * must otherwise be the whole statement and that statement must be a direct
+ * item in a statement list.
+ *
+ * This is the shared semantic boundary for both target-neutral diagnostics and
+ * lazy-ID allocation. Keeping those callers on one predicate ensures collect
+ * mode never allocates an ID for a shape that analysis has diagnosed.
+ *
+ * @param {AST.AssignmentExpression} node
+ * @param {AST.Node[]} path
+ * @returns {boolean}
+ */
+export function is_supported_lazy_assignment_position(node, path) {
+	if (
+		node.operator !== '=' ||
+		(node.left.type !== 'ObjectPattern' && node.left.type !== 'ArrayPattern') ||
+		!node.left.lazy
+	) {
+		return false;
+	}
+
+	/** @type {AST.Node} */
+	let child = node;
+
+	for (let i = path.length - 1; i >= 0; i -= 1) {
+		const parent = path[i];
+		if (
+			(parent.type === 'ParenthesizedExpression' ||
+				parent.type === 'TSAsExpression' ||
+				parent.type === 'TSSatisfiesExpression' ||
+				parent.type === 'TSNonNullExpression' ||
+				parent.type === 'TSInstantiationExpression' ||
+				parent.type === 'TSTypeAssertion' ||
+				parent.type === 'ChainExpression') &&
+			/** @type {{ expression?: AST.Node }} */ (parent).expression === child
+		) {
+			child = parent;
+			continue;
+		}
+
+		if (parent.type !== 'ExpressionStatement' || parent.expression !== child) return false;
+
+		const container = path[i - 1];
+		return !!container && is_statement_list_item(container, parent);
+	}
+
+	return false;
+}
+
+/**
  * Returns the closest native TSRX function in an ancestry path. By default,
  * function and class boundaries stop the search so callers only match direct
  * native TSRX function body/control-flow nodes.

--- a/packages/tsrx/src/utils/ast.js
+++ b/packages/tsrx/src/utils/ast.js
@@ -209,6 +209,28 @@ export function is_statement_list_item(parent, child) {
 }
 
 /**
+ * Whether `parent` preserves `child` as the same expression value. Looking
+ * through these wrappers keeps strict and editor-oriented ASTs on the same
+ * semantic path.
+ *
+ * @param {AST.Node} parent
+ * @param {AST.Node} child
+ * @returns {boolean}
+ */
+export function is_transparent_expression_wrapper(parent, child) {
+	return (
+		(parent.type === 'ParenthesizedExpression' ||
+			parent.type === 'TSAsExpression' ||
+			parent.type === 'TSSatisfiesExpression' ||
+			parent.type === 'TSNonNullExpression' ||
+			parent.type === 'TSInstantiationExpression' ||
+			parent.type === 'TSTypeAssertion' ||
+			parent.type === 'ChainExpression') &&
+		/** @type {{ expression?: AST.Node }} */ (parent).expression === child
+	);
+}
+
+/**
  * Whether a lazy destructuring assignment can be lowered from an expression
  * statement into a declaration without changing the syntactic category of its
  * parent slot. Transparent expression wrappers are allowed, but the assignment
@@ -237,16 +259,7 @@ export function is_supported_lazy_assignment_position(node, path) {
 
 	for (let i = path.length - 1; i >= 0; i -= 1) {
 		const parent = path[i];
-		if (
-			(parent.type === 'ParenthesizedExpression' ||
-				parent.type === 'TSAsExpression' ||
-				parent.type === 'TSSatisfiesExpression' ||
-				parent.type === 'TSNonNullExpression' ||
-				parent.type === 'TSInstantiationExpression' ||
-				parent.type === 'TSTypeAssertion' ||
-				parent.type === 'ChainExpression') &&
-			/** @type {{ expression?: AST.Node }} */ (parent).expression === child
-		) {
+		if (is_transparent_expression_wrapper(parent, child)) {
 			child = parent;
 			continue;
 		}

--- a/packages/tsrx/src/utils/ast.js
+++ b/packages/tsrx/src/utils/ast.js
@@ -167,14 +167,9 @@ export function is_code_block_function_body(node, parent) {
  * @returns {boolean}
  */
 export function is_statement_position(parent, child) {
+	if (is_statement_list_item(parent, child)) return true;
+
 	switch (parent.type) {
-		case 'Program':
-		case 'BlockStatement':
-			return parent.body.includes(/** @type {AST.Statement} */ (child));
-		case 'SwitchCase':
-			return parent.consequent.includes(/** @type {AST.Statement} */ (child));
-		case 'JSXCodeBlock':
-			return parent.body.includes(/** @type {AST.Statement} */ (child));
 		case 'IfStatement':
 			return parent.consequent === child || parent.alternate === child;
 		case 'ForStatement':
@@ -185,6 +180,29 @@ export function is_statement_position(parent, child) {
 		case 'LabeledStatement':
 		case 'WithStatement':
 			return parent.body === child;
+		default:
+			return false;
+	}
+}
+
+/**
+ * Returns whether `child` is a direct item in a statement list. Unlike
+ * {@link is_statement_position}, this deliberately excludes single-statement
+ * control-flow bodies: transforms may replace a list item with declarations,
+ * but a declaration is not valid in those braceless statement slots.
+ *
+ * @param {AST.Node} parent
+ * @param {AST.Node} child
+ * @returns {boolean}
+ */
+export function is_statement_list_item(parent, child) {
+	switch (parent.type) {
+		case 'Program':
+		case 'BlockStatement':
+		case 'JSXCodeBlock':
+			return parent.body.includes(/** @type {AST.Statement} */ (child));
+		case 'SwitchCase':
+			return parent.consequent.includes(/** @type {AST.Statement} */ (child));
 		default:
 			return false;
 	}

--- a/packages/tsrx/tests/analyze/analyze.test.js
+++ b/packages/tsrx/tests/analyze/analyze.test.js
@@ -250,9 +250,7 @@ describe('target-neutral TSRX analysis', () => {
 				const errors = unsupported_lazy_assignment_errors(analyze(source));
 
 				expect(errors, source).toHaveLength(1);
-				expect(errors[0].message, source).toBe(
-					TSRX_UNSUPPORTED_LAZY_ASSIGNMENT_POSITION_ERROR,
-				);
+				expect(errors[0].message, source).toBe(TSRX_UNSUPPORTED_LAZY_ASSIGNMENT_POSITION_ERROR);
 			}
 		});
 
@@ -267,9 +265,7 @@ describe('target-neutral TSRX analysis', () => {
 				const errors = unsupported_lazy_assignment_errors(analyze(source));
 
 				expect(errors, source).toHaveLength(1);
-				expect(errors[0].message, source).toBe(
-					TSRX_UNSUPPORTED_LAZY_ASSIGNMENT_POSITION_ERROR,
-				);
+				expect(errors[0].message, source).toBe(TSRX_UNSUPPORTED_LAZY_ASSIGNMENT_POSITION_ERROR);
 			}
 		});
 

--- a/packages/tsrx/tests/analyze/analyze.test.js
+++ b/packages/tsrx/tests/analyze/analyze.test.js
@@ -282,6 +282,21 @@ describe('target-neutral TSRX analysis', () => {
 			expect(source.slice(errors[0].pos, errors[0].end)).toBe(target);
 		});
 
+		it('leaves lazy assignments in evaluated target expressions to their own visitor', () => {
+			for (const [source, target] of [
+				['[x = (&{ value } = source)] = items;', '{ value }'],
+				['({ [(&{ x } = source).key]: value } = object);', '{ x }'],
+			]) {
+				const errors = unsupported_lazy_assignment_errors(analyze(source));
+				const start = source.indexOf(target);
+
+				expect(errors, source).toHaveLength(1);
+				expect(errors[0].pos, source).toBe(start);
+				expect(errors[0].end, source).toBe(start + target.length);
+				expect(source.slice(errors[0].pos, errors[0].end), source).toBe(target);
+			}
+		});
+
 		it('throws in strict analysis and collects in editor and type-only modes', () => {
 			const source = 'if (ready) &{ value } = source;';
 			const ast = parseModule(source, filename);

--- a/packages/tsrx/tests/analyze/analyze.test.js
+++ b/packages/tsrx/tests/analyze/analyze.test.js
@@ -3,7 +3,10 @@
 
 import { describe, expect, it } from 'vitest';
 import { analyzeTsrx, DIAGNOSTIC_CODES, parseModule } from '../../src/index.js';
-import { TSRX_FORGOTTEN_STATEMENT_CONTAINER_ERROR } from '../../src/analyze/validation.js';
+import {
+	TSRX_FORGOTTEN_STATEMENT_CONTAINER_ERROR,
+	TSRX_UNSUPPORTED_LAZY_ASSIGNMENT_POSITION_ERROR,
+} from '../../src/analyze/validation.js';
 
 const filename = 'App.tsrx';
 
@@ -35,6 +38,13 @@ function analyze(source, options = { collect: true }) {
 function forgotten_output_errors(result) {
 	return result.errors.filter(
 		(error) => error.code === DIAGNOSTIC_CODES.FORGOTTEN_STATEMENT_CONTAINER,
+	);
+}
+
+/** @param {ReturnType<typeof analyze>} result */
+function unsupported_lazy_assignment_errors(result) {
+	return result.errors.filter(
+		(error) => error.code === DIAGNOSTIC_CODES.UNSUPPORTED_LAZY_ASSIGNMENT_POSITION,
 	);
 }
 
@@ -200,6 +210,99 @@ describe('target-neutral TSRX analysis', () => {
 				const result = analyze('function Test() { <div /> }', options);
 
 				expect(forgotten_output_errors(result), JSON.stringify(options)).toHaveLength(1);
+			}
+		});
+	});
+
+	describe('lazy destructuring assignment positions', () => {
+		it('allows direct assignments in every supported statement list', () => {
+			const result = analyze(`&{ root } = source;
+				{ &{ block } = source; }
+				function View() @{ &{ code_block } = source; <div /> }
+				switch (kind) { case 1: &{ switch_case } = source; break; }`);
+
+			expect(unsupported_lazy_assignment_errors(result)).toEqual([]);
+		});
+
+		it('allows a parenthesized direct assignment in the preserve-parens editor path', () => {
+			const errors = /** @type {CompileError[]} */ ([]);
+			const comments = /** @type {AST.CommentWithLocation[]} */ ([]);
+			const ast = parseModule('(&{ value } = source);', filename, {
+				collect: true,
+				preserveParens: true,
+				errors,
+				comments,
+			});
+
+			const result = analyzeTsrx(ast, filename, { collect: true, errors, comments });
+
+			expect(unsupported_lazy_assignment_errors(result)).toEqual([]);
+		});
+
+		it('reports every braceless statement position exactly once', () => {
+			for (const source of [
+				'if (ready) &{ value } = source;',
+				'if (ready) {} else &{ value } = source;',
+				'for (;;) &{ value } = source;',
+				'while (ready) &{ value } = source;',
+				'label: &{ value } = source;',
+			]) {
+				const errors = unsupported_lazy_assignment_errors(analyze(source));
+
+				expect(errors, source).toHaveLength(1);
+				expect(errors[0].message, source).toBe(
+					TSRX_UNSUPPORTED_LAZY_ASSIGNMENT_POSITION_ERROR,
+				);
+			}
+		});
+
+		it('reports nested and non-direct assignment targets exactly once', () => {
+			for (const source of [
+				'(&{ value } = source, consume());',
+				'consume(&{ value } = source);',
+				'target = (&{ value } = source);',
+				'[&{ value }] = pairs;',
+				'[&{ value } as any] = pairs;',
+			]) {
+				const errors = unsupported_lazy_assignment_errors(analyze(source));
+
+				expect(errors, source).toHaveLength(1);
+				expect(errors[0].message, source).toBe(
+					TSRX_UNSUPPORTED_LAZY_ASSIGNMENT_POSITION_ERROR,
+				);
+			}
+		});
+
+		it('focuses one diagnostic on the first lazy descendant in an unsupported target', () => {
+			const source = '[&{ first }, &{ second }] = pairs;';
+			const errors = unsupported_lazy_assignment_errors(analyze(source));
+			const target = '{ first }';
+			const start = source.indexOf(target);
+
+			expect(errors).toHaveLength(1);
+			expect(errors[0].code).toBe(DIAGNOSTIC_CODES.UNSUPPORTED_LAZY_ASSIGNMENT_POSITION);
+			expect(errors[0].pos).toBe(start);
+			expect(errors[0].end).toBe(start + target.length);
+			expect(source.slice(errors[0].pos, errors[0].end)).toBe(target);
+		});
+
+		it('throws in strict analysis and collects in editor and type-only modes', () => {
+			const source = 'if (ready) &{ value } = source;';
+			const ast = parseModule(source, filename);
+
+			expect(() => analyzeTsrx(ast, filename)).toThrow(
+				TSRX_UNSUPPORTED_LAZY_ASSIGNMENT_POSITION_ERROR,
+			);
+
+			for (const options of [
+				{ collect: true },
+				{ loose: true },
+				{ typeOnly: true },
+				{ to_ts: true },
+			]) {
+				const errors = unsupported_lazy_assignment_errors(analyze(source, options));
+
+				expect(errors, JSON.stringify(options)).toHaveLength(1);
 			}
 		});
 	});

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -45,6 +45,14 @@ function virtual_parse_diagnostics(code) {
 const TSRX_TEMPLATE_RETURN_ERROR =
 	'Return statements are not allowed inside TSRX templates. Move the return before the TSRX return value, or use conditional rendering instead.';
 
+const UNSUPPORTED_LAZY_ASSIGNMENT_SOURCES = [
+	'function recover() { if (ready) &{ value } = source; }',
+	'function recover() { (&{ value } = source, consume()); }',
+	'function recover() { consume(&{ value } = source); }',
+	'function recover() { target = (&{ value } = source); }',
+	'function recover() { [&{ value }] = pairs; }',
+];
+
 /**
  * Shared compile/editor diagnostics. These do not assert source-map structure;
  * they only verify that editor-facing compile entry points collect diagnostics.
@@ -54,13 +62,7 @@ const TSRX_TEMPLATE_RETURN_ERROR =
 export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, name }) {
 	describe(`[${name}] compile diagnostics`, () => {
 		it('collects unsupported lazy assignment positions in type-only output', () => {
-			for (const source of [
-				'function recover() { if (ready) &{ value } = source; }',
-				'function recover() { (&{ value } = source, consume()); }',
-				'function recover() { consume(&{ value } = source); }',
-				'function recover() { target = (&{ value } = source); }',
-				'function recover() { [&{ value }] = pairs; }',
-			]) {
+			for (const source of UNSUPPORTED_LAZY_ASSIGNMENT_SOURCES) {
 				const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
 
 				expect(diagnostic_codes(result), source).toContain(
@@ -1109,6 +1111,18 @@ export function runSharedLazyLoopTests({ compile, name }) {
 			expect(code).toContain('for await (var __lazy0 of items)');
 			expect(code).toContain('consume(__lazy0.value)');
 			expect(code).toContain('return __lazy0.value');
+		});
+
+		it('keeps module-level var loop bindings visible after the loop', () => {
+			const { code } = compile(
+				`for (var &{ value } of items) consume(value);
+				consume(value);`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('for (var __lazy0 of items)');
+			expect(code).toContain('consume(__lazy0.value)');
+			expect(count_substring(code, 'consume(__lazy0.value)')).toBe(2);
 		});
 
 		it('retains the last for-of var source and the initialized classic-for source', () => {
@@ -2209,13 +2223,7 @@ export function runSharedCompileTests({
 		});
 
 		it('keeps every diagnosed assignment shape on a parseable best-effort path', () => {
-			for (const source of [
-				'function recover() { if (ready) &{ value } = source; }',
-				'function recover() { (&{ value } = source, consume()); }',
-				'function recover() { consume(&{ value } = source); }',
-				'function recover() { target = (&{ value } = source); }',
-				'function recover() { [&{ value }] = pairs; }',
-			]) {
+			for (const source of UNSUPPORTED_LAZY_ASSIGNMENT_SOURCES) {
 				const result = compile(source, 'App.tsrx', { collect: true });
 
 				expect(diagnostic_codes(result), source).toContain(

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1,5 +1,7 @@
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 import { DIAGNOSTIC_CODES } from '../../src/diagnostics.js';
+import { createLazyContext, parseModule, preallocateLazyIds } from '../../src/index.js';
 
 /** @import { CompileDiagnosticsHarness, CompileHarness } from '../../types/index' */
 
@@ -20,6 +22,26 @@ function diagnostic_codes(result) {
 	return result.errors.map((error) => error.code);
 }
 
+/**
+ * Parse generated target output as TSX and return syntax diagnostics. Target
+ * compilers intentionally leave TypeScript and JSX for downstream tooling, so
+ * this checks the same grammar boundary their virtual modules must satisfy.
+ *
+ * @param {string} code
+ * @returns {readonly ts.Diagnostic[]}
+ */
+function virtual_parse_diagnostics(code) {
+	const source_file = ts.createSourceFile(
+		'virtual.tsx',
+		code,
+		ts.ScriptTarget.Latest,
+		true,
+		ts.ScriptKind.TSX,
+	);
+	return /** @type {ts.SourceFile & { parseDiagnostics: readonly ts.Diagnostic[] }} */ (source_file)
+		.parseDiagnostics;
+}
+
 const TSRX_TEMPLATE_RETURN_ERROR =
 	'Return statements are not allowed inside TSRX templates. Move the return before the TSRX return value, or use conditional rendering instead.';
 
@@ -31,6 +53,24 @@ const TSRX_TEMPLATE_RETURN_ERROR =
  */
 export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, name }) {
 	describe(`[${name}] compile diagnostics`, () => {
+		it('collects unsupported lazy assignment positions in type-only output', () => {
+			for (const source of [
+				'function recover() { if (ready) &{ value } = source; }',
+				'function recover() { (&{ value } = source, consume()); }',
+				'function recover() { consume(&{ value } = source); }',
+				'function recover() { target = (&{ value } = source); }',
+				'function recover() { [&{ value }] = pairs; }',
+			]) {
+				const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+
+				expect(diagnostic_codes(result), source).toContain(
+					DIAGNOSTIC_CODES.UNSUPPORTED_LAZY_ASSIGNMENT_POSITION,
+				);
+				expect(virtual_parse_diagnostics(result.code), result.code).toEqual([]);
+				expect(result.code, source).not.toContain('__lazy');
+			}
+		});
+
 		it('preserves deferred imports in type-only output', () => {
 			const result = compile_to_volar_mappings(
 				`import defer * as feature from './feature.js';
@@ -1987,6 +2027,65 @@ export function runSharedCompileTests({
 	runSharedNestedLazyDestructuringTests({ compile, name });
 	runSharedLazyScopeNestingTests({ compile, name });
 	runSharedLazyJsxNameTests({ compile, name });
+
+	describe(`[${name}] lazy assignment recovery`, () => {
+		it('keeps a supported standalone lazy assignment on the declaration path', () => {
+			const result = compile(
+				`function recover() {
+					&{ value } = source;
+					consume(value);
+				}`,
+				'App.tsrx',
+				{ collect: true },
+			);
+
+			expect(result.errors).toEqual([]);
+			expect(result.code).toContain('const __lazy0 = source');
+			expect(result.code).toContain('consume(__lazy0.value)');
+			expect(virtual_parse_diagnostics(result.code), result.code).toEqual([]);
+		});
+
+		it('keeps every diagnosed assignment shape on a parseable best-effort path', () => {
+			for (const source of [
+				'function recover() { if (ready) &{ value } = source; }',
+				'function recover() { (&{ value } = source, consume()); }',
+				'function recover() { consume(&{ value } = source); }',
+				'function recover() { target = (&{ value } = source); }',
+				'function recover() { [&{ value }] = pairs; }',
+			]) {
+				const result = compile(source, 'App.tsrx', { collect: true });
+
+				expect(diagnostic_codes(result), source).toContain(
+					DIAGNOSTIC_CODES.UNSUPPORTED_LAZY_ASSIGNMENT_POSITION,
+				);
+				expect(virtual_parse_diagnostics(result.code), result.code).toEqual([]);
+				expect(result.code, source).not.toContain('__lazy');
+				expect(result.code, source).not.toMatch(/if\s*\([^)]*\)\s+(?:const|let|var)\s/);
+			}
+		});
+
+		it('keeps lazy ID preallocation idempotent for supported assignments', () => {
+			const ast = parseModule(
+				'function recover() { &{ value } = source; consume(value); }',
+				'App.tsrx',
+			);
+			const context = createLazyContext();
+			const statement = /** @type {import('estree').FunctionDeclaration} */ (ast.body[0]).body
+				.body[0];
+			const assignment = /** @type {import('estree').AssignmentExpression} */ (
+				/** @type {import('estree').ExpressionStatement} */ (statement).expression
+			);
+			const pattern = /** @type {import('../../types/index').LazyPattern} */ (assignment.left);
+
+			preallocateLazyIds(ast, context);
+			const first_id = pattern.metadata?.lazy_id;
+			preallocateLazyIds(ast, context);
+
+			expect(first_id).toBe('__lazy0');
+			expect(pattern.metadata?.lazy_id).toBe(first_id);
+			expect(context.lazy_next_id).toBe(1);
+		});
+	});
 
 	describe(`[${name}] deferred imports`, () => {
 		it('preserves deferred imports in compiled output', () => {

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -73,6 +73,20 @@ export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, na
 			}
 		});
 
+		it('lowers transparent standalone lazy assignments in type-only output', () => {
+			for (const source of [
+				'function recover() { (&{ value } = source); consume(value); }',
+				'function recover() { (&{ value } = source) as unknown; consume(value); }',
+			]) {
+				const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+
+				expect(result.errors, source).toEqual([]);
+				expect(result.code, source).toContain('const __lazy0 = source');
+				expect(result.code, source).toContain('consume(__lazy0.value)');
+				expect(virtual_parse_diagnostics(result.code), result.code).toEqual([]);
+			}
+		});
+
 		it('preserves deferred imports in type-only output', () => {
 			const result = compile_to_volar_mappings(
 				`import defer * as feature from './feature.js';
@@ -1068,6 +1082,22 @@ export function runSharedLazyLoopTests({ compile, name }) {
 			expect(code).toContain('consume(__lazy0.value, doubled)');
 		});
 
+		it('keeps outer lazy bindings active through classic-for initializers', () => {
+			const { code } = compile(
+				`export function self(&{ value }) {
+					for (let &{ value } = value; false;) consume(value);
+				}
+				export function later(&{ value }, source) {
+					for (let before = value, &{ value } = source; false;) consume(before, value);
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('for (let __lazy1 = __lazy0.value; false; )');
+			expect(code).toContain('for (let before = __lazy2.value, __lazy3 = source; false; )');
+			expect(code).toContain('consume(before, __lazy3.value)');
+		});
+
 		it('keeps classic-for var sources visible after nested control flow', () => {
 			const { code } = compile(
 				`export function count(ready, source, limit) {
@@ -1097,6 +1127,20 @@ export function runSharedLazyLoopTests({ compile, name }) {
 			expect(code).toContain('for (const __lazy1 of __lazy0.item.children)');
 			expect(code).toContain('consume(__lazy1.item)');
 			expect(code).toContain('return __lazy0.item');
+		});
+
+		it('shadows outer lazy names with non-lazy siblings in bare loop targets', () => {
+			const { code } = compile(
+				`export function read(&{ existing }, items) {
+					for ([existing, &{ value }] of items) consume(existing, value);
+					return existing;
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('for (const [existing, __lazy1] of items)');
+			expect(code).toContain('consume(existing, __lazy1.value)');
+			expect(code).toContain('return __lazy0.existing');
 		});
 
 		it('preserves for-await and var last-source lifetime lowering', () => {
@@ -1162,6 +1206,23 @@ export function runSharedLazyLoopTests({ compile, name }) {
 			expect(code).toContain('return __lazy0.value');
 			expect(code).toContain('return [inner, value]');
 			expect(code).not.toContain('return [inner, __lazy0.value]');
+		});
+
+		it('keeps static-block var loop bindings inside the static block', () => {
+			const { code } = compile(
+				`class Example {
+					static {
+						for (var &{ value } of items) consume(value);
+						consume(value);
+					}
+				}
+				consume(value);`,
+				'App.tsrx',
+			);
+
+			expect(count_substring(code, 'consume(__lazy0.value)')).toBe(2);
+			expect(code).toMatch(/}\s*consume\(value\);?$/);
+			expect(code).not.toMatch(/}\s*consume\(__lazy0\.value\);?$/);
 		});
 	});
 }
@@ -2220,6 +2281,20 @@ export function runSharedCompileTests({
 			expect(result.code).toContain('const __lazy0 = source');
 			expect(result.code).toContain('consume(__lazy0.value)');
 			expect(virtual_parse_diagnostics(result.code), result.code).toEqual([]);
+		});
+
+		it('lowers transparent standalone lazy assignments in strict output', () => {
+			for (const source of [
+				'function recover() { (&{ value } = source); consume(value); }',
+				'function recover() { (&{ value } = source) as unknown; consume(value); }',
+			]) {
+				const result = compile(source, 'App.tsrx');
+
+				expect(result.errors, source).toEqual([]);
+				expect(result.code, source).toContain('const __lazy0 = source');
+				expect(result.code, source).toContain('consume(__lazy0.value)');
+				expect(virtual_parse_diagnostics(result.code), result.code).toEqual([]);
+			}
 		});
 
 		it('keeps every diagnosed assignment shape on a parseable best-effort path', () => {

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -991,6 +991,168 @@ export function runSharedNestedLazyDestructuringTests({ compile, name }) {
 }
 
 /**
+ * JavaScript loop headers are binding sites with different evaluation and
+ * lifetime rules from ordinary declarations. These regressions stay in the
+ * shared harness so every target consumes the same lazy lowering.
+ *
+ * @param {Pick<CompileHarness, 'compile' | 'name'>} harness
+ */
+export function runSharedLazyLoopTests({ compile, name }) {
+	describe(`[${name}] lazy destructuring in JavaScript loops`, () => {
+		it('lowers for-of and for-in declaration targets without changing their kind', () => {
+			const { code } = compile(
+				`export function read(items, table) {
+					for (const &{ value } of items) consume(value);
+					for (let &[entry] of items) consume(entry);
+					for (var &{ key } in table) consume(key);
+					return key;
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('for (const __lazy0 of items)');
+			expect(code).toContain('consume(__lazy0.value)');
+			expect(code).toContain('for (let __lazy1 of items)');
+			expect(code).toContain('consume(__lazy1[0])');
+			expect(code).toContain('for (var __lazy2 in table)');
+			expect(code).toContain('consume(__lazy2.key)');
+			expect(code).toContain('return __lazy2.key');
+		});
+
+		it('normalizes bare direct and nested lazy targets to per-iteration const declarations', () => {
+			const { code } = compile(
+				`export function read(items, table) {
+					for (&{ value } of items) consume(value);
+					for ({ pair: &[first] } of items) consume(first);
+					for ([&{ key }] in table) consume(key);
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('for (const __lazy0 of items)');
+			expect(code).toContain('consume(__lazy0.value)');
+			expect(code).toMatch(/for \(const \{\s*pair:\s*__lazy1\s*\} of items\)/);
+			expect(code).toContain('consume(__lazy1[0])');
+			expect(code).toMatch(/for \(const \[__lazy2\] in table\)/);
+			expect(code).toContain('consume(__lazy2.key)');
+			expect(virtual_parse_diagnostics(code), code).toEqual([]);
+		});
+
+		it('rewrites lazy descendants nested in declaration targets', () => {
+			const { code } = compile(
+				`export function read(items) {
+					for (const { pair: &[first] } of items) consume(first);
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toMatch(/for \(const \{\s*pair:\s*__lazy0\s*\} of items\)/);
+			expect(code).toContain('consume(__lazy0[0])');
+		});
+
+		it('threads classic-for bindings through later initializers, test, update, and body', () => {
+			const { code } = compile(
+				`export function count(source, limit) {
+					for (let &{ value } = source, doubled = value * 2; value < limit; value++) {
+						consume(value, doubled);
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('let __lazy0 = source, doubled = __lazy0.value * 2');
+			expect(code).toContain('__lazy0.value < limit');
+			expect(code).toContain('__lazy0.value++');
+			expect(code).toContain('consume(__lazy0.value, doubled)');
+		});
+
+		it('keeps classic-for var sources visible after nested control flow', () => {
+			const { code } = compile(
+				`export function count(ready, source, limit) {
+					if (ready) {
+						for (var &{ value } = source; value < limit; value++) consume(value);
+					}
+					return value;
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('for (var __lazy0 = source; __lazy0.value < limit; __lazy0.value++)');
+			expect(code).toContain('consume(__lazy0.value)');
+			expect(code).toContain('return __lazy0.value');
+		});
+
+		it('evaluates for-of RHS names in the outer environment before loop shadowing', () => {
+			const { code } = compile(
+				`export function read(&{ item }, items) {
+					for (const &{ item } of item.children) consume(item);
+					return item;
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function read(__lazy0, items)');
+			expect(code).toContain('for (const __lazy1 of __lazy0.item.children)');
+			expect(code).toContain('consume(__lazy1.item)');
+			expect(code).toContain('return __lazy0.item');
+		});
+
+		it('preserves for-await and var last-source lifetime lowering', () => {
+			const { code } = compile(
+				`export async function read(items) {
+					for await (var &{ value } of items) consume(value);
+					return value;
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('for await (var __lazy0 of items)');
+			expect(code).toContain('consume(__lazy0.value)');
+			expect(code).toContain('return __lazy0.value');
+		});
+
+		it('retains the last for-of var source and the initialized classic-for source', () => {
+			const { code } = compile(
+				`function read(items) {
+					for (var &{ value } of items) {}
+					return value;
+				}
+				function classic(source) {
+					for (var &{ value } = source; false;) {}
+					return value;
+				}`,
+				'App.tsrx',
+			);
+			// Plain functions do not introduce target runtime imports, so execute
+			// the emitted JavaScript to pin the generated source lifetime itself.
+			const compiled = new Function(`${code}\nreturn { read, classic };`)();
+
+			expect(compiled.read([{ value: 1 }, { value: 2 }])).toBe(2);
+			expect(() => compiled.read([])).toThrow();
+			expect(compiled.classic({ value: 3 })).toBe(3);
+		});
+
+		it('does not propagate lazy var loop bindings across nested function boundaries', () => {
+			const { code } = compile(
+				`export function outer(items) {
+					function inner() {
+						for (var &{ value } of items) consume(value);
+						return value;
+					}
+					return [inner, value];
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('for (var __lazy0 of items)');
+			expect(code).toContain('return __lazy0.value');
+			expect(code).toContain('return [inner, value]');
+			expect(code).not.toContain('return [inner, __lazy0.value]');
+		});
+	});
+}
+
+/**
  * Lazy `&{...}` / `&[...]` declarations inside a nested `@{ ... }` code block or a
  * `@if` / `@for` / `@switch` directive body must be rewritten exactly as they are
  * in a flat component body. These scopes lower to generated function boundaries
@@ -2025,6 +2187,7 @@ export function runSharedCompileTests({
 
 	runSharedComponentLoopControlFlowTests({ compile, name });
 	runSharedNestedLazyDestructuringTests({ compile, name });
+	runSharedLazyLoopTests({ compile, name });
 	runSharedLazyScopeNestingTests({ compile, name });
 	runSharedLazyJsxNameTests({ compile, name });
 

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -841,6 +841,45 @@ function C() @{
 	});
 
 	describe(`[${name}] lazy destructuring mappings`, () => {
+		it('maps generated loop sources and rewritten body references to authored lazy bindings', () => {
+			const source = `function read(items) {
+	for (const &{ value } of items) {
+		consume(value);
+	}
+}`;
+			const result = compile(source, 'App.tsrx');
+			const generated_line_offsets = build_line_offsets(result.code);
+			const [src_to_gen_map] = build_src_to_gen_map(
+				result.map,
+				new Map(),
+				generated_line_offsets,
+				result.code,
+			);
+			const source_line_offsets = build_line_offsets(source);
+			const loop_pattern = offset_to_line_col(source.indexOf('&{ value }'), source_line_offsets);
+			const body_value = offset_to_line_col(source.lastIndexOf('value'), source_line_offsets);
+			const generated_pattern = get_generated_position(
+				loop_pattern.line,
+				loop_pattern.column,
+				src_to_gen_map,
+			);
+			const generated_body = get_generated_position(
+				body_value.line,
+				body_value.column,
+				src_to_gen_map,
+			);
+
+			expect(result.code).toContain('for (const __lazy0 of items)');
+			expect(result.code).toContain('consume(__lazy0.value)');
+			if (generated_pattern instanceof Error) throw generated_pattern;
+			if (generated_body instanceof Error) throw generated_body;
+			const pattern_offset =
+				generated_line_offsets[generated_pattern.line - 1] + generated_pattern.column;
+			const body_offset = generated_line_offsets[generated_body.line - 1] + generated_body.column;
+			expect(result.code.slice(pattern_offset, pattern_offset + '__lazy0'.length)).toBe('__lazy0');
+			expect(result.code.slice(body_offset, body_offset + 'value'.length)).toBe('value');
+		});
+
 		it('preserves untyped lazy object patterns so source identifiers map identity-style', () => {
 			const source = `function Hello(&{ a: value, b }) @{
 	<>{value}{b}</>

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -170,6 +170,8 @@ export interface BaseNodeMetaData {
 	forceMapping?: boolean;
 	generated_loop_skip_if?: boolean;
 	lazy_id?: string;
+	/** The current var scope contains a lazy `var` binding in a JavaScript loop header. */
+	has_lazy_var_loop_descendants?: boolean;
 	disable_verification?: boolean;
 	/** Identifiers whose source ranges also map to this generated identifier. */
 	extra_source_mappings?: Array<(AST.Identifier | AST.PrivateIdentifier) & AST.NodeWithLocation>;

--- a/website-tsrx/public/llms.txt
+++ b/website-tsrx/public/llms.txt
@@ -514,6 +514,36 @@ const UserCard = (&{ name, age }: { name: string; age: number }) =>
 let &[count, setCount] = createSignal(0);
 ```
 
+Lazy patterns are also supported in ordinary JavaScript loop headers: classic
+`for` initializers, `for...of`, `for...in`, and `for await...of`. A `for...of`
+or `for...in` target may be either a declaration or a bare target containing a
+lazy pattern; a bare target is normalized to a per-iteration binding. The
+iterable or right-hand expression uses the outer binding environment, while the
+new lazy names apply after the target is established. Declaration kinds keep
+their normal ECMAScript scope, including post-loop visibility for `var`.
+
+```tsrx
+for (const &{ value } of items) consume(value);
+for (let &[key] in table) consume(key);
+for (&{ value } of items) consume(value);
+for (let &{ value } = cursor; value < limit; value++) consume(value);
+for await (const &{ value } of stream) consume(value);
+```
+
+These are imperative JavaScript loops, not rendered-list constructs. Use the
+`@for` template directive when the loop itself produces UI.
+
+A lazy destructuring assignment is supported only when its entire left-hand
+side is a directly lazy array or object pattern and the assignment is the
+complete expression statement in a program, block, TSRX `@{...}` code block, or
+`switch` case statement list. Braceless control-flow bodies, nested
+assignments, sequence operands, call arguments, and non-lazy outer targets that
+contain a lazy pattern report
+`tsrx-unsupported-lazy-assignment-position`. Strict compilation rejects the
+source. Diagnostic-collecting, type-only, and editor paths report the error and
+retain syntactically valid best-effort output; that recovery does not give the
+unsupported assignment lazy semantics.
+
 ### Prop shorthand
 
 When a prop name matches the variable, use `{name}` instead of `name={name}`.
@@ -917,6 +947,7 @@ const List = <T,>({ items, render }: Props<T>) =>
 | Expression children    | `<List children={items.map(render)} />`                |
 | Lazy prop destructure  | `const C = (&{ x, y }: Props) => <div />;`             |
 | Lazy array destructure | `let &[count, set] = createSignal(0);`                 |
+| Lazy JS loop target    | `for (const &{ x } of items) use(x);`                  |
 | Prop shorthand         | `<Input {value} {onChange} />`                         |
 | Conditional rendering  | `@if (cond) { <Panel /> }`                             |
 | List rendering         | `@for (const x of xs; index i; key x.id) { <li /> }`   |

--- a/website-tsrx/src/pages/specification.tsrx
+++ b/website-tsrx/src/pages/specification.tsrx
@@ -119,6 +119,14 @@ const LAZY_GRAMMAR = [
 	'  LazyArrayBindingPattern = AssignmentExpression ;',
 ].join('\n');
 
+const LAZY_LOOP_EXAMPLES = [
+	'for (const &{ value } of items) { use(value); }',
+	'for (let &[key] in table) { use(key); }',
+	'for (&{ value } of items) { use(value); }',
+	'for (let &{ value } = cursor; value < limit; value++) { use(value); }',
+	'for await (const &{ value } of stream) { use(value); }',
+].join('\n');
+
 const STYLE_GRAMMAR = [
 	'JSXStyleElement :',
 	'  <style JSXAttributesopt> CSSSource </style>',
@@ -744,6 +752,36 @@ export function SpecificationPage() @{
 							<pre class="code-block plain">
 								<code>{LAZY_GRAMMAR}</code>
 							</pre>
+							<p class="section-body">
+								Lazy binding patterns are permitted in ordinary JavaScript loop headers: in a
+								classic
+								<code class="inline-code">for</code>
+								initializer, in
+								<code class="inline-code">for...of</code>
+								and
+								<code class="inline-code">for...in</code>
+								declarations, and in
+								<code class="inline-code">for await...of</code>
+								declarations. A
+								<code class="inline-code">for...of</code>
+								or
+								<code class="inline-code">for...in</code>
+								header may also use a bare target that contains a lazy pattern; it behaves as a
+								per-iteration binding. Declaration kinds retain their ordinary ECMAScript scope,
+								including post-loop visibility for
+								<code class="inline-code">var</code>.
+							</p>
+							<pre class="code-block plain">
+								<code>{LAZY_LOOP_EXAMPLES}</code>
+							</pre>
+							<p class="section-body">
+								The iterable or right-hand expression is evaluated in the outer binding environment.
+								The lazy names introduced by the loop target apply to the loop's test, update, and
+								body only after that target has been established. These are ordinary JavaScript
+								loops used in setup or imperative logic; rendered list output continues to use the
+								<code class="inline-code">@for</code>
+								template directive.
+							</p>
 						</section>
 
 						<section class="doc-section" id="style">
@@ -813,6 +851,16 @@ export function SpecificationPage() @{
 									is not a template output node. Use a JSX fragment when a statement container or
 									control-flow block needs to render text, expression containers, or multiple
 									siblings.
+								</li>
+								<li>
+									A lazy destructuring assignment must have a directly lazy array or object target,
+									must be the complete expression statement, and must be a direct item in a Program,
+									BlockStatement, JSXCodeBlock, or SwitchCase statement list. Braceless control-flow
+									bodies, nested assignments, sequence operands, call arguments, and non-lazy outer
+									targets that contain a lazy pattern are early errors reported as
+									<code class="inline-code">tsrx-unsupported-lazy-assignment-position</code>.
+									Diagnostic-collecting tooling may preserve syntactically valid best-effort output,
+									but that recovery does not make the unsupported assignment conforming TSRX.
 								</li>
 								<li>
 									In hosts that enable server-oriented submodules, server exports must be imported


### PR DESCRIPTION
## Summary

Lazy destructuring now lowers through shared JavaScript loop headers instead of silently becoming eager output. Unsupported assignment positions receive one target-neutral diagnostic while collection and editor paths retain parseable recovery output.

This implementation preserves broad parser acceptance and applies the shared behavior across React, Preact, Solid, and Vue.

## Design decisions

- Validate assignment eligibility after parsing so editor recovery remains available.
- Evaluate loop iterables in the outer binding environment, then layer loop-local bindings for the body.
- Preserve declaration kind, `for await...of`, source mappings, and supported `var` visibility.
- Keep the change in shared `@tsrx/core` rather than adding target-specific workarounds.

## Review focus

The implementation review identified four unresolved findings for maintainer review:

- Bare lazy `for...of` and `for...in` targets lose their binding in type-only/Volar output.
- Same-name lazy `var` loop bindings can overwrite the pre-loop binding environment.
- Computed keys and default values inside loop targets can retain stale authored lazy names.
- Type-only transforms now perform an unconditional extra lazy-transform traversal.

## Validation

- 25 focused test files: 2,170 passed, 33 skipped
- Core TSRX typecheck passed
- Scoped formatting and changeset validation passed
- TSRX website production build passed: 502 client modules and 101 SSR modules

Session-settled decision carried from planning: support loop bindings and diagnose unsafe assignment positions (user-approved over lowering or hoisting every parsed assignment shape).

Related: #12

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core lazy binding semantics, loop lowering, and var scoping across all TSRX targets; behavior is heavily tested but the transform surface area is large.
> 
> **Overview**
> Extends shared lazy destructuring lowering to **JavaScript loop headers** (`for` initializers, `for...of` / `for...in` / `for await...of`), including bare lazy targets normalized to per-iteration `const` declarations, classic-`for` declarator ordering, outer-scope RHS evaluation, and `var` loop lifetime via `has_lazy_var_loop_descendants` metadata.
> 
> Adds a **target-neutral** `tsrx-unsupported-lazy-assignment-position` diagnostic when lazy assignments are not a directly lazy pattern as a standalone statement in a program, block, `@{...}` code block, or switch case. Analysis and `preallocate_lazy_ids` share `is_supported_lazy_assignment_position` so collect mode does not allocate IDs for diagnosed shapes.
> 
> **Type-only / editor paths** still run lazy transforms for supported standalone assignments (including parenthesized wrappers); unsupported positions emit diagnostics and emit parseable best-effort assignments without `__lazy` IDs. Specification and `llms.txt` document loop targets and assignment rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c57ce0335bd2064434c62f8e19fa0884e5201ac2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
