### PR TITLE
fix(tsrx): address lazy loop review feedback

### DIFF
--- a/.changeset/lazy-loop-review-fixes.md
+++ b/.changeset/lazy-loop-review-fixes.md
@@ -1,0 +1,5 @@
+---
+"@tsrx/core": patch
+---
+
+Preserve lazy loop bindings across type-only output, `var` source ordering, computed keys, and default values.

--- a/packages/tsrx/src/transform/lazy.js
+++ b/packages/tsrx/src/transform/lazy.js
@@ -433,9 +433,75 @@ function replace_lazy_in_pattern(pattern, is_top = true) {
 }
 
 /**
+ * Rewrite expression-bearing slots in a loop target without walking binding
+ * identifiers or non-computed property keys. Computed keys and default RHS
+ * values are evaluated while the target is established, so they see the lazy
+ * environment active at that point in the loop header.
+ *
+ * This runs before `replace_lazy_in_pattern`: computed keys inside a lazy
+ * pattern become part of the deferred member access collected from that
+ * pattern, while defaults surrounding a nested lazy pattern remain in the
+ * emitted binding target.
+ *
+ * @template {AST.Pattern} T
+ * @param {T} pattern
+ * @param {Map<string, LazyBinding>} lazy_bindings
+ * @returns {T}
+ */
+function transform_loop_pattern_expressions(pattern, lazy_bindings) {
+	if (!pattern || typeof pattern !== 'object') return pattern;
+
+	if (pattern.type === 'AssignmentPattern') {
+		const new_left = transform_loop_pattern_expressions(pattern.left, lazy_bindings);
+		const new_right = apply_lazy_transforms_to_slot(pattern.right, lazy_bindings);
+		return new_left !== pattern.left || new_right !== pattern.right
+			? /** @type {T} */ ({ ...pattern, left: new_left, right: new_right })
+			: pattern;
+	}
+	if (pattern.type === 'RestElement') {
+		const new_argument = transform_loop_pattern_expressions(pattern.argument, lazy_bindings);
+		return new_argument === pattern.argument
+			? pattern
+			: /** @type {T} */ ({ ...pattern, argument: new_argument });
+	}
+	if (pattern.type === 'ObjectPattern') {
+		let changed = false;
+		const properties = pattern.properties.map((property) => {
+			if (property.type === 'RestElement') {
+				const new_argument = transform_loop_pattern_expressions(property.argument, lazy_bindings);
+				if (new_argument === property.argument) return property;
+				changed = true;
+				return rebuild(property, { argument: new_argument });
+			}
+
+			const new_key = property.computed
+				? apply_lazy_transforms_to_slot(property.key, lazy_bindings)
+				: property.key;
+			const new_value = transform_loop_pattern_expressions(property.value, lazy_bindings);
+			if (new_key === property.key && new_value === property.value) return property;
+			changed = true;
+			return rebuild(property, { key: new_key, value: new_value });
+		});
+		return changed ? /** @type {T} */ ({ ...pattern, properties }) : pattern;
+	}
+	if (pattern.type === 'ArrayPattern') {
+		let changed = false;
+		const elements = pattern.elements.map((element) => {
+			if (!element) return element;
+			const new_element = transform_loop_pattern_expressions(element, lazy_bindings);
+			if (new_element !== element) changed = true;
+			return new_element;
+		});
+		return changed ? /** @type {T} */ ({ ...pattern, elements }) : pattern;
+	}
+
+	return pattern;
+}
+
+/**
  * Walk the AST and pre-allocate `lazy_id` metadata on every lazy destructuring
- * pattern: function params, variable declarator ids, and supported standalone
- * assignment LHS. Walks into non-lazy outer patterns to
+ * pattern: function params, variable declarator ids, bare for-of/in targets,
+ * and supported standalone assignment LHS. Walks into non-lazy outer patterns to
  * find nested lazy ones, e.g. `{ pair: &[a, b] }` allocates an id for the inner
  * `&[a, b]`. Idempotent: skips patterns that already have a `lazy_id`.
  *
@@ -499,7 +565,6 @@ export function preallocate_lazy_ids(root, context, assignments_only = false) {
 		}
 
 		if (
-			!assignments_only &&
 			(node.type === 'ForOfStatement' || node.type === 'ForInStatement') &&
 			node.left.type !== 'VariableDeclaration'
 		) {
@@ -557,7 +622,10 @@ export function preallocate_lazy_ids(root, context, assignments_only = false) {
 			// Class static blocks own a distinct var environment. Their loop
 			// bindings must not be collected by the surrounding function/module.
 			flags &= ~HAS_VAR_LOOP;
-		} else if (node.type === 'Program' && flags & HAS_VAR_LOOP) {
+		} else if (flags & HAS_VAR_LOOP) {
+			// Statement containers and their direct statements use this signal to
+			// advance function-scoped lazy `var` bindings in source order without
+			// rescanning unaffected subtrees during the transform.
 			node.metadata = { ...node.metadata, has_lazy_var_loop_descendants: true };
 		}
 
@@ -676,15 +744,15 @@ function collect_preallocated_lazy_bindings(pattern, lazy_bindings) {
 }
 
 /**
- * Collect lazy `var` bindings introduced by JavaScript loop headers in the
- * current function. A generated `var __lazyN` has the same function lifetime
- * as the source binding, including when the loop is nested in ordinary control
- * flow. Nested functions own a different var environment and are not visited.
+ * Collect lazy `var` bindings introduced by JavaScript loop headers in one
+ * statement. The caller installs the collected mappings after transforming
+ * that statement, including when the loop is nested in ordinary control flow.
+ * Nested functions own a different var environment and are not visited.
  *
  * @param {AST.Node} node
  * @param {Map<string, LazyBinding>} lazy_bindings
  */
