### PR TITLE
fix(typescript-plugin): use bare default lib name in resolveConfig

### DIFF
--- a/.changeset/default-lib-bare-name.md
+++ b/.changeset/default-lib-bare-name.md
@@ -3,4 +3,4 @@
 '@tsrx/language-server': patch
 ---
 
-Fix the language server dropping the ES standard library when a project's `tsconfig.json` omits `lib`. The default lib entry was built from `CompilerHost#getDefaultLibFileName`, which returns an absolute path (then lower-cased), so TypeScript could not load `lib.esnext.full.d.ts` and globals such as `Array`, `Promise`, `Function`, `Exclude`, and `Pick` went missing — surfacing as bogus `unknown` inference and JSX attribute errors in `.tsrx` files. The entry is now the bare lib name from `ts.getDefaultLibFileName`.
+Fix the language server dropping the ES standard library when a project's `tsconfig.json` omits `lib`. Omitted library configuration is now left unset so TypeScript selects the target's default library through the active language-service host, while explicit `lib: []` and `noLib` configurations retain their intended semantics.

--- a/.changeset/default-lib-bare-name.md
+++ b/.changeset/default-lib-bare-name.md
@@ -1,0 +1,6 @@
+---
+'@tsrx/typescript-plugin': patch
+'@tsrx/language-server': patch
+---
+
+Fix the language server dropping the ES standard library when a project's `tsconfig.json` omits `lib`. The default lib entry was built from `CompilerHost#getDefaultLibFileName`, which returns an absolute path (then lower-cased), so TypeScript could not load `lib.esnext.full.d.ts` and globals such as `Array`, `Promise`, `Function`, `Exclude`, and `Pick` went missing — surfacing as bogus `unknown` inference and JSX attribute errors in `.tsrx` files. The entry is now the bare lib name from `ts.getDefaultLibFileName`.

--- a/packages/typescript-plugin/src/language.js
+++ b/packages/typescript-plugin/src/language.js
@@ -877,9 +877,13 @@ export const resolveConfig = (config) => {
 	);
 
 	if (normalizedLibs.size === 0) {
-		const host = ts.createCompilerHost(options);
-		const defaultLibFileName = host.getDefaultLibFileName(options).toLowerCase();
-		normalizedLibs.add(defaultLibFileName);
+		// `CompilerOptions.lib` takes bare lib names such as `lib.esnext.full.d.ts`.
+		// `CompilerHost#getDefaultLibFileName` returns an absolute path instead, which
+		// TypeScript cannot resolve as a lib entry (and lower-casing it also breaks the
+		// path on case-sensitive lookups), so the whole ES standard library silently
+		// dropped out of the checker — only the two DOM libs below survived.
+		const defaultLibFileName = normalizeLibName(ts.getDefaultLibFileName(options));
+		if (defaultLibFileName) normalizedLibs.add(defaultLibFileName);
 		normalizedLibs.add('lib.dom.d.ts');
 		normalizedLibs.add('lib.dom.iterable.d.ts');
 	}

--- a/packages/typescript-plugin/src/language.js
+++ b/packages/typescript-plugin/src/language.js
@@ -860,35 +860,9 @@ export const resolveConfig = (config) => {
 		options.target = ts.ScriptTarget.ESNext;
 	}
 
