### PR TITLE
chore(intellij-plugin): add dedicated publishing job

### DIFF
--- a/.github/workflows/intellij-plugin.yml
+++ b/.github/workflows/intellij-plugin.yml
@@ -9,6 +9,7 @@ on:
       - "scripts/regenerate-textmate.js"
       - "scripts/sync-intellij-plugin-version.js"
       - ".github/workflows/intellij-plugin.yml"
+      - ".github/workflows/publish-intellij-plugin.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/publish-intellij-plugin.yml
+++ b/.github/workflows/publish-intellij-plugin.yml
@@ -1,0 +1,127 @@
+name: Publish IntelliJ Plugin
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Expected IntelliJ plugin version
+        required: true
+        type: string
+    secrets:
+      JETBRAINS_MARKETPLACE_CERTIFICATE_CHAIN:
+        required: true
+      JETBRAINS_MARKETPLACE_PRIVATE_KEY:
+        required: true
+      JETBRAINS_MARKETPLACE_PRIVATE_KEY_PASSWORD:
+        required: true
+      JETBRAINS_MARKETPLACE_PUBLISH_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      version:
+        description: IntelliJ plugin version to publish from main
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Build, sign, and publish
+    if: >-
+      github.repository == 'tsrx-org/tsrx' &&
+      github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    environment: jetbrains-marketplace
+    concurrency:
+      group: intellij-plugin-publish
+      cancel-in-progress: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+
+      - name: Setup Java 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle cache
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
+
+      - name: Validate requested plugin version
+        env:
+          EXPECTED_VERSION: ${{ inputs.version }}
+        run: |
+          version="$(node -p "require('./packages/intellij-plugin/package.json').version")"
+          if [[ "$version" != "$EXPECTED_VERSION" ]]; then
+            echo "Requested IntelliJ plugin version $EXPECTED_VERSION, but main contains $version." >&2
+            exit 1
+          fi
+
+      - name: Verify synchronized versions
+        run: node scripts/sync-intellij-plugin-version.js --check
+
+      - name: Verify the published language-server package
+        run: node packages/intellij-plugin/scripts/verify-language-server-release.mjs
+
+      - name: Test, build, and verify the plugin
+        run: >-
+          packages/intellij-plugin/gradlew -p packages/intellij-plugin
+          test verifyPluginProjectConfiguration buildPlugin verifyPluginStructure verifyPlugin
+
+      - name: Validate signing credentials
+        env:
+          CERTIFICATE_CHAIN: ${{ secrets.JETBRAINS_MARKETPLACE_CERTIFICATE_CHAIN }}
+          PRIVATE_KEY: ${{ secrets.JETBRAINS_MARKETPLACE_PRIVATE_KEY }}
+          PRIVATE_KEY_PASSWORD: ${{ secrets.JETBRAINS_MARKETPLACE_PRIVATE_KEY_PASSWORD }}
+        run: |
+          for required in CERTIFICATE_CHAIN PRIVATE_KEY PRIVATE_KEY_PASSWORD; do
+            if [[ -z "${!required}" ]]; then
+              echo "Missing JetBrains Marketplace secret: JETBRAINS_MARKETPLACE_$required" >&2
+              exit 1
+            fi
+          done
+
+      - name: Sign plugin archive
+        id: sign
+        env:
+          CERTIFICATE_CHAIN: ${{ secrets.JETBRAINS_MARKETPLACE_CERTIFICATE_CHAIN }}
+          PRIVATE_KEY: ${{ secrets.JETBRAINS_MARKETPLACE_PRIVATE_KEY }}
+          PRIVATE_KEY_PASSWORD: ${{ secrets.JETBRAINS_MARKETPLACE_PRIVATE_KEY_PASSWORD }}
+        run: packages/intellij-plugin/gradlew -p packages/intellij-plugin signPlugin
+
+      - name: Validate Marketplace credential
+        env:
+          PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_PUBLISH_TOKEN }}
+        run: |
+          test -n "$PUBLISH_TOKEN" || {
+            echo "Missing JetBrains Marketplace secret: JETBRAINS_MARKETPLACE_PUBLISH_TOKEN" >&2
+            exit 1
+          }
+
+      - name: Publish Marketplace update
+        env:
+          CERTIFICATE_CHAIN: ${{ secrets.JETBRAINS_MARKETPLACE_CERTIFICATE_CHAIN }}
+          PRIVATE_KEY: ${{ secrets.JETBRAINS_MARKETPLACE_PRIVATE_KEY }}
+          PRIVATE_KEY_PASSWORD: ${{ secrets.JETBRAINS_MARKETPLACE_PRIVATE_KEY_PASSWORD }}
+          PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_PUBLISH_TOKEN }}
+        run: packages/intellij-plugin/gradlew -p packages/intellij-plugin publishPlugin
+
+      - name: Upload signed plugin archive
+        if: always() && steps.sign.outcome == 'success'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: intellij-plugin-signed-${{ github.sha }}
+          path: packages/intellij-plugin/build/distributions/*-signed.zip
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
       cancel-in-progress: false
     outputs:
       intellij-version-changed: ${{ steps.intellij.outputs.changed }}
+      intellij-version: ${{ steps.intellij.outputs.version }}
       zed-version-changed: ${{ steps.zed.outputs.changed }}
       zed-tag: ${{ steps.zed.outputs.tag }}
     steps:
@@ -60,6 +61,8 @@ jobs:
             echo "Could not determine the previous and current IntelliJ plugin versions." >&2
             exit 1
           fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
           if [ "$previous_version" = "$version" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -167,85 +170,11 @@ jobs:
       needs.publish.outputs.intellij-version-changed == 'true'
     permissions:
       contents: read
-    runs-on: ubuntu-latest
-    environment: jetbrains-marketplace
-    concurrency:
-      group: intellij-plugin-publish
-      cancel-in-progress: false
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          persist-credentials: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-        with:
-          node-version: 24
-
-      - name: Setup Java 21
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
-        with:
-          distribution: temurin
-          java-version: 21
-
-      - name: Setup Gradle cache
-        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
-
-      - name: Verify synchronized versions
-        run: node scripts/sync-intellij-plugin-version.js --check
-
-      - name: Verify the published language-server package
-        run: node packages/intellij-plugin/scripts/verify-language-server-release.mjs
-
-      - name: Test, build, and verify the plugin
-        run: >-
-          packages/intellij-plugin/gradlew -p packages/intellij-plugin
-          test verifyPluginProjectConfiguration buildPlugin verifyPluginStructure verifyPlugin
-
-      - name: Validate signing credentials
-        env:
-          CERTIFICATE_CHAIN: ${{ secrets.JETBRAINS_MARKETPLACE_CERTIFICATE_CHAIN }}
-          PRIVATE_KEY: ${{ secrets.JETBRAINS_MARKETPLACE_PRIVATE_KEY }}
-          PRIVATE_KEY_PASSWORD: ${{ secrets.JETBRAINS_MARKETPLACE_PRIVATE_KEY_PASSWORD }}
-        run: |
-          for required in CERTIFICATE_CHAIN PRIVATE_KEY PRIVATE_KEY_PASSWORD; do
-            if [[ -z "${!required}" ]]; then
-              echo "Missing JetBrains Marketplace secret: JETBRAINS_MARKETPLACE_$required" >&2
-              exit 1
-            fi
-          done
-
-      - name: Sign plugin archive
-        id: sign
-        env:
-          CERTIFICATE_CHAIN: ${{ secrets.JETBRAINS_MARKETPLACE_CERTIFICATE_CHAIN }}
-          PRIVATE_KEY: ${{ secrets.JETBRAINS_MARKETPLACE_PRIVATE_KEY }}
-          PRIVATE_KEY_PASSWORD: ${{ secrets.JETBRAINS_MARKETPLACE_PRIVATE_KEY_PASSWORD }}
-        run: packages/intellij-plugin/gradlew -p packages/intellij-plugin signPlugin
-
-      - name: Validate Marketplace credential
-        env:
-          PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_PUBLISH_TOKEN }}
-        run: |
-          test -n "$PUBLISH_TOKEN" || {
-            echo "Missing jetbrains-marketplace secret: JETBRAINS_MARKETPLACE_PUBLISH_TOKEN" >&2
-            exit 1
-          }
-
-      - name: Publish Marketplace update
-        env:
-          CERTIFICATE_CHAIN: ${{ secrets.JETBRAINS_MARKETPLACE_CERTIFICATE_CHAIN }}
-          PRIVATE_KEY: ${{ secrets.JETBRAINS_MARKETPLACE_PRIVATE_KEY }}
-          PRIVATE_KEY_PASSWORD: ${{ secrets.JETBRAINS_MARKETPLACE_PRIVATE_KEY_PASSWORD }}
-          PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_PUBLISH_TOKEN }}
-        run: packages/intellij-plugin/gradlew -p packages/intellij-plugin publishPlugin
-
-      - name: Upload signed plugin archive
-        if: always() && steps.sign.outcome == 'success'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: intellij-plugin-signed-${{ github.sha }}
-          path: packages/intellij-plugin/build/distributions/*-signed.zip
-          if-no-files-found: error
-          retention-days: 30
+    uses: ./.github/workflows/publish-intellij-plugin.yml
+    with:
+      version: ${{ needs.publish.outputs.intellij-version }}
+    secrets:
+      JETBRAINS_MARKETPLACE_CERTIFICATE_CHAIN: ${{ secrets.JETBRAINS_MARKETPLACE_CERTIFICATE_CHAIN }}
+      JETBRAINS_MARKETPLACE_PRIVATE_KEY: ${{ secrets.JETBRAINS_MARKETPLACE_PRIVATE_KEY }}
+      JETBRAINS_MARKETPLACE_PRIVATE_KEY_PASSWORD: ${{ secrets.JETBRAINS_MARKETPLACE_PRIVATE_KEY_PASSWORD }}
+      JETBRAINS_MARKETPLACE_PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_PUBLISH_TOKEN }}

--- a/packages/intellij-plugin/DEVELOPMENT.md
+++ b/packages/intellij-plugin/DEVELOPMENT.md
@@ -52,12 +52,24 @@ The plugin XML ID is `tsrx.intellij-plugin`. The deleted third-party listing use
 a different ID and is intentionally not reused.
 
 Changesets owns the plugin version. When the **Version Packages** commit changes
-`packages/intellij-plugin/package.json`, the conditional IntelliJ job in
-`.github/workflows/publish.yml` waits for the repository's npm publication job,
-then repeats the release checks, signs the archive, and publishes the update to
-Marketplace. The initial `0.0.82` submission was uploaded manually; the workflow
-is only responsible for later versions. It always retains the signed ZIP when
-signing succeeds, including when Marketplace rejects the upload.
+`packages/intellij-plugin/package.json`, `.github/workflows/publish.yml` waits for
+the repository's npm publication job, then calls the reusable
+`.github/workflows/publish-intellij-plugin.yml` workflow. The dedicated workflow
+repeats the release checks, signs the archive, and publishes the Marketplace
+update. The initial `0.0.82` submission was uploaded manually; the workflow is
+only responsible for later versions. It always retains the signed ZIP when signing
+succeeds, including when Marketplace rejects the upload.
+
+For a Marketplace-only retry, manually dispatch the dedicated workflow with the
+version currently committed on `main`:
+
+```sh
+gh workflow run publish-intellij-plugin.yml --repo tsrx-org/tsrx --ref main \
+  -f version="$(node -p "require('./packages/intellij-plugin/package.json').version")"
+```
+
+This path does not invoke the npm or Zed publishing jobs. The expected-version
+input must exactly match `packages/intellij-plugin/package.json` on `main`.
 
 Configure `JETBRAINS_MARKETPLACE_CERTIFICATE_CHAIN`,
 `JETBRAINS_MARKETPLACE_PRIVATE_KEY`, `JETBRAINS_MARKETPLACE_PRIVATE_KEY_PASSWORD`,

--- a/packages/intellij-plugin/tests/package.test.js
+++ b/packages/intellij-plugin/tests/package.test.js
@@ -150,8 +150,12 @@ describe('@tsrx/intellij-plugin release contract', () => {
 		expect(gradle).not.toContain('advertisedProductTypes');
 	});
 
-	it('publishes in one Changesets-gated job after npm publication', () => {
+	it('publishes through an isolated reusable workflow after npm publication', () => {
 		const workflow = readFileSync(resolve(repository_dir, '.github/workflows/publish.yml'), 'utf8');
+		const intellij_workflow = readFileSync(
+			resolve(repository_dir, '.github/workflows/publish-intellij-plugin.yml'),
+			'utf8',
+		);
 		const publish_job_start = workflow.indexOf('  publish:');
 		const zed_job_start = workflow.indexOf('  publish-zed:');
 		const intellij_job_start = workflow.indexOf('  publish-intellij-plugin:');
@@ -160,10 +164,10 @@ describe('@tsrx/intellij-plugin release contract', () => {
 		const zed_job = workflow.slice(zed_job_start, intellij_job_start);
 		const intellij_job = workflow.slice(intellij_job_start);
 
-		expect(intellij_job.match(/^    runs-on:/gm)).toHaveLength(1);
 		expect(workflow).toContain("contains(github.event.head_commit.message, 'Version Packages')");
 		expect(workflow).toContain('packages/intellij-plugin/package.json');
 		expect(workflow).toContain('intellij-version-changed: ${{ steps.intellij.outputs.changed }}');
+		expect(workflow).toContain('intellij-version: ${{ steps.intellij.outputs.version }}');
 		expect(workflow_header).not.toContain('concurrency:');
 		expect(publish_job).toContain('group: npm-publish');
 		expect(publish_job).not.toContain('Submit Zed extension update');
@@ -172,23 +176,41 @@ describe('@tsrx/intellij-plugin release contract', () => {
 		expect(intellij_job).toContain('needs: publish');
 		expect(intellij_job).toContain("needs.publish.result == 'success'");
 		expect(intellij_job).toContain("needs.publish.outputs.intellij-version-changed == 'true'");
-		expect(intellij_job).toContain('environment: jetbrains-marketplace');
-		expect(intellij_job).toContain('group: intellij-plugin-publish');
-		expect(intellij_job).toContain('verify-language-server-release.mjs');
-		expect(intellij_job).toContain('signPlugin');
-		expect(intellij_job).toContain('publishPlugin');
+		expect(intellij_job).toContain('uses: ./.github/workflows/publish-intellij-plugin.yml');
+		expect(intellij_job).toContain('version: ${{ needs.publish.outputs.intellij-version }}');
 		expect(intellij_job).toContain('secrets.JETBRAINS_MARKETPLACE_CERTIFICATE_CHAIN');
 		expect(intellij_job).toContain('secrets.JETBRAINS_MARKETPLACE_PRIVATE_KEY');
 		expect(intellij_job).toContain('secrets.JETBRAINS_MARKETPLACE_PRIVATE_KEY_PASSWORD');
 		expect(intellij_job).toContain('secrets.JETBRAINS_MARKETPLACE_PUBLISH_TOKEN');
-		expect(intellij_job).toContain('Upload signed plugin archive');
-		expect(intellij_job).not.toContain('secrets.CERTIFICATE_CHAIN');
-		expect(intellij_job).not.toContain('secrets.PRIVATE_KEY');
-		expect(intellij_job).not.toContain('secrets.PRIVATE_KEY_PASSWORD');
-		expect(intellij_job).not.toContain('secrets.PUBLISH_TOKEN');
-		expect(intellij_job).not.toContain('verify-marketplace-state.mjs');
-		expect(intellij_job).not.toContain('steps.marketplace.outputs');
+		expect(intellij_job).not.toContain('secrets: inherit');
+		expect(intellij_job).not.toContain('runs-on:');
 		expect(intellij_job).not.toMatch(/^\s*uses: (?!\.\/).*@v\d+/m);
+
+		expect(intellij_workflow).toContain('workflow_call:');
+		expect(intellij_workflow).toContain('workflow_dispatch:');
+		expect(intellij_workflow).toContain("github.ref == 'refs/heads/main'");
+		expect(intellij_workflow).toContain('EXPECTED_VERSION: ${{ inputs.version }}');
+		expect(intellij_workflow.match(/^    runs-on:/gm)).toHaveLength(1);
+		expect(intellij_workflow).toContain('environment: jetbrains-marketplace');
+		expect(intellij_workflow).toContain('group: intellij-plugin-publish');
+		expect(intellij_workflow).toContain('verify-language-server-release.mjs');
+		expect(intellij_workflow).toContain('signPlugin');
+		expect(intellij_workflow).toContain('publishPlugin');
+		expect(intellij_workflow).toContain('secrets.JETBRAINS_MARKETPLACE_CERTIFICATE_CHAIN');
+		expect(intellij_workflow).toContain('secrets.JETBRAINS_MARKETPLACE_PRIVATE_KEY');
+		expect(intellij_workflow).toContain('secrets.JETBRAINS_MARKETPLACE_PRIVATE_KEY_PASSWORD');
+		expect(intellij_workflow).toContain('secrets.JETBRAINS_MARKETPLACE_PUBLISH_TOKEN');
+		expect(intellij_workflow).toContain('Upload signed plugin archive');
+		expect(intellij_workflow).not.toContain('changesets/action');
+		expect(intellij_workflow).not.toContain('publish-zed');
+		expect(intellij_workflow).not.toContain('ZED_EXTENSION_TOKEN');
+		expect(intellij_workflow).not.toContain('secrets.CERTIFICATE_CHAIN');
+		expect(intellij_workflow).not.toContain('secrets.PRIVATE_KEY');
+		expect(intellij_workflow).not.toContain('secrets.PRIVATE_KEY_PASSWORD');
+		expect(intellij_workflow).not.toContain('secrets.PUBLISH_TOKEN');
+		expect(intellij_workflow).not.toContain('verify-marketplace-state.mjs');
+		expect(intellij_workflow).not.toContain('steps.marketplace.outputs');
+		expect(intellij_workflow).not.toMatch(/^\s*uses: (?!\.\/).*@v\d+/m);
 	});
 
 	it('accepts only the exact published language-server package and launcher', () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches release automation and JetBrains signing/publish credentials; behavior is mostly a refactor with a new manual retry path, so misconfigured version input or secret wiring could block or misfire publishes.
> 
> **Overview**
> **Moves JetBrains Marketplace build/sign/publish out of `publish.yml` into a dedicated reusable workflow** (`publish-intellij-plugin.yml`), callable after npm release or on its own.
> 
> The main **Publish** workflow still gates on a Version Packages bump and IntelliJ version change, but the `publish-intellij-plugin` job now only **`uses`** the new workflow and passes the detected **`intellij-version`** plus the four Marketplace secrets explicitly (not `secrets: inherit`).
> 
> The new workflow supports **`workflow_call`** and **`workflow_dispatch`**, restricts runs to **`main`** on **`tsrx-org/tsrx`**, and **fails if the `version` input does not match** `packages/intellij-plugin/package.json`—supporting **Marketplace-only retries** without npm/Zed jobs. PR verification path filters and release-contract tests/docs were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7bda08b3066a525afd0b4b5824a2bda9e4e6bfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->