-function collect_function_var_loop_bindings(node, lazy_bindings) {
+function collect_statement_var_loop_bindings(node, lazy_bindings) {
 	if (is_function_or_component_node(node) || node.type === 'StaticBlock') return;
 
 	if (
@@ -706,8 +774,40 @@ function collect_function_var_loop_bindings(node, lazy_bindings) {
 	}
 
 	for (const child of child_nodes(node)) {
-		collect_function_var_loop_bindings(child, lazy_bindings);
+		collect_statement_var_loop_bindings(child, lazy_bindings);
 	}
+}
+
+/**
+ * Rewrite a statement list in source order, installing lazy `var` loop
+ * bindings only after the statement that establishes them. The mapping then
+ * remains visible to subsequent statements in the current var environment.
+ *
+ * @param {AST.Program['body']} statements
+ * @param {Map<string, LazyBinding>} lazy_bindings
+ * @param {boolean} has_lazy_var_loop_descendants
+ * @returns {{ body: AST.Program['body'], lazy_bindings: Map<string, LazyBinding>, changed: boolean }}
+ */
+function transform_statement_list(statements, lazy_bindings, has_lazy_var_loop_descendants) {
+	let effective_bindings = lazy_bindings;
+	let changed = false;
+	const body = statements.map((statement) => {
+		const transformed = apply_lazy_transforms_to_slot(statement, effective_bindings);
+		if (transformed !== statement) changed = true;
+
+		if (has_lazy_var_loop_descendants && statement.metadata?.has_lazy_var_loop_descendants) {
+			/** @type {Map<string, LazyBinding>} */
+			const statement_bindings = new Map();
+			collect_statement_var_loop_bindings(statement, statement_bindings);
+			if (statement_bindings.size > 0) {
+				effective_bindings = new Map([...effective_bindings, ...statement_bindings]);
+			}
+		}
+
+		return transformed;
+	});
+
+	return { body, lazy_bindings: effective_bindings, changed };
 }
 
 /**
@@ -728,12 +828,13 @@ function transform_classic_for_declaration(declaration, lazy_bindings) {
 	const declarations = declaration.declarations.map((declarator) => {
 		const new_init =
 			declarator.init && apply_lazy_transforms_to_slot(declarator.init, effective_bindings);
-		const new_id = replace_lazy_in_pattern(declarator.id);
+		const expression_id = transform_loop_pattern_expressions(declarator.id, effective_bindings);
+		const new_id = replace_lazy_in_pattern(expression_id);
 		if (new_init !== declarator.init || new_id !== declarator.id) changed = true;
 
 		/** @type {Map<string, LazyBinding>} */
 		const own_bindings = new Map();
-		collect_preallocated_lazy_bindings(declarator.id, own_bindings);
+		collect_preallocated_lazy_bindings(expression_id, own_bindings);
 		if (own_bindings.size > 0) {
 			mutable_bindings ??= new Map(effective_bindings);
 			for (const [name, binding] of own_bindings) mutable_bindings.set(name, binding);
@@ -757,17 +858,19 @@ function transform_classic_for_declaration(declaration, lazy_bindings) {
  * generated source identifiers have an owning declaration.
  *
  * @param {AST.ForOfStatement['left'] | AST.ForInStatement['left']} left
+ * @param {Map<string, LazyBinding>} lazy_bindings
  * @returns {{ left: AST.VariableDeclaration, lazy_bindings: Map<string, LazyBinding> } | { left: AST.ForOfStatement['left'] | AST.ForInStatement['left'], lazy_bindings: Map<string, LazyBinding> }}
  */
-function transform_for_each_left(left) {
+function transform_for_each_left(left, lazy_bindings) {
 	/** @type {Map<string, LazyBinding>} */
 	const own_bindings = new Map();
 
 	if (left.type === 'VariableDeclaration') {
 		let changed = false;
 		const declarations = left.declarations.map((declarator) => {
-			collect_preallocated_lazy_bindings(declarator.id, own_bindings);
-			const new_id = replace_lazy_in_pattern(declarator.id);
+			const expression_id = transform_loop_pattern_expressions(declarator.id, lazy_bindings);
+			collect_preallocated_lazy_bindings(expression_id, own_bindings);
+			const new_id = replace_lazy_in_pattern(expression_id);
 			if (new_id === declarator.id) return declarator;
 			changed = true;
 			return rebuild(declarator, { id: new_id });
@@ -778,10 +881,11 @@ function transform_for_each_left(left) {
 		};
 	}
 
-	collect_preallocated_lazy_bindings(left, own_bindings);
-	if (own_bindings.size === 0) return { left, lazy_bindings: own_bindings };
+	const expression_left = transform_loop_pattern_expressions(left, lazy_bindings);
+	collect_preallocated_lazy_bindings(expression_left, own_bindings);
+	if (own_bindings.size === 0) return { left: expression_left, lazy_bindings: own_bindings };
 
-	const new_id = replace_lazy_in_pattern(left);
+	const new_id = replace_lazy_in_pattern(expression_left);
 	return {
 		left: b.declaration('const', [b.declarator(new_id)]),
 		lazy_bindings: own_bindings,
@@ -836,18 +940,8 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 			own_bindings.size > 0
 				? new Map([...outer_minus_shadow, ...own_bindings])
 				: outer_minus_shadow;
-		/** @type {Map<string, LazyBinding>} */
-		const function_var_bindings = new Map();
-		if (node.metadata?.has_lazy_var_loop_descendants) {
-			collect_function_var_loop_bindings(node.body, function_var_bindings);
-		}
-		const function_bindings =
-			function_var_bindings.size > 0
-				? new Map([...inner_bindings, ...function_var_bindings])
-				: inner_bindings;
-
 		if (
-			function_bindings.size === 0 &&
+			inner_bindings.size === 0 &&
 			!params_changed &&
 			!had_lazy_param &&
 			!node.metadata?.has_lazy_descendants
@@ -859,7 +953,7 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 		// params to replace, defaults referencing outer lazy, or the body
 		// contains lazy descendants the BlockStatement handler will collect.
 		// In every case the body needs to be walked.
-		const new_body = apply_lazy_transforms_to_slot(node.body, function_bindings);
+		const new_body = apply_lazy_transforms_to_slot(node.body, inner_bindings);
 
 		const final_params_src = params_changed ? new_params : node.params;
 		const final_params = had_lazy_param ? replace_lazy_params(final_params_src) : final_params_src;
@@ -873,39 +967,22 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 	if (node.type === 'BlockStatement' || node.type === 'Program' || node.type === 'StaticBlock') {
 		/** @type {AST.Program['body']} */
 		const body = node.body;
-		/** @type {Map<string, LazyBinding>} */
-		const var_scope_bindings = new Map();
-		if (node.metadata?.has_lazy_var_loop_descendants) {
-			if (node.type === 'Program') {
-				collect_function_var_loop_bindings(node, var_scope_bindings);
-			} else if (node.type === 'StaticBlock') {
-				for (const statement of node.body) {
-					collect_function_var_loop_bindings(statement, var_scope_bindings);
-				}
-			}
-		}
-		const scope_bindings =
-			var_scope_bindings.size > 0
-				? new Map([...lazy_bindings, ...var_scope_bindings])
-				: lazy_bindings;
-		const block_bindings = collect_block_shadowed_names(body, scope_bindings);
+		const block_bindings = collect_block_shadowed_names(body, lazy_bindings);
 		const after_shadow =
-			block_bindings.size > 0 ? remove_shadowed(scope_bindings, block_bindings) : scope_bindings;
+			block_bindings.size > 0 ? remove_shadowed(lazy_bindings, block_bindings) : lazy_bindings;
 
 		/** @type {Map<string, LazyBinding>} */
 		const block_lazy = new Map();
 		collect_lazy_bindings_from_statements(body, block_lazy);
 
-		const effective_bindings =
+		const initial_bindings =
 			block_lazy.size > 0 ? new Map([...after_shadow, ...block_lazy]) : after_shadow;
-
-		let changed = false;
-		const new_body = node.body.map((stmt) => {
-			const transformed = apply_lazy_transforms_to_slot(stmt, effective_bindings);
-			if (transformed !== stmt) changed = true;
-			return transformed;
-		});
-		return changed ? rebuild(node, { body: new_body }) : node;
+		const transformed = transform_statement_list(
+			node.body,
+			initial_bindings,
+			node.metadata?.has_lazy_var_loop_descendants === true,
+		);
+		return transformed.changed ? rebuild(node, { body: transformed.body }) : node;
 	}
 
 	if (node.type === 'CatchClause') {
@@ -963,7 +1040,7 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 		}
 		const after_shadow =
 			shadowed.size > 0 ? remove_shadowed(lazy_bindings, shadowed) : lazy_bindings;
-		const transformed_left = transform_for_each_left(node.left);
+		const transformed_left = transform_for_each_left(node.left, after_shadow);
 		const effective_bindings =
 			transformed_left.lazy_bindings.size > 0
 				? new Map([...after_shadow, ...transformed_left.lazy_bindings])
@@ -1006,20 +1083,23 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 		// binding declared inside a case body.
 		const new_discriminant = apply_lazy_transforms_to_slot(node.discriminant, after_shadow);
 		if (new_discriminant !== node.discriminant) changed = true;
+		let consequent_bindings = effective_bindings;
 		const new_cases = node.cases.map((switch_case) => {
 			let case_changed = false;
 			const new_test = switch_case.test
 				? apply_lazy_transforms_to_slot(switch_case.test, effective_bindings)
 				: null;
 			if (new_test !== switch_case.test) case_changed = true;
-			const new_consequent = switch_case.consequent.map((stmt) => {
-				const transformed = apply_lazy_transforms_to_slot(stmt, effective_bindings);
-				if (transformed !== stmt) case_changed = true;
-				return transformed;
-			});
+			const transformed = transform_statement_list(
+				switch_case.consequent,
+				consequent_bindings,
+				node.metadata?.has_lazy_var_loop_descendants === true,
+			);
+			consequent_bindings = transformed.lazy_bindings;
+			if (transformed.changed) case_changed = true;
 			if (case_changed) {
 				changed = true;
-				return rebuild(switch_case, { test: new_test, consequent: new_consequent });
+				return rebuild(switch_case, { test: new_test, consequent: transformed.body });
 			}
 			return switch_case;
 		});

--- a/packages/tsrx/src/transform/lazy.js
+++ b/packages/tsrx/src/transform/lazy.js
@@ -779,6 +779,28 @@ function collect_statement_var_loop_bindings(node, lazy_bindings) {
 }
 
 /**
+ * Install lazy `var` loop bindings introduced by a statement slot before
+ * transforming a later-evaluated slot of the same compound statement. The
+ * preallocation pass marks only subtrees that can contribute bindings in the
+ * current var environment, so unaffected slots keep the existing map without
+ * a rescan or allocation.
+ *
+ * @param {AST.Node} node
+ * @param {Map<string, LazyBinding>} lazy_bindings
+ * @returns {Map<string, LazyBinding>}
+ */
+function advance_statement_var_loop_bindings(node, lazy_bindings) {
+	if (!node.metadata?.has_lazy_var_loop_descendants) return lazy_bindings;
+
+	/** @type {Map<string, LazyBinding>} */
+	const statement_bindings = new Map();
+	collect_statement_var_loop_bindings(node, statement_bindings);
+	return statement_bindings.size > 0
+		? new Map([...lazy_bindings, ...statement_bindings])
+		: lazy_bindings;
+}
+
+/**
  * Rewrite a statement list in source order, installing lazy `var` loop
  * bindings only after the statement that establishes them. The mapping then
  * remains visible to subsequent statements in the current var environment.
@@ -796,12 +818,7 @@ function transform_statement_list(statements, lazy_bindings, has_lazy_var_loop_d
 		if (transformed !== statement) changed = true;
 
 		if (has_lazy_var_loop_descendants && statement.metadata?.has_lazy_var_loop_descendants) {
-			/** @type {Map<string, LazyBinding>} */
-			const statement_bindings = new Map();
-			collect_statement_var_loop_bindings(statement, statement_bindings);
-			if (statement_bindings.size > 0) {
-				effective_bindings = new Map([...effective_bindings, ...statement_bindings]);
-			}
+			effective_bindings = advance_statement_var_loop_bindings(statement, effective_bindings);
 		}
 
 		return transformed;
@@ -993,6 +1010,60 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 			shadowed.size > 0 ? remove_shadowed(lazy_bindings, shadowed) : lazy_bindings;
 		const new_body = apply_lazy_transforms_to_slot(node.body, effective_bindings);
 		if (new_body !== node.body) return rebuild(node, { body: new_body });
+		return node;
+	}
+
+	if (node.type === 'DoWhileStatement') {
+		const new_body = apply_lazy_transforms_to_slot(node.body, lazy_bindings);
+		const test_bindings = advance_statement_var_loop_bindings(node.body, lazy_bindings);
+		const new_test = apply_lazy_transforms_to_slot(node.test, test_bindings);
+		if (new_body !== node.body || new_test !== node.test) {
+			return rebuild(node, { body: new_body, test: new_test });
+		}
+		return node;
+	}
+
+	if (node.type === 'IfStatement') {
+		const new_test = apply_lazy_transforms_to_slot(node.test, lazy_bindings);
+		const new_consequent = apply_lazy_transforms_to_slot(node.consequent, lazy_bindings);
+		const alternate_bindings = advance_statement_var_loop_bindings(node.consequent, lazy_bindings);
+		const new_alternate =
+			node.alternate && apply_lazy_transforms_to_slot(node.alternate, alternate_bindings);
+		if (
+			new_test !== node.test ||
+			new_consequent !== node.consequent ||
+			new_alternate !== node.alternate
+		) {
+			return rebuild(node, {
+				test: new_test,
+				consequent: new_consequent,
+				alternate: new_alternate,
+			});
+		}
+		return node;
+	}
+
+	if (node.type === 'TryStatement') {
+		const new_block = apply_lazy_transforms_to_slot(node.block, lazy_bindings);
+		const handler_bindings = advance_statement_var_loop_bindings(node.block, lazy_bindings);
+		const new_handler =
+			node.handler && apply_lazy_transforms_to_slot(node.handler, handler_bindings);
+		const finalizer_bindings = node.handler
+			? advance_statement_var_loop_bindings(node.handler, handler_bindings)
+			: handler_bindings;
+		const new_finalizer =
+			node.finalizer && apply_lazy_transforms_to_slot(node.finalizer, finalizer_bindings);
+		if (
+			new_block !== node.block ||
+			new_handler !== node.handler ||
+			new_finalizer !== node.finalizer
+		) {
+			return rebuild(node, {
+				block: new_block,
+				handler: new_handler,
+				finalizer: new_finalizer,
+			});
+		}
 		return node;
 	}
 

--- a/packages/tsrx/src/transform/segments.js
+++ b/packages/tsrx/src/transform/segments.js
@@ -1477,10 +1477,23 @@ export function convert_source_map_to_mappings(
 				if (node.type === 'AssignmentPattern') {
 					// We need a mapping for the whole AssignmentPattern for diagnostics
 					// Only enable diagnostic verification here to avoid duplicate mappings
-					// that can cause things like double definitions
-					mappings.push(
-						get_mapping_from_node(node, src_to_gen_map, gen_line_offsets, mapping_data_verify_only),
-					);
+					// that can cause things like double definitions. A type-only lazy
+					// pattern drops its leading `&`, so there is no generated source-map
+					// position for the AssignmentPattern's authored start; its child
+					// mappings still provide diagnostics for the emitted pattern/default.
+					if (
+						(node.left.type !== 'ObjectPattern' && node.left.type !== 'ArrayPattern') ||
+						!node.left.lazy
+					) {
+						mappings.push(
+							get_mapping_from_node(
+								node,
+								src_to_gen_map,
+								gen_line_offsets,
+								mapping_data_verify_only,
+							),
+						);
+					}
 				}
 
 				return;

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1184,6 +1184,39 @@ export function runSharedLazyLoopTests({ compile, name }) {
 			expect(code).toMatch(/}\s*return __lazy1\.value/);
 		});
 
+		it('advances lazy var loop bindings through later compound-statement slots', () => {
+			const { code } = compile(
+				`export function repeat(items) {
+					do {
+						for (var &{ value } of items) consume(value);
+					} while (value);
+				}
+				export function branch(ready, items) {
+					if (ready) {
+						for (var &{ value } of items) consume(value);
+					} else consume(value);
+				}
+				export function recover(items) {
+					try {
+						for (var &{ value } of items) consume(value);
+					} catch {
+						consume(value);
+						for (var &{ recovered } of items) consume(recovered);
+					} finally {
+						consume(value, recovered);
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toMatch(/}\s*while \(__lazy0\.value\)/);
+			expect(code).toMatch(/}\s*else consume\(__lazy1\.value\)/);
+			expect(code).toMatch(/}\s*catch \{\s*consume\(__lazy2\.value\)/);
+			expect(code).toMatch(/for \(var __lazy3 of items\) consume\(__lazy3\.recovered\)/);
+			expect(code).toMatch(/}\s*finally \{\s*consume\(__lazy2\.value, __lazy3\.recovered\)/);
+			expect(virtual_parse_diagnostics(code), code).toEqual([]);
+		});
+
 		it('keeps classic-for var sources visible after nested control flow', () => {
 			const { code } = compile(
 				`export function count(ready, source, limit) {

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -87,6 +87,43 @@ export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, na
 			}
 		});
 
+		it('declares bare lazy loop targets in type-only output', () => {
+			const result = compile_to_volar_mappings(
+				`export function read(items, table) {
+					for (&{ value } of items) consume(value);
+					for ({ pair: &[first] } of items) consume(first);
+					for ([&{ key }] in table) consume(key);
+				}`,
+				'App.tsrx',
+				{ loose: true },
+			);
+
+			expect(result.errors).toEqual([]);
+			expect(result.code).toContain('for (const __lazy0 of items)');
+			expect(result.code).toContain('consume(__lazy0.value)');
+			expect(result.code).toMatch(/for \(const \{\s*pair:\s*__lazy1\s*\} of items\)/);
+			expect(result.code).toContain('consume(__lazy1[0])');
+			expect(result.code).toMatch(/for \(const \[__lazy2\] in table\)/);
+			expect(result.code).toContain('consume(__lazy2.key)');
+			expect(virtual_parse_diagnostics(result.code), result.code).toEqual([]);
+		});
+
+		it('maps nested lazy loop targets with defaults in type-only output', () => {
+			const result = compile_to_volar_mappings(
+				`export function read(items, fallback) {
+					for (const { pair: &[value] = fallback } of items) consume(value);
+					for (let { pair: &[other] = fallback } = items[0]; false;) consume(other);
+				}`,
+				'App.tsrx',
+				{ loose: true },
+			);
+
+			expect(result.errors).toEqual([]);
+			expect(result.code).toContain('pair: [value] = fallback');
+			expect(result.code).toContain('pair: [other] = fallback');
+			expect(virtual_parse_diagnostics(result.code), result.code).toEqual([]);
+		});
+
 		it('preserves deferred imports in type-only output', () => {
 			const result = compile_to_volar_mappings(
 				`import defer * as feature from './feature.js';
@@ -1098,6 +1135,55 @@ export function runSharedLazyLoopTests({ compile, name }) {
 			expect(code).toContain('consume(before, __lazy3.value)');
 		});
 
+		it('advances same-name lazy var loops in source order', () => {
+			const { code } = compile(
+				`export function read(&{ item }) {
+					consume(item);
+					for (var &{ item } of item.children) consume(item);
+					consume(item);
+					for (var &{ item } of item.children) consume(item);
+					for (var &{ item } = item.next; false;) consume(item);
+					return item;
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function read(__lazy0)');
+			expect(code).toMatch(
+				/consume\(__lazy0\.item\);\s*for \(var __lazy1 of __lazy0\.item\.children\)/,
+			);
+			expect(code).toMatch(
+				/consume\(__lazy1\.item\);\s*consume\(__lazy1\.item\);\s*for \(var __lazy2 of __lazy1\.item\.children\)/,
+			);
+			expect(code).toMatch(
+				/consume\(__lazy2\.item\);\s*for \(var __lazy3 = __lazy2\.item\.next; false; \)\s*consume\(__lazy3\.item\)/,
+			);
+			expect(code).toMatch(/return __lazy3\.item/);
+		});
+
+		it('advances lazy var loop bindings through nested control flow', () => {
+			const { code } = compile(
+				`export function read(&{ value }, ready, items) {
+					consume(value);
+					if (ready) {
+						consume(value);
+						for (var &{ value } of items) consume(value);
+						consume(value);
+					}
+					return value;
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toMatch(
+				/consume\(__lazy0\.value\);\s*if \(ready\) \{\s*consume\(__lazy0\.value\)/,
+			);
+			expect(code).toMatch(
+				/for \(var __lazy1 of items\)\s*consume\(__lazy1\.value\);\s*consume\(__lazy1\.value\)/,
+			);
+			expect(code).toMatch(/}\s*return __lazy1\.value/);
+		});
+
 		it('keeps classic-for var sources visible after nested control flow', () => {
 			const { code } = compile(
 				`export function count(ready, source, limit) {
@@ -1127,6 +1213,28 @@ export function runSharedLazyLoopTests({ compile, name }) {
 			expect(code).toContain('for (const __lazy1 of __lazy0.item.children)');
 			expect(code).toContain('consume(__lazy1.item)');
 			expect(code).toContain('return __lazy0.item');
+		});
+
+		it('rewrites outer lazy names in loop target computed keys and defaults', () => {
+			const { code } = compile(
+				`export function read(&{ key, fallback }, items, source) {
+					for (const &{ [key]: value } of items) consume(value);
+					for (const { pair: &[nested] = fallback, [key]: current = fallback } of items) {
+						consume(nested, current);
+					}
+					for (let { pair: &[classic] = fallback, [key]: current = fallback } = source; false;) {
+						consume(classic, current);
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('for (const __lazy1 of items) consume(__lazy1[__lazy0.key])');
+			expect(code).toContain('pair: __lazy2 = __lazy0.fallback');
+			expect(code).toContain('[__lazy0.key]: current = __lazy0.fallback');
+			expect(code).toContain('pair: __lazy3 = __lazy0.fallback');
+			expect(count_substring(code, '[__lazy0.key]: current = __lazy0.fallback')).toBe(2);
+			expect(virtual_parse_diagnostics(code), code).toEqual([]);
 		});
 
 		it('shadows outer lazy names with non-lazy siblings in bare loop targets', () => {


### PR DESCRIPTION
## Summary

- Declare bare lazy `for...of` / `for...in` targets in type-only and editor output.
- Advance lazy `var` loop bindings in source order so pre-loop reads and iterable expressions retain the incoming binding.
- Rewrite computed keys and default RHS expressions while a loop target is established.
- Keep Volar mappings valid when type-only output drops a lazy pattern's leading `&`.

Follow-up to #37 and #12. This addresses the three unresolved Cursor review threads left after #37 merged.

## Validation

- Affected React, Preact, Solid, and Vue compiler suites: 4 files passed; 1,673 tests passed; 33 skipped.
- All 30 workspace typecheck projects passed.
- Repository-wide Prettier check passed.
- Full Vitest run reached 68 passing files and 3,234 passing tests; untouched environment/setup failures remain in ESLint parser workspace linkage, unbuilt TypeScript-plugin fixture artifacts, and MCP localhost binding (`EPERM`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core lazy-transform scoping and evaluation order across loops and compound statements; regressions would show up as wrong `__lazyN` references rather than auth or data risks.
> 
> **Overview**
> Fixes lazy destructuring in JavaScript loop headers so generated code and editor/type-only output match real binding and evaluation order.
> 
> The lazy transform now **installs function-scoped `var` loop bindings statement-by-statement** instead of hoisting them for the whole function/block. Later slots (subsequent statements, `do…while` tests, `if` alternates, `try`/`catch`/`finally`, switch case consequents) see bindings only after the statement that introduced them, so repeated `var` lazy loops and post-loop reads resolve to the correct `__lazyN`.
> 
> **Loop binding targets** get a new `transform_loop_pattern_expressions` pass before pattern replacement: computed keys and default initializer expressions use the lazy environment active when the header is set up, while bare `for…of` / `for…in` lazy targets still normalize to per-iteration `const` declarations for type-only output.
> 
> **Volar/source maps** skip a whole-`AssignmentPattern` mapping when a type-only lazy object/array pattern drops its leading `&`, avoiding invalid positions while child mappings still cover defaults and inner pattern.
> 
> Shared compile tests cover type-only loop lowering, `var` ordering through control flow, and computed keys/defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9e4ce3b5b9c660b0430b80ca136b2d28073122a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->