-	/** @param {string} libName */
-	const normalizeLibName = (libName) => {
-		if (typeof libName !== 'string' || libName.length === 0) {
-			return undefined;
-		}
-		const trimmed = libName.trim();
-		if (trimmed.startsWith('lib.')) {
-			return trimmed.toLowerCase();
-		}
-		return `lib.${trimmed.toLowerCase().replace(/\s+/g, '').replace(/_/g, '.')}\.d.ts`;
-	};
-
-	const normalizedLibs = new Set(
-		(options.lib ?? []).map(normalizeLibName).filter((lib) => typeof lib === 'string'),
-	);
-
-	if (normalizedLibs.size === 0) {
-		// `CompilerOptions.lib` takes bare lib names such as `lib.esnext.full.d.ts`.
-		// `CompilerHost#getDefaultLibFileName` returns an absolute path instead, which
-		// TypeScript cannot resolve as a lib entry (and lower-casing it also breaks the
-		// path on case-sensitive lookups), so the whole ES standard library silently
-		// dropped out of the checker — only the two DOM libs below survived.
-		const defaultLibFileName = normalizeLibName(ts.getDefaultLibFileName(options));
-		if (defaultLibFileName) normalizedLibs.add(defaultLibFileName);
-		normalizedLibs.add('lib.dom.d.ts');
-		normalizedLibs.add('lib.dom.iterable.d.ts');
-	}
-
-	options.lib = [...normalizedLibs];
+	// Leave `lib` unchanged. When omitted, TypeScript selects the target's
+	// default library through the active language-service host. `lib: []`
+	// and `noLib` must retain their distinct TypeScript semantics.
 
 	// Default typeRoots: automatically discover @types like tsserver.
 	if (!options.types) {

--- a/packages/typescript-plugin/tests/resolve-config.test.js
+++ b/packages/typescript-plugin/tests/resolve-config.test.js
@@ -1,5 +1,3 @@
-import fs from 'node:fs';
-import path from 'node:path';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 import { resolveConfig } from '../src/language.js';
@@ -29,32 +27,51 @@ function unresolved_global_types(options, source) {
 }
 
 describe('resolveConfig', () => {
-	it('fills in bare default lib names when `lib` is omitted', () => {
-		const { options } = resolveConfig({ options: { target: ts.ScriptTarget.ESNext } });
+	it('defaults the target while leaving lib selection to TypeScript', () => {
+		const { options } = resolveConfig({ options: { types: [] } });
 
-		expect(options.lib).toEqual(['lib.esnext.full.d.ts', 'lib.dom.d.ts', 'lib.dom.iterable.d.ts']);
+		expect(options.target).toBe(ts.ScriptTarget.ESNext);
+		expect(options.lib).toBeUndefined();
+		expect(ts.getDefaultLibFileName(options)).toBe('lib.esnext.full.d.ts');
 	});
 
-	it('derives the default lib from the configured target', () => {
-		const { options } = resolveConfig({ options: { target: ts.ScriptTarget.ES2020 } });
+	it('preserves explicitly configured libs', () => {
+		const libs = ['lib.es2022.d.ts', 'lib.dom.d.ts'];
+		const { options } = resolveConfig({ options: { lib: libs, types: [] } });
 
-		expect(options.lib?.[0]).toBe('lib.es2020.full.d.ts');
+		expect(options.lib).toEqual(libs);
 	});
 
-	it('never emits absolute paths or re-cased names as lib entries', () => {
-		const { options } = resolveConfig({ options: {} });
-		const lib_directory = path.dirname(ts.getDefaultLibFilePath(options));
+	it('preserves an explicitly empty lib list', () => {
+		const { options } = resolveConfig({ options: { lib: [], types: [] } });
 
-		for (const lib of options.lib ?? []) {
-			expect(path.isAbsolute(lib)).toBe(false);
-			expect(fs.existsSync(path.join(lib_directory, lib))).toBe(true);
-		}
+		expect(options.lib).toEqual([]);
 	});
 
-	it('keeps explicitly configured libs untouched', () => {
-		const { options } = resolveConfig({ options: { lib: ['lib.es2022.d.ts', 'DOM'] } });
+	it('does not synthesize lib when noLib is enabled', () => {
+		const { options } = resolveConfig({ options: { noLib: true, types: [] } });
 
-		expect(options.lib).toEqual(['lib.es2022.d.ts', 'lib.dom.d.ts']);
+		expect(options.noLib).toBe(true);
+		expect(options.lib).toBeUndefined();
+	});
+
+	it('allows TypeScript to load its valid ES5 default', () => {
+		const { options } = resolveConfig({
+			options: { target: ts.ScriptTarget.ES5, noEmit: true, types: [] },
+		});
+
+		expect(options.lib).toBeUndefined();
+		expect(
+			unresolved_global_types(
+				options,
+				[
+					'declare const a: Array<number>;',
+					'declare const f: Function;',
+					'declare const el: HTMLButtonElement;',
+					'export {};',
+				].join('\n'),
+			),
+		).toEqual([]);
 	});
 
 	it('leaves the ES standard library available to the checker', () => {

--- a/packages/typescript-plugin/tests/resolve-config.test.js
+++ b/packages/typescript-plugin/tests/resolve-config.test.js
@@ -1,0 +1,80 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import { resolveConfig } from '../src/language.js';
+
+/**
+ * Type-check `source` under `options` and return the global type names that
+ * failed to resolve. An empty array means the standard library is intact.
+ * @param {ts.CompilerOptions} options
+ * @param {string} source
+ */
+function unresolved_global_types(options, source) {
+	const file_name = '/virtual/probe.ts';
+	const host = ts.createCompilerHost(options, true);
+	const original_get_source_file = host.getSourceFile.bind(host);
+	host.getSourceFile = (name, language_version, on_error, should_create) =>
+		name === file_name
+			? ts.createSourceFile(name, source, language_version, true)
+			: original_get_source_file(name, language_version, on_error, should_create);
+	host.fileExists = (name) => name === file_name || ts.sys.fileExists(name);
+	host.readFile = (name) => (name === file_name ? source : ts.sys.readFile(name));
+
+	const program = ts.createProgram({ rootNames: [file_name], options, host });
+	return ts
+		.getPreEmitDiagnostics(program)
+		.filter((diagnostic) => diagnostic.code === 2304 || diagnostic.code === 2318)
+		.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'));
+}
+
+describe('resolveConfig', () => {
+	it('fills in bare default lib names when `lib` is omitted', () => {
+		const { options } = resolveConfig({ options: { target: ts.ScriptTarget.ESNext } });
+
+		expect(options.lib).toEqual(['lib.esnext.full.d.ts', 'lib.dom.d.ts', 'lib.dom.iterable.d.ts']);
+	});
+
+	it('derives the default lib from the configured target', () => {
+		const { options } = resolveConfig({ options: { target: ts.ScriptTarget.ES2020 } });
+
+		expect(options.lib?.[0]).toBe('lib.es2020.full.d.ts');
+	});
+
+	it('never emits absolute paths or re-cased names as lib entries', () => {
+		const { options } = resolveConfig({ options: {} });
+		const lib_directory = path.dirname(ts.getDefaultLibFilePath(options));
+
+		for (const lib of options.lib ?? []) {
+			expect(path.isAbsolute(lib)).toBe(false);
+			expect(fs.existsSync(path.join(lib_directory, lib))).toBe(true);
+		}
+	});
+
+	it('keeps explicitly configured libs untouched', () => {
+		const { options } = resolveConfig({ options: { lib: ['lib.es2022.d.ts', 'DOM'] } });
+
+		expect(options.lib).toEqual(['lib.es2022.d.ts', 'lib.dom.d.ts']);
+	});
+
+	it('leaves the ES standard library available to the checker', () => {
+		const { options } = resolveConfig({
+			options: { target: ts.ScriptTarget.ESNext, strict: true, noEmit: true, types: [] },
+		});
+
+		const unresolved = unresolved_global_types(
+			options,
+			[
+				'declare const a: Array<number>;',
+				'declare const p: Promise<void>;',
+				'declare const f: Function;',
+				'declare const e: Exclude<1 | 2, 2>;',
+				'declare const k: Pick<{ a: 1 }, "a">;',
+				'declare const el: HTMLButtonElement;',
+				'export {};',
+			].join('\n'),
+		);
+
+		expect(unresolved).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

When a project's `tsconfig.json` omits `lib`, `resolveConfig` (in `@tsrx/typescript-plugin`, used by `@tsrx/language-server`) fills in a default lib entry via `CompilerHost#getDefaultLibFileName(options).toLowerCase()`. That host method returns an **absolute path** (e.g. `/Users/me/.cursor/extensions/…/typescript/lib/lib.esnext.full.d.ts`), not a lib name, and lower-casing it turns `/Users` into `/users`. TypeScript can't load that as a `lib` entry, so `lib.esnext.full.d.ts` — and everything it references (`es5` … `esnext`) — silently never loads. Only the two hardcoded `lib.dom.*` entries survive.

The effect in the editor is confusing because the checker still has DOM types but no ES globals: `Array`, `Promise`, `Function`, `Exclude`, `Pick`, `Readonly`, `Record` are all "Cannot find name". In a Solid `.tsrx` component that shows up as:

- `createSignal(0)` inferring `Signal<unknown>` (inference through `Exclude<T, Function>` can't run without `Exclude`) → `Object is of type 'unknown'` on every `count()`
- `Properties<T>` from `@solidjs/web` collapsing into an index signature (its `PropKey` relies on `Pick`/`Readonly`) → `Type '{ children: {}; … }' is not assignable to type 'ButtonHTMLAttributes<HTMLButtonElement> & Properties<HTMLButtonElement>' … incompatible with index signature`

`tsrx-tsc` and the tsserver plugin path are unaffected (they don't go through `resolveConfig`), which is what made this look like a compiler/Solid-types problem rather than a lib problem.

Fix: use `ts.getDefaultLibFileName(options)` (bare name such as `lib.esnext.full.d.ts`) and pass it through the same `normalizeLibName` as user-supplied entries.

## Repro

Any project with `.tsrx` files whose `tsconfig.json` has no `lib`, on macOS (`/Users/...`) or Linux. Open a `.tsrx` file with the TSRX Syntax extension (2.0.80) and hover a `createSignal(0)` result, or add `declare const x: Exclude<1, 2>;` — reported as `Cannot find name 'Exclude'`. Adding an explicit `"lib": [...]` to the tsconfig makes it go away, which is the current workaround.

## Test plan

- [x] New `packages/typescript-plugin/tests/resolve-config.test.js` — fails 3/5 on `main` (absolute path leaks into `options.lib`), passes 5/5 with this change; also asserts every default lib entry exists in TypeScript's lib directory and that `Array`/`Promise`/`Function`/`Exclude`/`Pick`/`HTMLButtonElement` all resolve under the resolved options.
- [x] `vitest run packages/typescript-plugin packages/language-server` — 174/174 passing.
- [x] `prettier --check` on touched files; `node scripts/check-changesets.js` passes (patch bumps for `@tsrx/typescript-plugin` and `@tsrx/language-server`).
- [x] Verified against a real Solid + `.tsrx` project by driving the built language server over LSP: the four bogus diagnostics disappear and `Exclude`/`Array`/`Promise` resolve to `lib.es5.d.ts`+.

Made with [Cursor](https://cursor.com)