### PR TITLE
feat(compiler): opt-in dead-code elimination

### DIFF
--- a/.changeset/dead-code-elimination.md
+++ b/.changeset/dead-code-elimination.md
@@ -1,0 +1,30 @@
+---
+'@tsrx/core': patch
+'@tsrx/react': patch
+'@tsrx/preact': patch
+'@tsrx/solid': patch
+'@tsrx/vue': patch
+'@tsrx/vite-plugin-react': patch
+'@tsrx/vite-plugin-preact': patch
+'@tsrx/vite-plugin-solid': patch
+'@tsrx/vite-plugin-vue': patch
+'@tsrx/rspack-plugin-react': patch
+'@tsrx/rspack-plugin-preact': patch
+'@tsrx/rspack-plugin-solid': patch
+'@tsrx/rspack-plugin-vue': patch
+'@tsrx/turbopack-plugin-react': patch
+'@tsrx/bun-plugin-react': patch
+'@tsrx/bun-plugin-preact': patch
+'@tsrx/bun-plugin-solid': patch
+'@tsrx/bun-plugin-vue': patch
+---
+
+Dead code can now be removed from compiled output.
+Pass `optimize: true` to a target compiler or to any Vite, Rspack, Turbopack, or
+Bun integration to turn it on. It is off by default.
+
+The pass folds statically known expressions and drops the code they prove dead.
+This covers `@if` branches with a false test, `@switch` cases that cannot match,
+`@for` over an empty iterable, statements after a `return`, and declarations
+nothing reads. Editor tooling never runs it, so hovers and diagnostics still
+match the authored source.

--- a/.changeset/dead-code-elimination.md
+++ b/.changeset/dead-code-elimination.md
@@ -19,13 +19,16 @@
 '@tsrx/bun-plugin-vue': patch
 ---
 
-Dead code can now be removed from compiled output.
-Pass `optimize: true` to a target compiler or to any Vite, Rspack, Turbopack, or
-Bun integration to turn it on. It is off by default.
+TSRX control-flow branches that can never render are now removed from compiled
+output. Pass `optimize: true` to a target compiler or to any Vite, Rspack,
+Turbopack, or Bun integration to turn it on. It is off by default.
 
-The pass folds statically known expressions and drops the code they prove dead.
-This covers `@if` branches with a false test, `@switch` cases that cannot match,
-`@for` over an empty iterable, statements after a `return`, and declarations
-nothing reads. It also picks the arm of a `?:`, `&&`, `||`, or `??` whose test
-is always truthy, keeping the test when it still has to run. Editor tooling never runs it, so hovers and diagnostics still
-match the authored source.
+The pass only rewrites the TSRX keyword directives. It drops `@if` and `@else if`
+branches with a provably false test, selects the matching case of a `@switch`
+with a known discriminant, and removes a `@for` over an empty iterable or renders
+its `@empty` clause instead.
+
+To decide a test it reads constants from the module, so `@if (SHOW)` can be
+decided from a `const SHOW = false`. It does not fold expressions, remove unused
+declarations, drop unreachable statements, or touch plain JavaScript. Editor
+tooling never runs it, so hovers and diagnostics still match the authored source.

--- a/.changeset/dead-code-elimination.md
+++ b/.changeset/dead-code-elimination.md
@@ -26,5 +26,6 @@ Bun integration to turn it on. It is off by default.
 The pass folds statically known expressions and drops the code they prove dead.
 This covers `@if` branches with a false test, `@switch` cases that cannot match,
 `@for` over an empty iterable, statements after a `return`, and declarations
-nothing reads. Editor tooling never runs it, so hovers and diagnostics still
+nothing reads. It also picks the arm of a `?:`, `&&`, `||`, or `??` whose test
+is always truthy, keeping the test when it still has to run. Editor tooling never runs it, so hovers and diagnostics still
 match the authored source.

--- a/packages/bun-plugin-preact/src/index.js
+++ b/packages/bun-plugin-preact/src/index.js
@@ -15,6 +15,7 @@ const CSS_QUERY_PATTERN = /\?tsrx-css&lang\.css$/;
  * 	jsxImportSource?: string,
  * 	suspenseSource?: string,
  * 	runtimeImports?: RuntimeImportMode,
+ * 	optimize?: boolean,
  * 	emitCss?: boolean,
  * }} TsrxPreactBunPluginOptions
  */
@@ -96,6 +97,7 @@ export function tsrxPreact(options = {}) {
 	const compile_options = {
 		suspenseSource: options.suspenseSource,
 		runtimeImports: options.runtimeImports,
+		optimize: options.optimize,
 	};
 
 	/** @type {Map<string, string>} */

--- a/packages/bun-plugin-react/src/index.js
+++ b/packages/bun-plugin-react/src/index.js
@@ -15,6 +15,7 @@ const CSS_QUERY_PATTERN = /\?tsrx-css&lang\.css$/;
  * 	jsxImportSource?: string,
  * 	emitCss?: boolean,
  * 	runtimeImports?: RuntimeImportMode,
+ * 	optimize?: boolean,
  * }} TsrxReactBunPluginOptions
  */
 
@@ -92,7 +93,10 @@ function create_transpiler(jsx_import_source, target) {
 export function tsrxReact(options = {}) {
 	const jsx_import_source = options.jsxImportSource ?? 'react';
 	const emit_css = options.emitCss ?? true;
-	const compile_options = { runtimeImports: options.runtimeImports };
+	const compile_options = {
+		runtimeImports: options.runtimeImports,
+		optimize: options.optimize,
+	};
 
 	/** @type {Map<string, string>} */
 	const css_cache = new Map();

--- a/packages/bun-plugin-solid/src/index.js
+++ b/packages/bun-plugin-solid/src/index.js
@@ -21,6 +21,7 @@ const CSS_QUERY_PATTERN = /\?tsrx-css&lang\.css$/;
  * 	emitCss?: boolean,
  * 	solid?: object,
  * 	runtimeImports?: RuntimeImportMode,
+ * 	optimize?: boolean,
  * }} TsrxSolidBunPluginOptions
  */
 
@@ -101,7 +102,10 @@ async function transform_solid(source, file_path, solid_options) {
  */
 export function tsrxSolid(options = {}) {
 	const emit_css = options.emitCss ?? true;
-	const compile_options = { runtimeImports: options.runtimeImports };
+	const compile_options = {
+		runtimeImports: options.runtimeImports,
+		optimize: options.optimize,
+	};
 
 	/** @type {Map<string, string>} */
 	const css_cache = new Map();

--- a/packages/bun-plugin-vue/src/index.js
+++ b/packages/bun-plugin-vue/src/index.js
@@ -27,6 +27,7 @@ const DEFAULT_VAPOR_OPTIONS = {
  * 	exclude?: RegExp | RegExp[],
  * 	emitCss?: boolean,
  * 	runtimeImports?: RuntimeImportMode,
+ * 	optimize?: boolean,
  * 	vapor?: {
  * 		macros?: boolean | object,
  * 		compiler?: { runtimeModuleName?: string },
@@ -130,7 +131,10 @@ function resolve_vapor_options(options) {
 export function tsrxVue(options = {}) {
 	const emit_css = options.emitCss ?? true;
 	const vapor_options = resolve_vapor_options(options.vapor);
-	const compile_options = { runtimeImports: options.runtimeImports };
+	const compile_options = {
+		runtimeImports: options.runtimeImports,
+		optimize: options.optimize,
+	};
 
 	/** @type {Map<string, string>} */
 	const css_cache = new Map();

--- a/packages/rspack-plugin-preact/src/css-loader.js
+++ b/packages/rspack-plugin-preact/src/css-loader.js
@@ -9,7 +9,7 @@ import { compile } from '@tsrx/preact';
  * the scoped CSS emitted by its `<style>` block. Invoked when rspack resolves
  * the sibling `?tsrx-css&lang.css` import prepended by the JS loader.
  *
- * @this {LoaderContext<{ suspenseSource?: string, runtimeImports?: RuntimeImportMode }>}
+ * @this {LoaderContext<{ suspenseSource?: string, runtimeImports?: RuntimeImportMode, optimize?: boolean }>}
  * @param {string} source
  * @returns {void}
  */

--- a/packages/rspack-plugin-preact/src/index.js
+++ b/packages/rspack-plugin-preact/src/index.js
@@ -24,13 +24,14 @@ const CSS_QUERY_PATTERN = /tsrx-css/;
  */
 export class TsrxPreactRspackPlugin {
 	/**
-	 * @param {{ jsxImportSource?: string, suspenseSource?: string, runtimeImports?: RuntimeImportMode }} [options]
+	 * @param {{ jsxImportSource?: string, suspenseSource?: string, runtimeImports?: RuntimeImportMode, optimize?: boolean }} [options]
 	 */
 	constructor(options = {}) {
 		this.options = {
 			jsxImportSource: options.jsxImportSource ?? 'preact',
 			suspenseSource: options.suspenseSource,
 			runtimeImports: options.runtimeImports ?? 'compiler',
+			optimize: options.optimize,
 		};
 	}
 
@@ -88,6 +89,7 @@ export class TsrxPreactRspackPlugin {
 						options: {
 							suspenseSource: this.options.suspenseSource,
 							runtimeImports: this.options.runtimeImports,
+							optimize: this.options.optimize,
 						},
 					},
 				],
@@ -102,6 +104,7 @@ export class TsrxPreactRspackPlugin {
 						options: {
 							suspenseSource: this.options.suspenseSource,
 							runtimeImports: this.options.runtimeImports,
+							optimize: this.options.optimize,
 						},
 					},
 				],

--- a/packages/rspack-plugin-preact/src/js-loader.js
+++ b/packages/rspack-plugin-preact/src/js-loader.js
@@ -9,7 +9,7 @@ import { compile } from '@tsrx/preact';
  * prepends an `import` to the sibling virtual CSS module so rspack can
  * include the styles in the asset graph.
  *
- * @this {LoaderContext<{ suspenseSource?: string, runtimeImports?: RuntimeImportMode }>}
+ * @this {LoaderContext<{ suspenseSource?: string, runtimeImports?: RuntimeImportMode, optimize?: boolean }>}
  * @param {string} source
  * @returns {void}
  */

--- a/packages/rspack-plugin-react/src/css-loader.js
+++ b/packages/rspack-plugin-react/src/css-loader.js
@@ -9,7 +9,7 @@ import { compile } from '@tsrx/react';
  * the scoped CSS emitted by its `<style>` block. Invoked when rspack resolves
  * the sibling `?tsrx-css&lang.css` import prepended by the JS loader.
  *
- * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode }>}
+ * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode, optimize?: boolean }>}
  * @param {string} source
  * @returns {void}
  */

--- a/packages/rspack-plugin-react/src/index.js
+++ b/packages/rspack-plugin-react/src/index.js
@@ -24,12 +24,13 @@ const CSS_QUERY_PATTERN = /tsrx-css/;
  */
 export class TsrxReactRspackPlugin {
 	/**
-	 * @param {{ jsxImportSource?: string, runtimeImports?: RuntimeImportMode }} [options]
+	 * @param {{ jsxImportSource?: string, runtimeImports?: RuntimeImportMode, optimize?: boolean }} [options]
 	 */
 	constructor(options = {}) {
 		this.options = {
 			jsxImportSource: options.jsxImportSource ?? 'react',
 			runtimeImports: options.runtimeImports ?? 'compiler',
+			optimize: options.optimize,
 		};
 	}
 
@@ -86,6 +87,7 @@ export class TsrxReactRspackPlugin {
 						loader: JS_LOADER,
 						options: {
 							runtimeImports: this.options.runtimeImports,
+							optimize: this.options.optimize,
 						},
 					},
 				],
@@ -99,6 +101,7 @@ export class TsrxReactRspackPlugin {
 						loader: CSS_LOADER,
 						options: {
 							runtimeImports: this.options.runtimeImports,
+							optimize: this.options.optimize,
 						},
 					},
 				],

--- a/packages/rspack-plugin-react/src/js-loader.js
+++ b/packages/rspack-plugin-react/src/js-loader.js
@@ -9,7 +9,7 @@ import { compile } from '@tsrx/react';
  * prepends an `import` to the sibling virtual CSS module so rspack can
  * include the styles in the asset graph.
  *
- * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode }>}
+ * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode, optimize?: boolean }>}
  * @param {string} source
  * @returns {void}
  */

--- a/packages/rspack-plugin-solid/src/css-loader.js
+++ b/packages/rspack-plugin-solid/src/css-loader.js
@@ -9,7 +9,7 @@ import { compile } from '@tsrx/solid';
  * the scoped CSS emitted by its `<style>` block. Invoked when rspack resolves
  * the sibling `?tsrx-css&lang.css` import prepended by the JS loader.
  *
- * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode }>}
+ * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode, optimize?: boolean }>}
  * @param {string} source
  * @returns {void}
  */

--- a/packages/rspack-plugin-solid/src/index.js
+++ b/packages/rspack-plugin-solid/src/index.js
@@ -30,12 +30,13 @@ const CSS_QUERY_PATTERN = /tsrx-css/;
  */
 export class TsrxSolidRspackPlugin {
 	/**
-	 * @param {{ hot?: boolean, runtimeImports?: RuntimeImportMode }} [options]
+	 * @param {{ hot?: boolean, runtimeImports?: RuntimeImportMode, optimize?: boolean }} [options]
 	 */
 	constructor(options = {}) {
 		this.options = {
 			hot: options.hot,
 			runtimeImports: options.runtimeImports ?? 'compiler',
+			optimize: options.optimize,
 		};
 	}
 
@@ -96,6 +97,7 @@ export class TsrxSolidRspackPlugin {
 						loader: JS_LOADER,
 						options: {
 							runtimeImports: this.options.runtimeImports,
+							optimize: this.options.optimize,
 						},
 					},
 				],
@@ -109,6 +111,7 @@ export class TsrxSolidRspackPlugin {
 						loader: CSS_LOADER,
 						options: {
 							runtimeImports: this.options.runtimeImports,
+							optimize: this.options.optimize,
 						},
 					},
 				],

--- a/packages/rspack-plugin-solid/src/js-loader.js
+++ b/packages/rspack-plugin-solid/src/js-loader.js
@@ -9,7 +9,7 @@ import { compile } from '@tsrx/solid';
  * prepends an `import` to the sibling virtual CSS module so rspack can
  * include the styles in the asset graph.
  *
- * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode }>}
+ * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode, optimize?: boolean }>}
  * @param {string} source
  * @returns {void}
  */

--- a/packages/rspack-plugin-vue/src/css-loader.js
+++ b/packages/rspack-plugin-vue/src/css-loader.js
@@ -9,7 +9,7 @@ import { compile } from '@tsrx/vue';
  * scoped CSS emitted by its `<style>` block. Invoked when rspack resolves the
  * sibling `?tsrx-css&lang.css` import prepended by the JS loader.
  *
- * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode }>}
+ * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode, optimize?: boolean }>}
  * @param {string} source
  * @returns {void}
  */

--- a/packages/rspack-plugin-vue/src/index.js
+++ b/packages/rspack-plugin-vue/src/index.js
@@ -27,12 +27,13 @@ const SOURCE_EXTENSION_PATTERN = /\.[cm]?[jt]sx?$/;
  */
 export class TsrxVueRspackPlugin {
 	/**
-	 * @param {{ vapor?: { macros?: boolean | object, compiler?: { runtimeModuleName?: string } }, runtimeImports?: RuntimeImportMode }} [options]
+	 * @param {{ vapor?: { macros?: boolean | object, compiler?: { runtimeModuleName?: string } }, runtimeImports?: RuntimeImportMode, optimize?: boolean }} [options]
 	 */
 	constructor(options = {}) {
 		this.options = {
 			vapor: options.vapor,
 			runtimeImports: options.runtimeImports ?? 'compiler',
+			optimize: options.optimize,
 		};
 	}
 
@@ -96,6 +97,7 @@ export class TsrxVueRspackPlugin {
 						loader: JS_LOADER,
 						options: {
 							runtimeImports: this.options.runtimeImports,
+							optimize: this.options.optimize,
 						},
 					},
 				],
@@ -109,6 +111,7 @@ export class TsrxVueRspackPlugin {
 						loader: CSS_LOADER,
 						options: {
 							runtimeImports: this.options.runtimeImports,
+							optimize: this.options.optimize,
 						},
 					},
 				],

--- a/packages/rspack-plugin-vue/src/js-loader.js
+++ b/packages/rspack-plugin-vue/src/js-loader.js
@@ -9,7 +9,7 @@ import { compile } from '@tsrx/vue';
  * present, prepends an `import` to the sibling virtual CSS module so rspack can
  * include the styles in the asset graph.
  *
- * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode }>}
+ * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode, optimize?: boolean }>}
  * @param {string} source
  * @returns {void}
  */

--- a/packages/tsrx-preact/src/index.js
+++ b/packages/tsrx-preact/src/index.js
@@ -3,7 +3,13 @@
 /** @import { NonEmptyString } from '@tsrx/core/types/helpers' */
 /** @import { CompileOptions } from '../types/index' */
 
-import { analyzeTsrx, createVolarMappingsResult, dedupeMappings, parseModule } from '@tsrx/core';
+import {
+	analyzeTsrx,
+	createVolarMappingsResult,
+	dedupeMappings,
+	optimizeTsrx,
+	parseModule,
+} from '@tsrx/core';
 import { DEFAULT_SUSPENSE_SOURCE, transform } from './transform.js';
 
 export { DEFAULT_SUSPENSE_SOURCE };
@@ -35,7 +41,7 @@ export function compile(source, filename, compile_options) {
 	const errors = /** @type {CompileError[]} */ ([]);
 	const comments = /** @type {AST.CommentWithLocation[]} */ ([]);
 	const collect = !!(compile_options?.collect || compile_options?.loose);
-	const ast = parseModule(
+	let ast = parseModule(
 		source,
 		filename,
 		collect ? { collect: true, loose: !!compile_options?.loose, errors, comments } : undefined,
@@ -52,6 +58,15 @@ export function compile(source, filename, compile_options) {
 				}
 			: undefined,
 	);
+
+	// Dead-code elimination runs on the target-neutral AST.
+	// Analysis has already seen the module as authored.
+	// Target lowering has not run yet.
+	// `compile_to_volar_mappings` skips this on purpose.
+	// Editor mappings have to line up with the source on screen.
+	if (compile_options?.optimize) {
+		({ ast } = optimizeTsrx(ast, filename));
+	}
 	const { ast: _ast, ...result } = transform(
 		ast,
 		source,

--- a/packages/tsrx-preact/tests/basic.test.js
+++ b/packages/tsrx-preact/tests/basic.test.js
@@ -5,6 +5,7 @@ import {
 	runSharedCompileTests,
 	runSharedTsxExpressionTsrxTests,
 } from '@tsrx/core/test-harness/compile';
+import { runSharedOptimizeTests } from '@tsrx/core/test-harness/optimize';
 import { runSharedSourceMappingTests } from '@tsrx/core/test-harness/source-mappings';
 import { compile, compile_to_volar_mappings } from '../src/index.js';
 
@@ -14,6 +15,8 @@ runSharedSourceMappingTests({
 	name: 'preact',
 	rejectsComponentAwait: false,
 });
+
+runSharedOptimizeTests({ compile, compile_to_volar_mappings, name: 'preact' });
 
 describe('@tsrx/preact direct runtime imports', () => {
 	it('emits target runtime package imports for every runtime helper surface', () => {

--- a/packages/tsrx-react/src/index.js
+++ b/packages/tsrx-react/src/index.js
@@ -2,7 +2,13 @@
 /** @import { BaseCompileOptions, CompileError, CompileResult, ParseOptions, VolarMappingsResult } from '@tsrx/core/types' */
 /** @import { NonEmptyString } from '@tsrx/core/types/helpers' */
 
-import { analyzeTsrx, createVolarMappingsResult, dedupeMappings, parseModule } from '@tsrx/core';
+import {
+	analyzeTsrx,
+	createVolarMappingsResult,
+	dedupeMappings,
+	optimizeTsrx,
+	parseModule,
+} from '@tsrx/core';
 import { transform } from './transform.js';
 
 export { isRefProp } from './ref.js';
@@ -33,7 +39,7 @@ export function compile(source, filename, options) {
 	const errors = /** @type {CompileError[]} */ ([]);
 	const comments = /** @type {AST.CommentWithLocation[]} */ ([]);
 	const collect = !!(options?.collect || options?.loose);
-	const ast = parseModule(
+	let ast = parseModule(
 		source,
 		filename,
 		collect ? { collect: true, loose: !!options?.loose, errors, comments } : undefined,
@@ -43,6 +49,15 @@ export function compile(source, filename, options) {
 		filename,
 		collect ? { collect: true, loose: !!options?.loose, errors, comments } : undefined,
 	);
+
+	// Dead-code elimination runs on the target-neutral AST.
+	// Analysis has already seen the module as authored.
+	// Target lowering has not run yet.
+	// `compile_to_volar_mappings` skips this on purpose.
+	// Editor mappings have to line up with the source on screen.
+	if (options?.optimize) {
+		({ ast } = optimizeTsrx(ast, filename));
+	}
 	const { ast: _ast, ...result } = transform(
 		ast,
 		source,

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -5,6 +5,7 @@ import {
 	runSharedCompileTests,
 	runSharedTsxExpressionTsrxTests,
 } from '@tsrx/core/test-harness/compile';
+import { runSharedOptimizeTests } from '@tsrx/core/test-harness/optimize';
 import { runSharedSourceMappingTests } from '@tsrx/core/test-harness/source-mappings';
 import { compile, compile_to_volar_mappings } from '../src/index.js';
 import { find_exact_mapping } from '../../tsrx/src/source-map-utils.js';
@@ -15,6 +16,8 @@ runSharedSourceMappingTests({
 	name: 'react',
 	rejectsComponentAwait: false,
 });
+
+runSharedOptimizeTests({ compile, compile_to_volar_mappings, name: 'react' });
 
 describe('@tsrx/react direct runtime imports', () => {
 	it('emits target runtime package imports for every runtime helper surface', () => {

--- a/packages/tsrx-solid/src/index.js
+++ b/packages/tsrx-solid/src/index.js
@@ -2,7 +2,13 @@
 /** @import { BaseCompileOptions, CompileError, CompileResult, ParseOptions, VolarMappingsResult } from '@tsrx/core/types' */
 /** @import { NonEmptyString } from '@tsrx/core/types/helpers' */
 
-import { analyzeTsrx, createVolarMappingsResult, dedupeMappings, parseModule } from '@tsrx/core';
+import {
+	analyzeTsrx,
+	createVolarMappingsResult,
+	dedupeMappings,
+	optimizeTsrx,
+	parseModule,
+} from '@tsrx/core';
 import { transform } from './transform.js';
 
 export { isRefProp } from './ref.js';
@@ -33,7 +39,7 @@ export function compile(source, filename, options) {
 	const errors = /** @type {CompileError[]} */ ([]);
 	const comments = /** @type {AST.CommentWithLocation[]} */ ([]);
 	const collect = !!(options?.collect || options?.loose);
-	const ast = parseModule(
+	let ast = parseModule(
 		source,
 		filename,
 		collect ? { collect: true, loose: !!options?.loose, errors, comments } : undefined,
@@ -43,6 +49,15 @@ export function compile(source, filename, options) {
 		filename,
 		collect ? { collect: true, loose: !!options?.loose, errors, comments } : undefined,
 	);
+
+	// Dead-code elimination runs on the target-neutral AST.
+	// Analysis has already seen the module as authored.
+	// Target lowering has not run yet.
+	// `compile_to_volar_mappings` skips this on purpose.
+	// Editor mappings have to line up with the source on screen.
+	if (options?.optimize) {
+		({ ast } = optimizeTsrx(ast, filename));
+	}
 	const { ast: _ast, ...result } = transform(
 		ast,
 		source,

--- a/packages/tsrx-solid/tests/basic.test.js
+++ b/packages/tsrx-solid/tests/basic.test.js
@@ -8,6 +8,7 @@ import {
 	runSharedSwitchHelperHoistingTests,
 	runSharedTsxExpressionTsrxTests,
 } from '@tsrx/core/test-harness/compile';
+import { runSharedOptimizeTests } from '@tsrx/core/test-harness/optimize';
 import { runSharedSourceMappingTests } from '@tsrx/core/test-harness/source-mappings';
 import { compile, compile_to_volar_mappings } from '../src/index.js';
 
@@ -17,6 +18,8 @@ runSharedSourceMappingTests({
 	name: 'solid',
 	rejectsComponentAwait: true,
 });
+
+runSharedOptimizeTests({ compile, compile_to_volar_mappings, name: 'solid' });
 
 describe('@tsrx/solid direct runtime imports', () => {
 	it('emits the target runtime package import for ref normalization', () => {

--- a/packages/tsrx-vue/src/index.js
+++ b/packages/tsrx-vue/src/index.js
@@ -2,7 +2,13 @@
 /** @import { BaseCompileOptions, CompileError, CompileResult, ParseOptions, VolarMappingsResult } from '@tsrx/core/types' */
 /** @import { NonEmptyString } from '@tsrx/core/types/helpers' */
 
-import { analyzeTsrx, createVolarMappingsResult, dedupeMappings, parseModule } from '@tsrx/core';
+import {
+	analyzeTsrx,
+	createVolarMappingsResult,
+	dedupeMappings,
+	optimizeTsrx,
+	parseModule,
+} from '@tsrx/core';
 import { transform } from './transform.js';
 
 export { isRefProp } from './ref.js';
@@ -33,7 +39,7 @@ export function compile(source, filename, options) {
 	const errors = /** @type {CompileError[]} */ ([]);
 	const comments = /** @type {AST.CommentWithLocation[]} */ ([]);
 	const collect = !!(options?.collect || options?.loose);
-	const ast = parseModule(
+	let ast = parseModule(
 		source,
 		filename,
 		collect ? { collect: true, loose: !!options?.loose, errors, comments } : undefined,
@@ -43,6 +49,15 @@ export function compile(source, filename, options) {
 		filename,
 		collect ? { collect: true, loose: !!options?.loose, errors, comments } : undefined,
 	);
+
+	// Dead-code elimination runs on the target-neutral AST.
+	// Analysis has already seen the module as authored.
+	// Target lowering has not run yet.
+	// `compile_to_volar_mappings` skips this on purpose.
+	// Editor mappings have to line up with the source on screen.
+	if (options?.optimize) {
+		({ ast } = optimizeTsrx(ast, filename));
+	}
 	const { ast: _ast, ...result } = transform(
 		ast,
 		source,

--- a/packages/tsrx-vue/tests/basic.test.js
+++ b/packages/tsrx-vue/tests/basic.test.js
@@ -8,6 +8,7 @@ import {
 	runSharedSwitchHelperHoistingTests,
 	runSharedTsxExpressionTsrxTests,
 } from '@tsrx/core/test-harness/compile';
+import { runSharedOptimizeTests } from '@tsrx/core/test-harness/optimize';
 import { runSharedSourceMappingTests } from '@tsrx/core/test-harness/source-mappings';
 import { compile, compile_to_volar_mappings } from '../src/index.js';
 
@@ -17,6 +18,8 @@ runSharedSourceMappingTests({
 	name: 'vue',
 	rejectsComponentAwait: true,
 });
+
+runSharedOptimizeTests({ compile, compile_to_volar_mappings, name: 'vue' });
 
 describe('@tsrx/vue direct runtime imports', () => {
 	it('emits target runtime package imports for error boundaries and refs', () => {

--- a/packages/tsrx/package.json
+++ b/packages/tsrx/package.json
@@ -63,6 +63,7 @@
     },
     "./test-harness/source-mappings": "./tests/shared/source-mappings.js",
     "./test-harness/compile": "./tests/shared/compile.js",
+    "./test-harness/optimize": "./tests/shared/optimize.js",
     "./test-harness/dep-scan": "./tests/shared/dep-scan.js",
     "./test-harness/runtime/*": "./tests/shared/runtime/*.js",
     "./test-harness/runtime/*.js": "./tests/shared/runtime/*.js",

--- a/packages/tsrx/src/index.js
+++ b/packages/tsrx/src/index.js
@@ -101,6 +101,14 @@ export {
 // Shared TSRX semantic analysis
 export { analyze_tsrx as analyzeTsrx } from './analyze/index.js';
 
+// Shared TSRX dead-code elimination
+export { optimize_tsrx as optimizeTsrx } from './optimize/index.js';
+export {
+	evaluate_expression as evaluateExpression,
+	is_static_value as isStaticValue,
+	value_to_node as valueToNode,
+} from './optimize/evaluate.js';
+
 // Builders (namespace re-export — members mirror AST node kinds)
 export * as builders from './utils/builders.js';
 

--- a/packages/tsrx/src/index.js
+++ b/packages/tsrx/src/index.js
@@ -103,11 +103,6 @@ export { analyze_tsrx as analyzeTsrx } from './analyze/index.js';
 
 // Shared TSRX dead-code elimination
 export { optimize_tsrx as optimizeTsrx } from './optimize/index.js';
-export {
-	evaluate_expression as evaluateExpression,
-	is_static_value as isStaticValue,
-	value_to_node as valueToNode,
-} from './optimize/evaluate.js';
 
 // Builders (namespace re-export — members mirror AST node kinds)
 export * as builders from './utils/builders.js';

--- a/packages/tsrx/src/optimize/constants.js
+++ b/packages/tsrx/src/optimize/constants.js
@@ -1,13 +1,12 @@
 /** @import * as AST from 'estree' */
 /** @import { Binding, ScopeInterface, StaticValue, StaticValueResult } from '../../types/index' */
 
-import { walk } from 'zimmerframe';
 import { create_scopes, ScopeRoot } from '../scope.js';
 import { evaluate_expression } from './evaluate.js';
 
 /**
  * Globals whose value is fixed by the language.
- * They fold only when the name is genuinely unbound.
+ * They resolve only when the name is genuinely unbound.
  * A local `const undefined = 1` creates a binding, which takes priority.
  *
  * @type {Map<string, StaticValue>}
@@ -19,45 +18,12 @@ const INTRINSIC_GLOBALS = new Map([
 ]);
 
 /**
- * Names that must survive even when nothing appears to use them.
- * Scope analysis skips TypeScript nodes.
- * So `typeof x` in a type position never registers as a reference.
- * Neither does `export { x }`.
- * Removing such a declaration would compile but break the emitted types.
- * Every name in either position is therefore pinned by name.
- * The check is coarse on purpose, since a false positive only keeps a declaration.
- *
- * @param {AST.Program} ast
- * @returns {Set<string>}
- */
-function collect_protected_names(ast) {
-	/** @type {Set<string>} */
-	const names = new Set();
-
-	walk(/** @type {AST.Node} */ (ast), /** @type {{ in_type: boolean }} */ ({ in_type: false }), {
-		_(node, { next, state }) {
-			// Everything below a TypeScript node is a type position.
-			// That includes the type annotations hanging off ordinary nodes.
-			const in_type = state?.in_type || node.type.startsWith('TS');
-
-			if (in_type || node.type === 'ExportSpecifier') {
-				if (node.type === 'Identifier') names.add(node.name);
-			}
-
-			next({ in_type: in_type || node.type === 'ExportSpecifier' });
-		},
-	});
-
-	return names;
-}
-
-/**
  * Collects every scope in a module.
  * `create_scopes` returns the top-level scope apart from its node map.
  *
  * @param {AST.Program} ast
  * @param {string | null} filename
- * @returns {{ scopes: Set<ScopeInterface> }}
+ * @returns {Set<ScopeInterface>}
  */
 function collect_scopes(ast, filename) {
 	const { scope, scopes } = create_scopes(ast, new ScopeRoot(), null, {
@@ -69,17 +35,17 @@ function collect_scopes(ast, filename) {
 		filename: filename ?? '',
 	});
 
-	return { scopes: new Set([scope, ...scopes.values()]) };
+	return new Set([scope, ...scopes.values()]);
 }
 
 /**
- * Reports whether a binding can be replaced at its use sites by its value.
+ * Reports whether a binding always holds the value of its initializer.
  *
  * @param {Binding} binding
  * @param {AST.VariableDeclarator} declarator
  * @returns {boolean}
  */
-function is_foldable_binding(binding, declarator) {
+function is_constant_binding(binding, declarator) {
 	return (
 		binding.kind === 'normal' &&
 		binding.declaration_kind === 'const' &&
@@ -94,59 +60,35 @@ function is_foldable_binding(binding, declarator) {
 }
 
 /**
- * Resolves every constant binding in a module.
- * The result is indexed by the identifier nodes that read each binding.
+ * Builds the identifier resolver the directive tests are evaluated against.
+ * Nothing here rewrites the module. The constants are only read, so that a
+ * directive test written as `@if (flag)` can be decided.
  * Resolution repeats because one constant can unlock another.
  * `const b = a + 1` only becomes constant once `a` does.
- * Candidates are rechecked until a full sweep adds nothing.
  *
  * @param {AST.Program} ast
  * @param {string | null} filename
- * @returns {{
- *   values: Map<AST.Identifier, StaticValue>,
- *   declarations: Map<AST.Identifier, Binding>,
- *   unused: Set<Binding>,
- *   resolve: (node: AST.Identifier) => StaticValueResult,
- * }}
+ * @returns {(node: AST.Identifier) => StaticValueResult}
  */
-export function analyze_constants(ast, filename) {
-	const { scopes } = collect_scopes(ast, filename);
-	const protected_names = collect_protected_names(ast);
-
+export function create_constant_resolver(ast, filename) {
 	/**
 	 * Identifier nodes that read a binding, mapped to that binding.
 	 * @type {Map<AST.Identifier, Binding>}
 	 */
 	const references = new Map();
-	/**
-	 * Identifier nodes that declare a binding.
-	 * @type {Map<AST.Identifier, Binding>}
-	 */
-	const declarations = new Map();
 	/** @type {Array<{ binding: Binding, declarator: AST.VariableDeclarator }>} */
 	const candidates = [];
-	/** @type {Set<Binding>} */
-	const unused = new Set();
 
-	for (const scope of scopes) {
+	for (const scope of collect_scopes(ast, filename)) {
 		for (const binding of scope.declarations.values()) {
-			declarations.set(binding.node, binding);
 			for (const reference of binding.references) {
 				references.set(reference.node, binding);
-			}
-
-			// Scope analysis counts the declaring identifier as a reference.
-			// So a name nothing reads still reports one reference.
-			const reads = binding.references.filter((reference) => reference.node !== binding.node);
-
-			if (reads.length === 0 && !binding.updated && !protected_names.has(binding.node.name)) {
-				unused.add(binding);
 			}
 		}
 
 		for (const [declarator, bindings] of scope.declarators) {
 			const binding = bindings.length === 1 ? bindings[0] : undefined;
-			if (binding && is_foldable_binding(binding, declarator)) {
+			if (binding && is_constant_binding(binding, declarator)) {
 				candidates.push({ binding, declarator });
 			}
 		}
@@ -187,11 +129,5 @@ export function analyze_constants(ast, filename) {
 		}
 	}
 
-	/** @type {Map<AST.Identifier, StaticValue>} */
-	const values = new Map();
-	for (const [node, binding] of references) {
-		if (constants.has(binding)) values.set(node, constants.get(binding));
-	}
-
-	return { values, declarations, unused, resolve };
+	return resolve;
 }

--- a/packages/tsrx/src/optimize/constants.js
+++ b/packages/tsrx/src/optimize/constants.js
@@ -1,0 +1,197 @@
+/** @import * as AST from 'estree' */
+/** @import { Binding, ScopeInterface, StaticValue, StaticValueResult } from '../../types/index' */
+
+import { walk } from 'zimmerframe';
+import { create_scopes, ScopeRoot } from '../scope.js';
+import { evaluate_expression } from './evaluate.js';
+
+/**
+ * Globals whose value is fixed by the language.
+ * They fold only when the name is genuinely unbound.
+ * A local `const undefined = 1` creates a binding, which takes priority.
+ *
+ * @type {Map<string, StaticValue>}
+ */
+const INTRINSIC_GLOBALS = new Map([
+	['undefined', undefined],
+	['NaN', NaN],
+	['Infinity', Infinity],
+]);
+
+/**
+ * Names that must survive even when nothing appears to use them.
+ * Scope analysis skips TypeScript nodes.
+ * So `typeof x` in a type position never registers as a reference.
+ * Neither does `export { x }`.
+ * Removing such a declaration would compile but break the emitted types.
+ * Every name in either position is therefore pinned by name.
+ * The check is coarse on purpose, since a false positive only keeps a declaration.
+ *
+ * @param {AST.Program} ast
+ * @returns {Set<string>}
+ */
+function collect_protected_names(ast) {
+	/** @type {Set<string>} */
+	const names = new Set();
+
+	walk(/** @type {AST.Node} */ (ast), /** @type {{ in_type: boolean }} */ ({ in_type: false }), {
+		_(node, { next, state }) {
+			// Everything below a TypeScript node is a type position.
+			// That includes the type annotations hanging off ordinary nodes.
+			const in_type = state?.in_type || node.type.startsWith('TS');
+
+			if (in_type || node.type === 'ExportSpecifier') {
+				if (node.type === 'Identifier') names.add(node.name);
+			}
+
+			next({ in_type: in_type || node.type === 'ExportSpecifier' });
+		},
+	});
+
+	return names;
+}
+
+/**
+ * Collects every scope in a module.
+ * `create_scopes` returns the top-level scope apart from its node map.
+ *
+ * @param {AST.Program} ast
+ * @param {string | null} filename
+ * @returns {{ scopes: Set<ScopeInterface> }}
+ */
+function collect_scopes(ast, filename) {
+	const { scope, scopes } = create_scopes(ast, new ScopeRoot(), null, {
+		// Analysis has already reported any real problems by this point.
+		// Collecting into a throwaway array stops a duplicate declaration
+		// from aborting the build a second time.
+		collect: true,
+		errors: [],
+		filename: filename ?? '',
+	});
+
+	return { scopes: new Set([scope, ...scopes.values()]) };
+}
+
+/**
+ * Reports whether a binding can be replaced at its use sites by its value.
+ *
+ * @param {Binding} binding
+ * @param {AST.VariableDeclarator} declarator
+ * @returns {boolean}
+ */
+function is_foldable_binding(binding, declarator) {
+	return (
+		binding.kind === 'normal' &&
+		binding.declaration_kind === 'const' &&
+		// `updated` covers both reassignment and property mutation.
+		!binding.updated &&
+		// A destructuring pattern binds part of the initializer, not all of it.
+		// `binding.initial` would be the wrong value there.
+		declarator.id.type === 'Identifier' &&
+		declarator.id === binding.node &&
+		!!binding.initial
+	);
+}
+
+/**
+ * Resolves every constant binding in a module.
+ * The result is indexed by the identifier nodes that read each binding.
+ * Resolution repeats because one constant can unlock another.
+ * `const b = a + 1` only becomes constant once `a` does.
+ * Candidates are rechecked until a full sweep adds nothing.
+ *
+ * @param {AST.Program} ast
+ * @param {string | null} filename
+ * @returns {{
+ *   values: Map<AST.Identifier, StaticValue>,
+ *   declarations: Map<AST.Identifier, Binding>,
+ *   unused: Set<Binding>,
+ *   resolve: (node: AST.Identifier) => StaticValueResult,
+ * }}
+ */
+export function analyze_constants(ast, filename) {
+	const { scopes } = collect_scopes(ast, filename);
+	const protected_names = collect_protected_names(ast);
+
+	/**
+	 * Identifier nodes that read a binding, mapped to that binding.
+	 * @type {Map<AST.Identifier, Binding>}
+	 */
+	const references = new Map();
+	/**
+	 * Identifier nodes that declare a binding.
+	 * @type {Map<AST.Identifier, Binding>}
+	 */
+	const declarations = new Map();
+	/** @type {Array<{ binding: Binding, declarator: AST.VariableDeclarator }>} */
+	const candidates = [];
+	/** @type {Set<Binding>} */
+	const unused = new Set();
+
+	for (const scope of scopes) {
+		for (const binding of scope.declarations.values()) {
+			declarations.set(binding.node, binding);
+			for (const reference of binding.references) {
+				references.set(reference.node, binding);
+			}
+
+			// Scope analysis counts the declaring identifier as a reference.
+			// So a name nothing reads still reports one reference.
+			const reads = binding.references.filter((reference) => reference.node !== binding.node);
+
+			if (reads.length === 0 && !binding.updated && !protected_names.has(binding.node.name)) {
+				unused.add(binding);
+			}
+		}
+
+		for (const [declarator, bindings] of scope.declarators) {
+			const binding = bindings.length === 1 ? bindings[0] : undefined;
+			if (binding && is_foldable_binding(binding, declarator)) {
+				candidates.push({ binding, declarator });
+			}
+		}
+	}
+
+	/** @type {Map<Binding, StaticValue>} */
+	const constants = new Map();
+
+	/**
+	 * @param {AST.Identifier} node
+	 * @returns {StaticValueResult}
+	 */
+	function resolve(node) {
+		const binding = references.get(node);
+
+		if (!binding) {
+			return INTRINSIC_GLOBALS.has(node.name) ? { value: INTRINSIC_GLOBALS.get(node.name) } : null;
+		}
+
+		return constants.has(binding) ? { value: constants.get(binding) } : null;
+	}
+
+	let progressed = true;
+	while (progressed) {
+		progressed = false;
+
+		for (const { binding } of candidates) {
+			if (constants.has(binding)) continue;
+
+			const evaluated = evaluate_expression(
+				/** @type {AST.Expression} */ (binding.initial),
+				resolve,
+			);
+			if (!evaluated) continue;
+
+			constants.set(binding, evaluated.value);
+			progressed = true;
+		}
+	}
+
+	/** @type {Map<AST.Identifier, StaticValue>} */
+	const values = new Map();
+	for (const [node, binding] of references) {
+		if (constants.has(binding)) values.set(node, constants.get(binding));
+	}
+
+	return { values, declarations, unused, resolve };
+}

--- a/packages/tsrx/src/optimize/evaluate.js
+++ b/packages/tsrx/src/optimize/evaluate.js
@@ -1,0 +1,321 @@
+/** @import * as AST from 'estree' */
+/** @import { StaticValue, StaticValueResult, ResolveStaticIdentifier } from '../../types/index' */
+
+import { is_transparent_expression_wrapper } from '../utils/ast.js';
+import * as b from '../utils/builders.js';
+
+/**
+ * Compile-time evaluation of expressions with no side effects.
+ * An expression is evaluated only when every operand is already known.
+ * That way folding never reorders evaluation or drops a side effect.
+ * Anything else returns `null`, which callers read as "leave this node alone".
+ */
+
+/**
+ * Values the optimizer will carry through a fold.
+ * Objects, arrays, functions and symbols are excluded.
+ * They have identity, so reusing one across two references would show up.
+ *
+ * @param {unknown} value
+ * @returns {value is StaticValue}
+ */
+export function is_static_value(value) {
+	if (value === null || value === undefined) return true;
+	const type = typeof value;
+	return type === 'string' || type === 'number' || type === 'boolean' || type === 'bigint';
+}
+
+/**
+ * Strips parenthesis and type-only wrappers.
+ * This lets folding see through `(x)`, `x as const`, and `x!`.
+ *
+ * @param {AST.Node} node
+ * @returns {AST.Node}
+ */
+export function unwrap_expression(node) {
+	let current = node;
+
+	while (true) {
+		const inner = /** @type {{ expression?: AST.Node }} */ (current).expression;
+		if (inner && is_transparent_expression_wrapper(current, inner)) {
+			current = inner;
+			continue;
+		}
+		return current;
+	}
+}
+
+/**
+ * @param {string} operator
+ * @param {StaticValue} value
+ * @returns {StaticValueResult}
+ */
+function evaluate_unary(operator, value) {
+	switch (operator) {
+		case '!':
+			return { value: !value };
+		case '-':
+			return { value: /** @type {never} */ (-(/** @type {number} */ (value))) };
+		case '+':
+			// `+1n` throws at runtime.
+			// Folding it would turn a TypeError into a value.
+			return typeof value === 'bigint' ? null : { value: +(/** @type {number} */ (value)) };
+		case '~':
+			return { value: /** @type {never} */ (~(/** @type {number} */ (value))) };
+		case 'typeof':
+			return { value: typeof value };
+		case 'void':
+			return { value: undefined };
+		default:
+			// `delete` is a side effect, so it is never folded.
+			return null;
+	}
+}
+
+/**
+ * @param {string} operator
+ * @param {any} left
+ * @param {any} right
+ * @returns {StaticValueResult}
+ */
+function evaluate_binary(operator, left, right) {
+	switch (operator) {
+		case '+':
+			return { value: left + right };
+		case '-':
+			return { value: left - right };
+		case '*':
+			return { value: left * right };
+		case '/':
+			return { value: left / right };
+		case '%':
+			return { value: left % right };
+		case '**':
+			return { value: left ** right };
+		case '==':
+			return { value: left == right };
+		case '!=':
+			return { value: left != right };
+		case '===':
+			return { value: left === right };
+		case '!==':
+			return { value: left !== right };
+		case '<':
+			return { value: left < right };
+		case '<=':
+			return { value: left <= right };
+		case '>':
+			return { value: left > right };
+		case '>=':
+			return { value: left >= right };
+		case '&':
+			return { value: left & right };
+		case '|':
+			return { value: left | right };
+		case '^':
+			return { value: left ^ right };
+		case '<<':
+			return { value: left << right };
+		case '>>':
+			return { value: left >> right };
+		case '>>>':
+			return { value: left >>> right };
+		default:
+			// `in` and `instanceof` need a real object on the right at runtime.
+			return null;
+	}
+}
+
+/**
+ * Evaluates an expression at compile time.
+ * Returns `null` when the value cannot be known.
+ *
+ * @param {AST.Node | null | undefined} node
+ * @param {ResolveStaticIdentifier} resolve
+ * @returns {StaticValueResult}
+ */
+export function evaluate_expression(node, resolve) {
+	if (!node || typeof node !== 'object') return null;
+
+	const expression = unwrap_expression(node);
+
+	switch (expression.type) {
+		case 'Literal': {
+			const value = expression.value;
+			// A regex literal is an object with identity, so it is never folded.
+			// Some parsers also keep regex payloads outside `value`.
+			if (/** @type {{ regex?: unknown }} */ (expression).regex) return null;
+			if (!is_static_value(value)) return null;
+			return { value: /** @type {StaticValue} */ (value) };
+		}
+
+		case 'Identifier':
+			return resolve(expression);
+
+		case 'TemplateLiteral': {
+			let result = '';
+			for (let i = 0; i < expression.quasis.length; i += 1) {
+				const cooked = expression.quasis[i]?.value.cooked;
+				// An invalid escape sequence has no cooked value.
+				// It is only legal in a tagged template and has no static form.
+				if (cooked == null) return null;
+				result += cooked;
+				const value = expression.expressions[i];
+				if (!value) continue;
+				const evaluated = evaluate_expression(value, resolve);
+				if (!evaluated) return null;
+				try {
+					result += `${evaluated.value}`;
+				} catch {
+					return null;
+				}
+			}
+			return { value: result };
+		}
+
+		case 'UnaryExpression': {
+			// `typeof unbound` stays untouched.
+			// `resolve` returns `null` for a name it cannot prove constant.
+			// The operand then fails to evaluate and the expression is kept.
+			const argument = evaluate_expression(expression.argument, resolve);
+			if (!argument) return null;
+			try {
+				return evaluate_unary(expression.operator, argument.value);
+			} catch {
+				return null;
+			}
+		}
+
+		case 'BinaryExpression': {
+			if (expression.left.type === 'PrivateIdentifier') return null;
+			const left = evaluate_expression(expression.left, resolve);
+			if (!left) return null;
+			const right = evaluate_expression(expression.right, resolve);
+			if (!right) return null;
+			try {
+				const result = evaluate_binary(expression.operator, left.value, right.value);
+				return result && is_static_value(result.value) ? result : null;
+			} catch {
+				// Mixing `bigint` with `number` throws.
+				// So does `2n ** -1n`.
+				return null;
+			}
+		}
+
+		case 'LogicalExpression': {
+			const left = evaluate_expression(expression.left, resolve);
+			if (!left) return null;
+
+			// The right operand is read only when the left one does not decide.
+			// This matches how short-circuiting works at runtime.
+			switch (expression.operator) {
+				case '&&':
+					return left.value ? evaluate_expression(expression.right, resolve) : left;
+				case '||':
+					return left.value ? left : evaluate_expression(expression.right, resolve);
+				case '??':
+					return left.value == null ? evaluate_expression(expression.right, resolve) : left;
+				default:
+					return null;
+			}
+		}
+
+		case 'ConditionalExpression': {
+			const test = evaluate_expression(expression.test, resolve);
+			if (!test) return null;
+			return evaluate_expression(
+				test.value ? expression.consequent : expression.alternate,
+				resolve,
+			);
+		}
+
+		case 'SequenceExpression': {
+			// This folds only when every element is pure.
+			// Otherwise the discarded expressions would lose their side effects.
+			let last = null;
+			for (const element of expression.expressions) {
+				last = evaluate_expression(element, resolve);
+				if (!last) return null;
+			}
+			return last;
+		}
+
+		default:
+			return null;
+	}
+}
+
+/**
+ * Builds the smallest expression node that reproduces `value`.
+ * Returns `null` when the value has no literal form.
+ * `NaN` and `Infinity` would need a global reference.
+ * `-0` is a signed zero the printer cannot round-trip.
+ *
+ * @param {StaticValue} value
+ * @param {AST.NodeWithLocation} [loc_info]
+ * @returns {AST.Expression | null}
+ */
+export function value_to_node(value, loc_info) {
+	if (value === undefined) {
+		return b.set_location(b.unary('void', b.literal(0, '0')), loc_info);
+	}
+
+	if (value === null) return b.literal(null, 'null', loc_info);
+
+	switch (typeof value) {
+		case 'boolean':
+			return b.literal(value, String(value), loc_info);
+
+		case 'string':
+			return b.literal(value, JSON.stringify(value), loc_info);
+
+		case 'bigint':
+			return value < 0n
+				? b.set_location(b.unary('-', b.literal(-value, `${-value}n`)), loc_info)
+				: b.literal(value, `${value}n`, loc_info);
+
+		case 'number': {
+			if (!Number.isFinite(value) || Object.is(value, -0)) return null;
+			return value < 0
+				? b.set_location(b.unary('-', b.literal(-value, String(-value))), loc_info)
+				: b.literal(value, String(value), loc_info);
+		}
+
+		default:
+			return null;
+	}
+}
+
+/**
+ * Reports whether `node` already spells `value` in its shortest form.
+ * Replacing such a node would churn the AST without changing the output.
+ *
+ * @param {AST.Node} node
+ * @param {StaticValue} value
+ * @returns {boolean}
+ */
+export function is_already_folded(node, value) {
+	if (node.type === 'Literal') {
+		return Object.is(node.value, value) && !(/** @type {{ regex?: unknown }} */ (node).regex);
+	}
+
+	if (
+		node.type === 'UnaryExpression' &&
+		node.operator === '-' &&
+		node.argument.type === 'Literal' &&
+		(typeof node.argument.value === 'number' || typeof node.argument.value === 'bigint')
+	) {
+		return Object.is(-node.argument.value, value);
+	}
+
+	if (
+		node.type === 'UnaryExpression' &&
+		node.operator === 'void' &&
+		node.argument.type === 'Literal' &&
+		node.argument.value === 0
+	) {
+		return value === undefined;
+	}
+
+	return false;
+}

--- a/packages/tsrx/src/optimize/evaluate.js
+++ b/packages/tsrx/src/optimize/evaluate.js
@@ -246,6 +246,51 @@ export function evaluate_expression(node, resolve) {
 }
 
 /**
+ * Reports what a test position can tell about an expression the pass cannot
+ * evaluate to a value.
+ * An array, object, function, or regex literal is always truthy and non-nullish.
+ * `pure` says whether evaluating the expression can be skipped.
+ * An impure test still has to run, so callers keep it in a sequence.
+ * Returns `null` when truthiness is not decidable.
+ *
+ * @param {AST.Node | null | undefined} node
+ * @param {ResolveStaticIdentifier} resolve
+ * @returns {{ truthy: boolean, nullish: boolean, pure: boolean } | null}
+ */
+export function evaluate_truthiness(node, resolve) {
+	if (!node || typeof node !== 'object') return null;
+
+	const evaluated = evaluate_expression(node, resolve);
+	if (evaluated) {
+		return {
+			truthy: !!evaluated.value,
+			nullish: evaluated.value == null,
+			pure: true,
+		};
+	}
+
+	const expression = unwrap_expression(node);
+
+	switch (expression.type) {
+		case 'ArrayExpression':
+			return { truthy: true, nullish: false, pure: expression.elements.length === 0 };
+		case 'ObjectExpression':
+			return { truthy: true, nullish: false, pure: expression.properties.length === 0 };
+		case 'FunctionExpression':
+		case 'ArrowFunctionExpression':
+			return { truthy: true, nullish: false, pure: true };
+		case 'Literal':
+			// A regex literal is the one literal `evaluate_expression` refuses.
+			// It is an object, so it is always truthy.
+			return /** @type {{ regex?: unknown }} */ (expression).regex
+				? { truthy: true, nullish: false, pure: true }
+				: null;
+		default:
+			return null;
+	}
+}
+
+/**
  * Builds the smallest expression node that reproduces `value`.
  * Returns `null` when the value has no literal form.
  * `NaN` and `Infinity` would need a global reference.

--- a/packages/tsrx/src/optimize/evaluate.js
+++ b/packages/tsrx/src/optimize/evaluate.js
@@ -6,6 +6,8 @@ import * as b from '../utils/builders.js';
 
 /**
  * Compile-time evaluation of expressions with no side effects.
+ * The optimizer reads values with this to decide a TSRX directive test.
+ * Nothing here rewrites code.
  * An expression is evaluated only when every operand is already known.
  * That way folding never reorders evaluation or drops a side effect.
  * Anything else returns `null`, which callers read as "leave this node alone".
@@ -288,79 +290,4 @@ export function evaluate_truthiness(node, resolve) {
 		default:
 			return null;
 	}
-}
-
-/**
- * Builds the smallest expression node that reproduces `value`.
- * Returns `null` when the value has no literal form.
- * `NaN` and `Infinity` would need a global reference.
- * `-0` is a signed zero the printer cannot round-trip.
- *
- * @param {StaticValue} value
- * @param {AST.NodeWithLocation} [loc_info]
- * @returns {AST.Expression | null}
- */
-export function value_to_node(value, loc_info) {
-	if (value === undefined) {
-		return b.set_location(b.unary('void', b.literal(0, '0')), loc_info);
-	}
-
-	if (value === null) return b.literal(null, 'null', loc_info);
-
-	switch (typeof value) {
-		case 'boolean':
-			return b.literal(value, String(value), loc_info);
-
-		case 'string':
-			return b.literal(value, JSON.stringify(value), loc_info);
-
-		case 'bigint':
-			return value < 0n
-				? b.set_location(b.unary('-', b.literal(-value, `${-value}n`)), loc_info)
-				: b.literal(value, `${value}n`, loc_info);
-
-		case 'number': {
-			if (!Number.isFinite(value) || Object.is(value, -0)) return null;
-			return value < 0
-				? b.set_location(b.unary('-', b.literal(-value, String(-value))), loc_info)
-				: b.literal(value, String(value), loc_info);
-		}
-
-		default:
-			return null;
-	}
-}
-
-/**
- * Reports whether `node` already spells `value` in its shortest form.
- * Replacing such a node would churn the AST without changing the output.
- *
- * @param {AST.Node} node
- * @param {StaticValue} value
- * @returns {boolean}
- */
-export function is_already_folded(node, value) {
-	if (node.type === 'Literal') {
-		return Object.is(node.value, value) && !(/** @type {{ regex?: unknown }} */ (node).regex);
-	}
-
-	if (
-		node.type === 'UnaryExpression' &&
-		node.operator === '-' &&
-		node.argument.type === 'Literal' &&
-		(typeof node.argument.value === 'number' || typeof node.argument.value === 'bigint')
-	) {
-		return Object.is(-node.argument.value, value);
-	}
-
-	if (
-		node.type === 'UnaryExpression' &&
-		node.operator === 'void' &&
-		node.argument.type === 'Literal' &&
-		node.argument.value === 0
-	) {
-		return value === undefined;
-	}
-
-	return false;
 }

--- a/packages/tsrx/src/optimize/index.js
+++ b/packages/tsrx/src/optimize/index.js
@@ -33,6 +33,32 @@ function is_removed(node) {
 }
 
 /**
+ * Slots whose visitor filters removal markers back out.
+ * A marker left anywhere else would stay in the tree and break it.
+ */
+const REMOVAL_CONTAINERS = new Set([
+	'Program',
+	'BlockStatement',
+	'StaticBlock',
+	'SwitchCase',
+	'JSXCodeBlock',
+	'JSXElement',
+	'JSXFragment',
+]);
+
+/**
+ * Reports whether the node at the end of `path` sits in a slot that can drop it.
+ * An unbraced `if` arm, a loop body, and a loop header are not such slots.
+ *
+ * @param {AST.Node[]} path
+ * @returns {boolean}
+ */
+function removal_is_handled(path) {
+	const parent = path.at(-1);
+	return !!parent && REMOVAL_CONTAINERS.has(parent.type);
+}
+
+/**
  * One fold can expose the next.
  * Replacing `flag` with `false` is what makes the `@if` above it dead.
  * So the pass repeats until a round changes nothing.
@@ -207,7 +233,9 @@ function is_droppable_when_unreachable(node) {
 /**
  * Reports whether dropping an initializer can be observed.
  * A statically evaluable expression is safe to drop.
- * So is a function or class literal, which touches nothing outside itself.
+ * So is a function literal, which touches nothing outside itself.
+ * A class literal is not, because evaluating it runs `extends`, static fields,
+ * static blocks, and computed static keys.
  *
  * @param {AST.Node} node
  * @param {ResolveStaticIdentifier} resolve
@@ -217,7 +245,6 @@ function is_pure_initializer(node, resolve) {
 	switch (unwrap_expression(node).type) {
 		case 'FunctionExpression':
 		case 'ArrowFunctionExpression':
-		case 'ClassExpression':
 			return true;
 		default:
 			return !!evaluate_expression(node, resolve);
@@ -655,6 +682,8 @@ function run_round(ast, filename) {
 		if (is_template_directive_node(visited)) {
 			const replacement = collapse_template_if(visited, resolve);
 			if (!replacement) return unchanged;
+			// A directive whose slot cannot drop it stays as authored.
+			if (is_removed(replacement) && !removal_is_handled(path)) return unchanged;
 			changed = true;
 			return replacement;
 		}
@@ -666,6 +695,11 @@ function run_round(ast, filename) {
 		if (!replacement) return unchanged;
 
 		changed = true;
+		// An unbraced arm, a loop body, and a label body all need a statement.
+		// An empty one is the smallest valid stand-in for the removed `if`.
+		if (is_removed(replacement) && !removal_is_handled(path)) {
+			return { type: 'EmptyStatement', metadata: { path: [] } };
+		}
 		return replacement;
 	}
 
@@ -690,16 +724,28 @@ function run_round(ast, filename) {
 
 	/**
 	 * @param {AST.Node} node
-	 * @param {{ next: () => AST.Node | undefined }} context
+	 * @param {{ next: () => AST.Node | undefined, path: AST.Node[] }} context
 	 * @returns {AST.Node | undefined}
 	 */
-	function visit_for(node, { next }) {
+	function visit_for(node, { next, path }) {
 		const visited = /** @type {AST.ForOfStatement} */ (next() ?? node);
-		if (!is_template_directive_node(visited)) return visited === node ? undefined : visited;
-		if (!is_empty_iterable(visited.right)) return visited === node ? undefined : visited;
-		if (contains_hoisted_declaration(visited.body)) {
-			return visited === node ? undefined : visited;
+		const unchanged = visited === node ? undefined : visited;
+
+		if (!is_template_directive_node(visited)) return unchanged;
+		if (!is_empty_iterable(visited.right)) return unchanged;
+		if (contains_hoisted_declaration(visited.body)) return unchanged;
+
+		// `@empty { … }` is the authored fallback for a loop that yields nothing.
+		// An empty iterable renders that clause, so the loop becomes its body.
+		const fallback = /** @type {{ empty?: AST.Node | null }} */ (visited).empty;
+		if (fallback) {
+			const child = branch_to_render_child(fallback);
+			if (!child) return unchanged;
+			changed = true;
+			return child;
 		}
+
+		if (!removal_is_handled(path)) return unchanged;
 
 		changed = true;
 		return removed_node;
@@ -714,7 +760,12 @@ function run_round(ast, filename) {
 		const visited = /** @type {AST.VariableDeclaration} */ (next() ?? node);
 		// `var` is hoisted, so removing it changes what other code sees.
 		// An exported name is public no matter how this module uses it.
-		if (visited.kind === 'var' || path.at(-1)?.type.startsWith('Export')) {
+		// A loop header is not a statement list, so its declaration has to stay.
+		if (
+			visited.kind === 'var' ||
+			path.at(-1)?.type.startsWith('Export') ||
+			!removal_is_handled(path)
+		) {
 			return visited === node ? undefined : visited;
 		}
 

--- a/packages/tsrx/src/optimize/index.js
+++ b/packages/tsrx/src/optimize/index.js
@@ -1,21 +1,15 @@
 /** @import * as AST from 'estree' */
-/** @import { Binding, OptimizeOptions, OptimizeResult, ResolveStaticIdentifier, StaticValue } from '../../types/index' */
+/** @import { OptimizeOptions, OptimizeResult, ResolveStaticIdentifier, StaticValue } from '../../types/index' */
 
 import { walk } from 'zimmerframe';
 import * as b from '../utils/builders.js';
-import { analyze_constants } from './constants.js';
-import {
-	evaluate_expression,
-	evaluate_truthiness,
-	is_already_folded,
-	unwrap_expression,
-	value_to_node,
-} from './evaluate.js';
+import { create_constant_resolver } from './constants.js';
+import { evaluate_expression, evaluate_truthiness, unwrap_expression } from './evaluate.js';
 
 /**
- * Marker that stands in for a node the pass removed.
+ * Marker that stands in for a directive the pass removed.
  * zimmerframe can replace a node but cannot delete one.
- * So a visitor swaps a dead node for this marker.
+ * So a visitor swaps a dead directive for this marker.
  * The enclosing list then filters the markers out.
  */
 const REMOVED = 'TSRXRemovedNode';
@@ -49,7 +43,6 @@ const REMOVAL_CONTAINERS = new Set([
 
 /**
  * Reports whether the node at the end of `path` sits in a slot that can drop it.
- * An unbraced `if` arm, a loop body, and a loop header are not such slots.
  *
  * @param {AST.Node[]} path
  * @returns {boolean}
@@ -60,16 +53,14 @@ function removal_is_handled(path) {
 }
 
 /**
- * One fold can expose the next.
- * Replacing `flag` with `false` is what makes the `@if` above it dead.
- * So the pass repeats until a round changes nothing.
- * This cap only stops a bug from looping forever.
+ * One collapse can expose the next, so the pass repeats until a round changes
+ * nothing. This cap only stops a bug from looping forever.
  */
 const MAX_ROUNDS = 5;
 
 /**
  * Node kinds that can stand where a template renders a child.
- * A branch holding exactly one of these can replace its `@if`.
+ * A branch holding exactly one of these can replace its directive.
  * Any other branch keeps the directive and only loses its dead arm.
  *
  * @param {AST.Node | null | undefined} node
@@ -100,40 +91,6 @@ function is_render_child(node) {
 }
 
 /**
- * Identifier positions where a name is a value that can be substituted.
- * A shorthand property shares one node between its key and its value.
- * Folding it would rewrite the key too, so it is excluded.
- * The other excluded positions are names rather than reads.
- *
- * @param {AST.Identifier} node
- * @param {AST.Node[]} path
- * @returns {boolean}
- */
-function is_foldable_identifier_position(node, path) {
-	const parent = path.at(-1);
-	if (!parent) return false;
-
-	switch (parent.type) {
-		case 'Property':
-			return !parent.shorthand && parent.key !== node;
-		case 'MemberExpression':
-			return parent.computed || parent.property !== node;
-		case 'LabeledStatement':
-		case 'BreakStatement':
-		case 'ContinueStatement':
-		case 'ImportSpecifier':
-		case 'ImportDefaultSpecifier':
-		case 'ImportNamespaceSpecifier':
-		case 'ExportSpecifier':
-		case 'MethodDefinition':
-		case 'PropertyDefinition':
-			return false;
-		default:
-			return true;
-	}
-}
-
-/**
  * @param {AST.Node | null | undefined} node
  * @returns {boolean}
  */
@@ -142,6 +99,11 @@ function is_if_node(node) {
 }
 
 /**
+ * Reports whether a node is one of the TSRX keyword directives.
+ * These are `@if`, `@for`, `@switch`, and `@try`, in both their expression and
+ * retyped statement forms.
+ * The pass rewrites nothing else.
+ *
  * @param {AST.Node | null | undefined} node
  * @returns {boolean}
  */
@@ -195,114 +157,14 @@ function contains_hoisted_declaration(node) {
 }
 
 /**
- * Statement kinds that can be dropped once control cannot reach them.
- * Declarations are excluded on purpose.
- * They are either hoisted, or removed later by the unused-binding rule.
- * That rule checks that nothing refers to them, which is what makes it safe.
+ * Drops removal markers from a list.
  *
- * @param {AST.Node} node
- * @returns {boolean}
- */
-function is_droppable_when_unreachable(node) {
-	switch (node.type) {
-		case 'ExpressionStatement':
-		case 'IfStatement':
-		case 'BlockStatement':
-		case 'ReturnStatement':
-		case 'ThrowStatement':
-		case 'BreakStatement':
-		case 'ContinueStatement':
-		case 'DebuggerStatement':
-		case 'EmptyStatement':
-		case 'SwitchStatement':
-		case 'TryStatement':
-		case 'WhileStatement':
-		case 'DoWhileStatement':
-		case 'ForStatement':
-		case 'ForInStatement':
-		case 'ForOfStatement':
-		case 'LabeledStatement':
-		case 'WithStatement':
-			// A template directive is output, not control flow.
-			// Reachability alone is not a reason to drop one.
-			return !is_template_directive_node(node);
-		default:
-			return false;
-	}
-}
-
-/**
- * Reports whether dropping an initializer can be observed.
- * A statically evaluable expression is safe to drop.
- * So is a function literal, which touches nothing outside itself.
- * A class literal is not, because evaluating it runs `extends`, static fields,
- * static blocks, and computed static keys.
- *
- * @param {AST.Node} node
- * @param {ResolveStaticIdentifier} resolve
- * @returns {boolean}
- */
-function is_pure_initializer(node, resolve) {
-	switch (unwrap_expression(node).type) {
-		case 'FunctionExpression':
-		case 'ArrowFunctionExpression':
-			return true;
-		default:
-			return !!evaluate_expression(node, resolve);
-	}
-}
-
-/**
- * @param {AST.Node} node
- * @returns {boolean}
- */
-function is_terminator(node) {
-	return (
-		node.type === 'ReturnStatement' ||
-		node.type === 'ThrowStatement' ||
-		node.type === 'BreakStatement' ||
-		node.type === 'ContinueStatement'
-	);
-}
-
-/**
- * Drops removal markers.
- * Then drops whatever follows an unconditional jump.
- *
- * @param {AST.Node[]} body
+ * @param {AST.Node[]} list
  * @returns {AST.Node[] | null} The new list, or `null` when nothing changed.
  */
-function prune_statements(body) {
-	/** @type {AST.Node[]} */
-	const result = [];
-	let terminated = false;
-	let changed = false;
-
-	for (const statement of body) {
-		if (is_removed(statement)) {
-			changed = true;
-			continue;
-		}
-
-		if (terminated && is_droppable_when_unreachable(statement)) {
-			changed = true;
-			continue;
-		}
-
-		result.push(statement);
-		if (!terminated && is_terminator(statement)) terminated = true;
-	}
-
-	return changed ? result : null;
-}
-
-/**
- * @param {AST.Node[]} children
- * @returns {AST.Node[] | null}
- */
-function prune_children(children) {
-	if (!children.some(is_removed)) return null;
-	return children.filter((child) => !is_removed(child));
+function prune_removed(list) {
+	if (!list.some(is_removed)) return null;
+	return list.filter((node) => !is_removed(node));
 }
 
 /**
@@ -338,6 +200,22 @@ function empty_fragment(node) {
 }
 
 /**
+ * Decides a directive test that the pass can read without running it.
+ * A test with side effects is refused.
+ * Choosing a branch discards the test, and a directive has no expression slot
+ * left to keep those effects in.
+ *
+ * @param {AST.Node} test
+ * @param {ResolveStaticIdentifier} resolve
+ * @returns {boolean | null}
+ */
+function decide_test(test, resolve) {
+	const truthiness = evaluate_truthiness(test, resolve);
+	if (!truthiness || !truthiness.pure) return null;
+	return truthiness.truthy;
+}
+
+/**
  * Reports whether `node` is a link in an `@if` chain rather than its head.
  * Only the head carries the directive typing.
  * So the whole chain is collapsed from the head.
@@ -363,7 +241,7 @@ function is_template_if_chain_link(node, path) {
 }
 
 /**
- * Every link of an `@if` / `@else if` chain, head first.
+ * Every link of an `@if` and `@else if` chain, head first.
  *
  * @param {AST.IfStatement} head
  * @returns {AST.IfStatement[]}
@@ -379,11 +257,11 @@ function collect_if_chain(head) {
 }
 
 /**
- * Collapses a template `@if` chain against the tests it can evaluate.
+ * Collapses an `@if` chain against the tests it can decide.
  * A link whose test is provably false is dropped.
  * The first provably true test ends the chain, and its branch is the result.
  * A chain that reduces to one output node replaces the directive.
- * A chain that still has an unknown test is rebuilt from the surviving links.
+ * A chain that still has an undecided test is rebuilt from the links that stay.
  *
  * @param {AST.IfStatement} head
  * @param {ResolveStaticIdentifier} resolve
@@ -400,14 +278,14 @@ function collapse_template_if(head, resolve) {
 	let taken;
 
 	for (const link of links) {
-		const test = evaluate_expression(link.test, resolve);
+		const test = decide_test(link.test, resolve);
 
-		if (!test) {
+		if (test === null) {
 			kept.push(link);
 			continue;
 		}
 
-		if (test.value) {
+		if (test) {
 			taken = link.consequent;
 			break;
 		}
@@ -460,23 +338,6 @@ function collapse_template_if(head, resolve) {
 		type: head.type,
 		statementType: /** @type {any} */ (head).statementType,
 	};
-}
-
-/**
- * Collapse a plain `if` statement whose test is statically known.
- *
- * @param {AST.IfStatement} node
- * @param {StaticValue} test
- * @returns {AST.Node | null}
- */
-function collapse_if(node, test) {
-	const taken = test ? node.consequent : node.alternate;
-	const dropped = test ? node.alternate : node.consequent;
-
-	if (contains_hoisted_declaration(dropped)) return null;
-	// In statement position the branch is already a block.
-	// Keeping the block preserves its own `let` and `const` scope.
-	return taken ?? removed_node;
 }
 
 /**
@@ -542,28 +403,12 @@ function is_empty_iterable(node) {
  * @returns {{ ast: AST.Program, changed: boolean }}
  */
 function run_round(ast, filename) {
-	const { values, declarations, unused, resolve } = analyze_constants(ast, filename);
+	const resolve = create_constant_resolver(ast, filename);
 	let changed = false;
 
 	/**
-	 * @param {AST.Node} node
-	 * @returns {AST.Node | undefined}
-	 */
-	function fold_expression(node) {
-		const evaluated = evaluate_expression(node, resolve);
-		if (!evaluated || is_already_folded(node, evaluated.value)) return undefined;
-
-		const folded = value_to_node(
-			evaluated.value,
-			/** @type {AST.NodeWithLocation} */ (/** @type {unknown} */ (node)),
-		);
-		if (!folded) return undefined;
-
-		changed = true;
-		return folded;
-	}
-
-	/**
+	 * Removes the markers a collapsed directive left behind.
+	 *
 	 * @param {AST.Node} node
 	 * @param {{ next: () => AST.Node | undefined }} context
 	 * @returns {AST.Node | undefined}
@@ -574,117 +419,11 @@ function run_round(ast, filename) {
 		const list = visited[key];
 		if (!Array.isArray(list)) return visited === node ? undefined : visited;
 
-		const pruned = key === 'children' ? prune_children(list) : prune_statements(list);
+		const pruned = prune_removed(list);
 		if (!pruned) return visited === node ? undefined : visited;
 
 		changed = true;
 		return { ...visited, [key]: pruned };
-	}
-
-	/**
-	 * @param {AST.Identifier} node
-	 * @param {{ path: AST.Node[] }} context
-	 * @returns {AST.Node | undefined}
-	 */
-	function visit_identifier(node, { path }) {
-		if (!values.has(node) || declarations.has(node)) return undefined;
-		if (!is_foldable_identifier_position(node, path)) return undefined;
-		return fold_expression(node);
-	}
-
-	const visitors = {
-		Identifier: visit_identifier,
-
-		UnaryExpression: fold_expression_visitor,
-		BinaryExpression: fold_expression_visitor,
-		LogicalExpression: fold_expression_visitor,
-		ConditionalExpression: fold_expression_visitor,
-		TemplateLiteral: fold_expression_visitor,
-
-		Program: visit_list_container,
-		BlockStatement: visit_list_container,
-		StaticBlock: visit_list_container,
-		SwitchCase: visit_switch_case,
-		JSXElement: visit_list_container,
-		JSXFragment: visit_list_container,
-		JSXCodeBlock: visit_code_block,
-
-		IfStatement: visit_if,
-		JSXIfExpression: visit_if,
-		SwitchStatement: visit_switch,
-		JSXSwitchExpression: visit_switch,
-		ForOfStatement: visit_for,
-		JSXForExpression: visit_for,
-
-		VariableDeclaration: visit_variable_declaration,
-	};
-
-	/**
-	 * @param {AST.Node} node
-	 * @param {{ next: () => AST.Node | undefined }} context
-	 * @returns {AST.Node | undefined}
-	 */
-	function fold_expression_visitor(node, { next }) {
-		const visited = next() ?? node;
-		return (
-			fold_expression(visited) ??
-			fold_by_truthiness(visited) ??
-			(visited === node ? undefined : visited)
-		);
-	}
-
-	/**
-	 * Picks the arm of a `?:` or a `&&` / `||` / `??` whose test has a known
-	 * truthiness but no known value.
-	 * `[b()] ? c() : d()` becomes `([b()], c())`, because an array literal is
-	 * always truthy and the call inside it still has to run.
-	 * A test that is also side-effect free is dropped instead of sequenced.
-	 *
-	 * @param {AST.Node} node
-	 * @returns {AST.Node | undefined}
-	 */
-	function fold_by_truthiness(node) {
-		/** @type {AST.Expression} */
-		let test;
-		/** @type {AST.Expression} */
-		let taken;
-		/** @type {boolean} */
-		let pure;
-
-		if (node.type === 'ConditionalExpression') {
-			const truthiness = evaluate_truthiness(node.test, resolve);
-			if (!truthiness) return undefined;
-			test = node.test;
-			pure = truthiness.pure;
-			taken = truthiness.truthy ? node.consequent : node.alternate;
-		} else if (node.type === 'LogicalExpression') {
-			const truthiness = evaluate_truthiness(node.left, resolve);
-			if (!truthiness) return undefined;
-			test = node.left;
-			pure = truthiness.pure;
-
-			switch (node.operator) {
-				case '&&':
-					taken = truthiness.truthy ? node.right : node.left;
-					break;
-				case '||':
-					taken = truthiness.truthy ? node.left : node.right;
-					break;
-				case '??':
-					taken = truthiness.nullish ? node.right : node.left;
-					break;
-				default:
-					return undefined;
-			}
-		} else {
-			return undefined;
-		}
-
-		changed = true;
-		// The operand that decides the result can also be the result. Sequencing
-		// it with itself would evaluate it twice.
-		if (taken === test || pure) return taken;
-		return b.sequence([test, taken]);
 	}
 
 	/**
@@ -694,7 +433,7 @@ function run_round(ast, filename) {
 	 */
 	function visit_switch_case(node, { next }) {
 		const visited = /** @type {AST.SwitchCase} */ (next() ?? node);
-		const pruned = prune_statements(visited.consequent);
+		const pruned = prune_removed(visited.consequent);
 		if (!pruned) return visited === node ? undefined : visited;
 
 		changed = true;
@@ -708,7 +447,7 @@ function run_round(ast, filename) {
 	 */
 	function visit_code_block(node, { next }) {
 		const visited = /** @type {AST.JSXCodeBlock} */ (next() ?? node);
-		const pruned = visited.body ? prune_statements(visited.body) : null;
+		const pruned = visited.body ? prune_removed(visited.body) : null;
 		// A code block still has to render something.
 		// So an eliminated output becomes an empty fragment instead of nothing.
 		const render = is_removed(visited.render)
@@ -735,47 +474,37 @@ function run_round(ast, filename) {
 		const visited = /** @type {AST.IfStatement} */ (next() ?? node);
 		const unchanged = visited === node ? undefined : visited;
 
+		// A plain `if` is ordinary JavaScript, not a TSRX directive.
+		if (!is_template_directive_node(visited)) return unchanged;
 		// A chain link is collapsed by its head, never on its own.
 		if (chain_link) return unchanged;
 
-		if (is_template_directive_node(visited)) {
-			const replacement = collapse_template_if(visited, resolve);
-			if (!replacement) return unchanged;
-			// A directive whose slot cannot drop it stays as authored.
-			if (is_removed(replacement) && !removal_is_handled(path)) return unchanged;
-			changed = true;
-			return replacement;
-		}
-
-		const test = evaluate_expression(visited.test, resolve);
-		if (!test) return unchanged;
-
-		const replacement = collapse_if(visited, test.value);
+		const replacement = collapse_template_if(visited, resolve);
 		if (!replacement) return unchanged;
+		// A directive whose slot cannot drop it stays as authored.
+		if (is_removed(replacement) && !removal_is_handled(path)) return unchanged;
 
 		changed = true;
-		// An unbraced arm, a loop body, and a label body all need a statement.
-		// An empty one is the smallest valid stand-in for the removed `if`.
-		if (is_removed(replacement) && !removal_is_handled(path)) {
-			return { type: 'EmptyStatement', metadata: { path: [] } };
-		}
 		return replacement;
 	}
 
 	/**
 	 * @param {AST.Node} node
-	 * @param {{ next: () => AST.Node | undefined }} context
+	 * @param {{ next: () => AST.Node | undefined, path: AST.Node[] }} context
 	 * @returns {AST.Node | undefined}
 	 */
-	function visit_switch(node, { next }) {
+	function visit_switch(node, { next, path }) {
 		const visited = /** @type {AST.SwitchStatement} */ (next() ?? node);
-		if (!is_template_directive_node(visited)) return visited === node ? undefined : visited;
+		const unchanged = visited === node ? undefined : visited;
+
+		if (!is_template_directive_node(visited)) return unchanged;
 
 		const discriminant = evaluate_expression(visited.discriminant, resolve);
-		if (!discriminant) return visited === node ? undefined : visited;
+		if (!discriminant) return unchanged;
 
 		const replacement = collapse_switch(visited, discriminant.value, resolve);
-		if (!replacement) return visited === node ? undefined : visited;
+		if (!replacement) return unchanged;
+		if (is_removed(replacement) && !removal_is_handled(path)) return unchanged;
 
 		changed = true;
 		return replacement;
@@ -810,39 +539,22 @@ function run_round(ast, filename) {
 		return removed_node;
 	}
 
-	/**
-	 * @param {AST.VariableDeclaration} node
-	 * @param {{ next: () => AST.Node | undefined, path: AST.Node[] }} context
-	 * @returns {AST.Node | undefined}
-	 */
-	function visit_variable_declaration(node, { next, path }) {
-		const visited = /** @type {AST.VariableDeclaration} */ (next() ?? node);
-		// `var` is hoisted, so removing it changes what other code sees.
-		// An exported name is public no matter how this module uses it.
-		// A loop header is not a statement list, so its declaration has to stay.
-		if (
-			visited.kind === 'var' ||
-			path.at(-1)?.type.startsWith('Export') ||
-			!removal_is_handled(path)
-		) {
-			return visited === node ? undefined : visited;
-		}
+	const visitors = {
+		Program: visit_list_container,
+		BlockStatement: visit_list_container,
+		StaticBlock: visit_list_container,
+		SwitchCase: visit_switch_case,
+		JSXElement: visit_list_container,
+		JSXFragment: visit_list_container,
+		JSXCodeBlock: visit_code_block,
 
-		const kept = visited.declarations.filter((declarator) => {
-			if (declarator.id.type !== 'Identifier') return true;
-			const binding = declarations.get(declarator.id);
-			if (!binding || binding.kind !== 'normal' || !unused.has(binding)) return true;
-			// A name nothing reads is removable only if its initializer is pure.
-			return !!declarator.init && !is_pure_initializer(declarator.init, resolve);
-		});
-
-		if (kept.length === visited.declarations.length) {
-			return visited === node ? undefined : visited;
-		}
-
-		changed = true;
-		return kept.length === 0 ? removed_node : { ...visited, declarations: kept };
-	}
+		IfStatement: visit_if,
+		JSXIfExpression: visit_if,
+		SwitchStatement: visit_switch,
+		JSXSwitchExpression: visit_switch,
+		ForOfStatement: visit_for,
+		JSXForExpression: visit_for,
+	};
 
 	const next_ast = /** @type {AST.Program} */ (
 		walk(/** @type {AST.Node} */ (ast), null, /** @type {any} */ (visitors))
@@ -852,10 +564,11 @@ function run_round(ast, filename) {
 }
 
 /**
- * Folds statically known expressions and removes the code they prove dead.
- * The pass is target-neutral.
- * It runs on the parsed TSRX AST before any target transform.
- * Every target therefore gets the same eliminations.
+ * Removes the TSRX directives that a module's own constants prove dead.
+ * The pass only rewrites `@if`, `@else if`, `@switch`, and `@for`.
+ * It reads constants and decides a directive test to choose a branch.
+ * It never rewrites the code those values came from.
+ * Plain JavaScript, setup statements, and expressions stay as authored.
  * It is opt-in through the `optimize` compile option.
  * It must not run on the editor and Volar path.
  * Those mappings have to match the authored source one for one.

--- a/packages/tsrx/src/optimize/index.js
+++ b/packages/tsrx/src/optimize/index.js
@@ -6,6 +6,7 @@ import * as b from '../utils/builders.js';
 import { analyze_constants } from './constants.js';
 import {
 	evaluate_expression,
+	evaluate_truthiness,
 	is_already_folded,
 	unwrap_expression,
 	value_to_node,
@@ -625,7 +626,65 @@ function run_round(ast, filename) {
 	 */
 	function fold_expression_visitor(node, { next }) {
 		const visited = next() ?? node;
-		return fold_expression(visited) ?? (visited === node ? undefined : visited);
+		return (
+			fold_expression(visited) ??
+			fold_by_truthiness(visited) ??
+			(visited === node ? undefined : visited)
+		);
+	}
+
+	/**
+	 * Picks the arm of a `?:` or a `&&` / `||` / `??` whose test has a known
+	 * truthiness but no known value.
+	 * `[b()] ? c() : d()` becomes `([b()], c())`, because an array literal is
+	 * always truthy and the call inside it still has to run.
+	 * A test that is also side-effect free is dropped instead of sequenced.
+	 *
+	 * @param {AST.Node} node
+	 * @returns {AST.Node | undefined}
+	 */
+	function fold_by_truthiness(node) {
+		/** @type {AST.Expression} */
+		let test;
+		/** @type {AST.Expression} */
+		let taken;
+		/** @type {boolean} */
+		let pure;
+
+		if (node.type === 'ConditionalExpression') {
+			const truthiness = evaluate_truthiness(node.test, resolve);
+			if (!truthiness) return undefined;
+			test = node.test;
+			pure = truthiness.pure;
+			taken = truthiness.truthy ? node.consequent : node.alternate;
+		} else if (node.type === 'LogicalExpression') {
+			const truthiness = evaluate_truthiness(node.left, resolve);
+			if (!truthiness) return undefined;
+			test = node.left;
+			pure = truthiness.pure;
+
+			switch (node.operator) {
+				case '&&':
+					taken = truthiness.truthy ? node.right : node.left;
+					break;
+				case '||':
+					taken = truthiness.truthy ? node.left : node.right;
+					break;
+				case '??':
+					taken = truthiness.nullish ? node.right : node.left;
+					break;
+				default:
+					return undefined;
+			}
+		} else {
+			return undefined;
+		}
+
+		changed = true;
+		// The operand that decides the result can also be the result. Sequencing
+		// it with itself would evaluate it twice.
+		if (taken === test || pure) return taken;
+		return b.sequence([test, taken]);
 	}
 
 	/**

--- a/packages/tsrx/src/optimize/index.js
+++ b/packages/tsrx/src/optimize/index.js
@@ -1,0 +1,769 @@
+/** @import * as AST from 'estree' */
+/** @import { Binding, OptimizeOptions, OptimizeResult, ResolveStaticIdentifier, StaticValue } from '../../types/index' */
+
+import { walk } from 'zimmerframe';
+import * as b from '../utils/builders.js';
+import { analyze_constants } from './constants.js';
+import {
+	evaluate_expression,
+	is_already_folded,
+	unwrap_expression,
+	value_to_node,
+} from './evaluate.js';
+
+/**
+ * Marker that stands in for a node the pass removed.
+ * zimmerframe can replace a node but cannot delete one.
+ * So a visitor swaps a dead node for this marker.
+ * The enclosing list then filters the markers out.
+ */
+const REMOVED = 'TSRXRemovedNode';
+
+/** @type {AST.Node} */
+const removed_node = /** @type {AST.Node} */ (/** @type {unknown} */ ({ type: REMOVED }));
+
+/**
+ * Reports whether a node is the removal marker.
+ *
+ * @param {AST.Node | null | undefined} node
+ * @returns {boolean}
+ */
+function is_removed(node) {
+	return /** @type {{ type?: string } | null | undefined} */ (node)?.type === REMOVED;
+}
+
+/**
+ * One fold can expose the next.
+ * Replacing `flag` with `false` is what makes the `@if` above it dead.
+ * So the pass repeats until a round changes nothing.
+ * This cap only stops a bug from looping forever.
+ */
+const MAX_ROUNDS = 5;
+
+/**
+ * Node kinds that can stand where a template renders a child.
+ * A branch holding exactly one of these can replace its `@if`.
+ * Any other branch keeps the directive and only loses its dead arm.
+ *
+ * @param {AST.Node | null | undefined} node
+ * @returns {boolean}
+ */
+function is_render_child(node) {
+	switch (node?.type) {
+		case 'JSXElement':
+		case 'JSXFragment':
+		case 'JSXText':
+		case 'JSXExpressionContainer':
+		case 'JSXStyleElement':
+		case 'JSXIfExpression':
+		case 'JSXForExpression':
+		case 'JSXSwitchExpression':
+		case 'JSXTryExpression':
+			return true;
+		case 'IfStatement':
+		case 'ForOfStatement':
+		case 'ForInStatement':
+		case 'ForStatement':
+		case 'SwitchStatement':
+		case 'TryStatement':
+			return !!(/** @type {{ statementType?: string }} */ (node).statementType);
+		default:
+			return false;
+	}
+}
+
+/**
+ * Identifier positions where a name is a value that can be substituted.
+ * A shorthand property shares one node between its key and its value.
+ * Folding it would rewrite the key too, so it is excluded.
+ * The other excluded positions are names rather than reads.
+ *
+ * @param {AST.Identifier} node
+ * @param {AST.Node[]} path
+ * @returns {boolean}
+ */
+function is_foldable_identifier_position(node, path) {
+	const parent = path.at(-1);
+	if (!parent) return false;
+
+	switch (parent.type) {
+		case 'Property':
+			return !parent.shorthand && parent.key !== node;
+		case 'MemberExpression':
+			return parent.computed || parent.property !== node;
+		case 'LabeledStatement':
+		case 'BreakStatement':
+		case 'ContinueStatement':
+		case 'ImportSpecifier':
+		case 'ImportDefaultSpecifier':
+		case 'ImportNamespaceSpecifier':
+		case 'ExportSpecifier':
+		case 'MethodDefinition':
+		case 'PropertyDefinition':
+			return false;
+		default:
+			return true;
+	}
+}
+
+/**
+ * @param {AST.Node | null | undefined} node
+ * @returns {boolean}
+ */
+function is_if_node(node) {
+	return node?.type === 'IfStatement' || node?.type === 'JSXIfExpression';
+}
+
+/**
+ * @param {AST.Node | null | undefined} node
+ * @returns {boolean}
+ */
+function is_template_directive_node(node) {
+	return (
+		node?.type === 'JSXIfExpression' ||
+		node?.type === 'JSXForExpression' ||
+		node?.type === 'JSXSwitchExpression' ||
+		node?.type === 'JSXTryExpression' ||
+		!!(node && /** @type {{ statementType?: string }} */ (node).statementType)
+	);
+}
+
+/**
+ * Reports whether a branch declares something that outlives it.
+ * `var` and function declarations hoist out of their block.
+ * A branch holding one stays observable even when unreachable.
+ * Such a branch is never removed.
+ * Nested functions have their own hoisting scope, so they are skipped.
+ *
+ * @param {AST.Node | null | undefined} node
+ * @returns {boolean}
+ */
+function contains_hoisted_declaration(node) {
+	if (!node) return false;
+
+	let found = false;
+
+	walk(node, null, {
+		FunctionDeclaration(_node, { stop }) {
+			found = true;
+			stop();
+		},
+		FunctionExpression() {},
+		ArrowFunctionExpression() {},
+		ClassDeclaration(_node, { stop }) {
+			found = true;
+			stop();
+		},
+		VariableDeclaration(declaration, { next, stop }) {
+			if (declaration.kind === 'var') {
+				found = true;
+				stop();
+				return;
+			}
+			next();
+		},
+	});
+
+	return found;
+}
+
+/**
+ * Statement kinds that can be dropped once control cannot reach them.
+ * Declarations are excluded on purpose.
+ * They are either hoisted, or removed later by the unused-binding rule.
+ * That rule checks that nothing refers to them, which is what makes it safe.
+ *
+ * @param {AST.Node} node
+ * @returns {boolean}
+ */
+function is_droppable_when_unreachable(node) {
+	switch (node.type) {
+		case 'ExpressionStatement':
+		case 'IfStatement':
+		case 'BlockStatement':
+		case 'ReturnStatement':
+		case 'ThrowStatement':
+		case 'BreakStatement':
+		case 'ContinueStatement':
+		case 'DebuggerStatement':
+		case 'EmptyStatement':
+		case 'SwitchStatement':
+		case 'TryStatement':
+		case 'WhileStatement':
+		case 'DoWhileStatement':
+		case 'ForStatement':
+		case 'ForInStatement':
+		case 'ForOfStatement':
+		case 'LabeledStatement':
+		case 'WithStatement':
+			// A template directive is output, not control flow.
+			// Reachability alone is not a reason to drop one.
+			return !is_template_directive_node(node);
+		default:
+			return false;
+	}
+}
+
+/**
+ * Reports whether dropping an initializer can be observed.
+ * A statically evaluable expression is safe to drop.
+ * So is a function or class literal, which touches nothing outside itself.
+ *
+ * @param {AST.Node} node
+ * @param {ResolveStaticIdentifier} resolve
+ * @returns {boolean}
+ */
+function is_pure_initializer(node, resolve) {
+	switch (unwrap_expression(node).type) {
+		case 'FunctionExpression':
+		case 'ArrowFunctionExpression':
+		case 'ClassExpression':
+			return true;
+		default:
+			return !!evaluate_expression(node, resolve);
+	}
+}
+
+/**
+ * @param {AST.Node} node
+ * @returns {boolean}
+ */
+function is_terminator(node) {
+	return (
+		node.type === 'ReturnStatement' ||
+		node.type === 'ThrowStatement' ||
+		node.type === 'BreakStatement' ||
+		node.type === 'ContinueStatement'
+	);
+}
+
+/**
+ * Drops removal markers.
+ * Then drops whatever follows an unconditional jump.
+ *
+ * @param {AST.Node[]} body
+ * @returns {AST.Node[] | null} The new list, or `null` when nothing changed.
+ */
+function prune_statements(body) {
+	/** @type {AST.Node[]} */
+	const result = [];
+	let terminated = false;
+	let changed = false;
+
+	for (const statement of body) {
+		if (is_removed(statement)) {
+			changed = true;
+			continue;
+		}
+
+		if (terminated && is_droppable_when_unreachable(statement)) {
+			changed = true;
+			continue;
+		}
+
+		result.push(statement);
+		if (!terminated && is_terminator(statement)) terminated = true;
+	}
+
+	return changed ? result : null;
+}
+
+/**
+ * @param {AST.Node[]} children
+ * @returns {AST.Node[] | null}
+ */
+function prune_children(children) {
+	if (!children.some(is_removed)) return null;
+	return children.filter((child) => !is_removed(child));
+}
+
+/**
+ * The one node a template branch renders, when that node is all it holds.
+ * A branch that also runs setup statements has no single-node form.
+ * That case returns `null`.
+ *
+ * @param {AST.Node | null | undefined} branch
+ * @returns {AST.Node | null}
+ */
+function branch_to_render_child(branch) {
+	if (!branch) return null;
+	if (is_render_child(branch)) return branch;
+	if (branch.type !== 'BlockStatement' || branch.body.length !== 1) return null;
+
+	const only = branch.body[0];
+	return only && is_render_child(only) ? only : null;
+}
+
+/**
+ * @param {AST.Node} node
+ * @returns {AST.Node}
+ */
+function empty_fragment(node) {
+	const fragment = b.jsx_fragment([]);
+	// The fragment sits in template position.
+	// The compiler tells authored TSRX output apart from plain JSX values there.
+	fragment.metadata = { ...(fragment.metadata ?? { path: [] }), native_tsrx: true };
+	return b.set_location(
+		fragment,
+		/** @type {AST.NodeWithLocation} */ (/** @type {unknown} */ (node)),
+	);
+}
+
+/**
+ * Reports whether `node` is a link in an `@if` chain rather than its head.
+ * Only the head carries the directive typing.
+ * So the whole chain is collapsed from the head.
+ * A link reached on its own is left alone.
+ *
+ * @param {AST.Node} node
+ * @param {AST.Node[]} path
+ * @returns {boolean}
+ */
+function is_template_if_chain_link(node, path) {
+	let child = node;
+
+	for (let i = path.length - 1; i >= 0; i -= 1) {
+		const parent = path[i];
+		if (!is_if_node(parent) || /** @type {AST.IfStatement} */ (parent).alternate !== child) {
+			return false;
+		}
+		if (is_template_directive_node(parent)) return true;
+		child = parent;
+	}
+
+	return false;
+}
+
+/**
+ * Every link of an `@if` / `@else if` chain, head first.
+ *
+ * @param {AST.IfStatement} head
+ * @returns {AST.IfStatement[]}
+ */
+function collect_if_chain(head) {
+	const links = [head];
+
+	while (true) {
+		const alternate = links[links.length - 1].alternate;
+		if (!alternate || !is_if_node(alternate)) return links;
+		links.push(/** @type {AST.IfStatement} */ (alternate));
+	}
+}
+
+/**
+ * Collapses a template `@if` chain against the tests it can evaluate.
+ * A link whose test is provably false is dropped.
+ * The first provably true test ends the chain, and its branch is the result.
+ * A chain that reduces to one output node replaces the directive.
+ * A chain that still has an unknown test is rebuilt from the surviving links.
+ *
+ * @param {AST.IfStatement} head
+ * @param {ResolveStaticIdentifier} resolve
+ * @returns {AST.Node | null} The replacement node, or `null` to keep the head.
+ */
+function collapse_template_if(head, resolve) {
+	const links = collect_if_chain(head);
+
+	/** @type {AST.IfStatement[]} */
+	const kept = [];
+	/** @type {AST.Node[]} */
+	const dropped = [];
+	/** @type {AST.Node | null | undefined} */
+	let taken;
+
+	for (const link of links) {
+		const test = evaluate_expression(link.test, resolve);
+
+		if (!test) {
+			kept.push(link);
+			continue;
+		}
+
+		if (test.value) {
+			taken = link.consequent;
+			break;
+		}
+
+		dropped.push(link.consequent);
+	}
+
+	// No test was decided, so nothing changes.
+	if (kept.length === links.length && taken === undefined) return null;
+
+	const trailing_else = links[links.length - 1].alternate;
+
+	/** @type {AST.Node | null} */
+	const alternate = taken !== undefined ? /** @type {AST.Node} */ (taken) : (trailing_else ?? null);
+
+	// Everything past the link that is provably taken is unreachable.
+	// So is the trailing `@else`, since some earlier branch already won.
+	const unreachable = [...dropped];
+	if (taken !== undefined) {
+		const taken_index = links.findIndex((link) => link.consequent === taken);
+		for (const link of links.slice(taken_index + 1)) unreachable.push(link.consequent);
+		if (trailing_else && !is_if_node(trailing_else)) unreachable.push(trailing_else);
+	}
+	if (unreachable.some((node) => contains_hoisted_declaration(node))) return null;
+
+	if (kept.length === 0) {
+		if (!alternate) return removed_node;
+		const child = branch_to_render_child(alternate);
+		if (child) return child;
+		// A branch with setup statements has no standalone form.
+		// The directive survives with a constant test and one arm.
+		return {
+			...head,
+			test: b.literal(true, 'true'),
+			consequent: /** @type {AST.Statement} */ (alternate),
+			alternate: null,
+		};
+	}
+
+	/** @type {AST.Node | null} */
+	let rebuilt = alternate;
+	for (let i = kept.length - 1; i >= 0; i -= 1) {
+		rebuilt = { ...kept[i], alternate: /** @type {AST.Statement | null} */ (rebuilt) };
+	}
+
+	// The head owns the directive typing.
+	// A promoted link has to inherit it.
+	return {
+		.../** @type {AST.IfStatement} */ (rebuilt),
+		type: head.type,
+		statementType: /** @type {any} */ (head).statementType,
+	};
+}
+
+/**
+ * Collapse a plain `if` statement whose test is statically known.
+ *
+ * @param {AST.IfStatement} node
+ * @param {StaticValue} test
+ * @returns {AST.Node | null}
+ */
+function collapse_if(node, test) {
+	const taken = test ? node.consequent : node.alternate;
+	const dropped = test ? node.alternate : node.consequent;
+
+	if (contains_hoisted_declaration(dropped)) return null;
+	// In statement position the branch is already a block.
+	// Keeping the block preserves its own `let` and `const` scope.
+	return taken ?? removed_node;
+}
+
+/**
+ * Collapses a `@switch` whose discriminant and case tests are all known.
+ *
+ * @param {AST.SwitchStatement} node
+ * @param {StaticValue} discriminant
+ * @param {ResolveStaticIdentifier} resolve
+ * @returns {AST.Node | null}
+ */
+function collapse_switch(node, discriminant, resolve) {
+	/** @type {AST.SwitchCase | null} */
+	let match = null;
+	/** @type {AST.SwitchCase | null} */
+	let fallback = null;
+
+	for (const switch_case of node.cases) {
+		if (!switch_case.test) {
+			fallback = switch_case;
+			continue;
+		}
+
+		const test = evaluate_expression(switch_case.test, resolve);
+		// One case test the pass cannot read makes every later case unreadable.
+		if (!test) return null;
+		if (match === null && test.value === discriminant) match = switch_case;
+	}
+
+	const taken = match ?? fallback;
+	if (!taken) return contains_hoisted_declaration(node) ? null : removed_node;
+
+	// `@switch` cases do not fall through.
+	// So the winning case is the whole result.
+	// It only replaces the directive when it is a lone output node.
+	const body = taken.consequent.filter((statement) => statement.type !== 'BreakStatement');
+	if (body.length !== 1 || !is_render_child(body[0])) return null;
+	if (contains_hoisted_declaration(node)) return null;
+
+	return body[0];
+}
+
+/**
+ * Reports whether an iterable literal provably yields nothing.
+ *
+ * @param {AST.Node | null | undefined} node
+ * @returns {boolean}
+ */
+function is_empty_iterable(node) {
+	if (!node) return false;
+	const expression = unwrap_expression(node);
+
+	if (expression.type === 'ArrayExpression') return expression.elements.length === 0;
+	if (expression.type === 'Literal') return expression.value === '';
+
+	return false;
+}
+
+/**
+ * One optimization round over a module.
+ *
+ * @param {AST.Program} ast
+ * @param {string | null} filename
+ * @returns {{ ast: AST.Program, changed: boolean }}
+ */
+function run_round(ast, filename) {
+	const { values, declarations, unused, resolve } = analyze_constants(ast, filename);
+	let changed = false;
+
+	/**
+	 * @param {AST.Node} node
+	 * @returns {AST.Node | undefined}
+	 */
+	function fold_expression(node) {
+		const evaluated = evaluate_expression(node, resolve);
+		if (!evaluated || is_already_folded(node, evaluated.value)) return undefined;
+
+		const folded = value_to_node(
+			evaluated.value,
+			/** @type {AST.NodeWithLocation} */ (/** @type {unknown} */ (node)),
+		);
+		if (!folded) return undefined;
+
+		changed = true;
+		return folded;
+	}
+
+	/**
+	 * @param {AST.Node} node
+	 * @param {{ next: () => AST.Node | undefined }} context
+	 * @returns {AST.Node | undefined}
+	 */
+	function visit_list_container(node, { next }) {
+		const visited = /** @type {any} */ (next() ?? node);
+		const key = 'children' in visited ? 'children' : 'body';
+		const list = visited[key];
+		if (!Array.isArray(list)) return visited === node ? undefined : visited;
+
+		const pruned = key === 'children' ? prune_children(list) : prune_statements(list);
+		if (!pruned) return visited === node ? undefined : visited;
+
+		changed = true;
+		return { ...visited, [key]: pruned };
+	}
+
+	/**
+	 * @param {AST.Identifier} node
+	 * @param {{ path: AST.Node[] }} context
+	 * @returns {AST.Node | undefined}
+	 */
+	function visit_identifier(node, { path }) {
+		if (!values.has(node) || declarations.has(node)) return undefined;
+		if (!is_foldable_identifier_position(node, path)) return undefined;
+		return fold_expression(node);
+	}
+
+	const visitors = {
+		Identifier: visit_identifier,
+
+		UnaryExpression: fold_expression_visitor,
+		BinaryExpression: fold_expression_visitor,
+		LogicalExpression: fold_expression_visitor,
+		ConditionalExpression: fold_expression_visitor,
+		TemplateLiteral: fold_expression_visitor,
+
+		Program: visit_list_container,
+		BlockStatement: visit_list_container,
+		StaticBlock: visit_list_container,
+		SwitchCase: visit_switch_case,
+		JSXElement: visit_list_container,
+		JSXFragment: visit_list_container,
+		JSXCodeBlock: visit_code_block,
+
+		IfStatement: visit_if,
+		JSXIfExpression: visit_if,
+		SwitchStatement: visit_switch,
+		JSXSwitchExpression: visit_switch,
+		ForOfStatement: visit_for,
+		JSXForExpression: visit_for,
+
+		VariableDeclaration: visit_variable_declaration,
+	};
+
+	/**
+	 * @param {AST.Node} node
+	 * @param {{ next: () => AST.Node | undefined }} context
+	 * @returns {AST.Node | undefined}
+	 */
+	function fold_expression_visitor(node, { next }) {
+		const visited = next() ?? node;
+		return fold_expression(visited) ?? (visited === node ? undefined : visited);
+	}
+
+	/**
+	 * @param {AST.SwitchCase} node
+	 * @param {{ next: () => AST.Node | undefined }} context
+	 * @returns {AST.Node | undefined}
+	 */
+	function visit_switch_case(node, { next }) {
+		const visited = /** @type {AST.SwitchCase} */ (next() ?? node);
+		const pruned = prune_statements(visited.consequent);
+		if (!pruned) return visited === node ? undefined : visited;
+
+		changed = true;
+		return { ...visited, consequent: /** @type {AST.Statement[]} */ (pruned) };
+	}
+
+	/**
+	 * @param {AST.JSXCodeBlock} node
+	 * @param {{ next: () => AST.Node | undefined }} context
+	 * @returns {AST.Node | undefined}
+	 */
+	function visit_code_block(node, { next }) {
+		const visited = /** @type {AST.JSXCodeBlock} */ (next() ?? node);
+		const pruned = visited.body ? prune_statements(visited.body) : null;
+		// A code block still has to render something.
+		// So an eliminated output becomes an empty fragment instead of nothing.
+		const render = is_removed(visited.render)
+			? empty_fragment(/** @type {AST.Node} */ (visited.render))
+			: visited.render;
+
+		if (!pruned && render === visited.render) return visited === node ? undefined : visited;
+
+		changed = true;
+		return {
+			...visited,
+			body: /** @type {AST.Statement[]} */ (pruned ?? visited.body),
+			render: /** @type {any} */ (render),
+		};
+	}
+
+	/**
+	 * @param {AST.Node} node
+	 * @param {{ next: () => AST.Node | undefined, path: AST.Node[] }} context
+	 * @returns {AST.Node | undefined}
+	 */
+	function visit_if(node, { next, path }) {
+		const chain_link = is_template_if_chain_link(node, path);
+		const visited = /** @type {AST.IfStatement} */ (next() ?? node);
+		const unchanged = visited === node ? undefined : visited;
+
+		// A chain link is collapsed by its head, never on its own.
+		if (chain_link) return unchanged;
+
+		if (is_template_directive_node(visited)) {
+			const replacement = collapse_template_if(visited, resolve);
+			if (!replacement) return unchanged;
+			changed = true;
+			return replacement;
+		}
+
+		const test = evaluate_expression(visited.test, resolve);
+		if (!test) return unchanged;
+
+		const replacement = collapse_if(visited, test.value);
+		if (!replacement) return unchanged;
+
+		changed = true;
+		return replacement;
+	}
+
+	/**
+	 * @param {AST.Node} node
+	 * @param {{ next: () => AST.Node | undefined }} context
+	 * @returns {AST.Node | undefined}
+	 */
+	function visit_switch(node, { next }) {
+		const visited = /** @type {AST.SwitchStatement} */ (next() ?? node);
+		if (!is_template_directive_node(visited)) return visited === node ? undefined : visited;
+
+		const discriminant = evaluate_expression(visited.discriminant, resolve);
+		if (!discriminant) return visited === node ? undefined : visited;
+
+		const replacement = collapse_switch(visited, discriminant.value, resolve);
+		if (!replacement) return visited === node ? undefined : visited;
+
+		changed = true;
+		return replacement;
+	}
+
+	/**
+	 * @param {AST.Node} node
+	 * @param {{ next: () => AST.Node | undefined }} context
+	 * @returns {AST.Node | undefined}
+	 */
+	function visit_for(node, { next }) {
+		const visited = /** @type {AST.ForOfStatement} */ (next() ?? node);
+		if (!is_template_directive_node(visited)) return visited === node ? undefined : visited;
+		if (!is_empty_iterable(visited.right)) return visited === node ? undefined : visited;
+		if (contains_hoisted_declaration(visited.body)) {
+			return visited === node ? undefined : visited;
+		}
+
+		changed = true;
+		return removed_node;
+	}
+
+	/**
+	 * @param {AST.VariableDeclaration} node
+	 * @param {{ next: () => AST.Node | undefined, path: AST.Node[] }} context
+	 * @returns {AST.Node | undefined}
+	 */
+	function visit_variable_declaration(node, { next, path }) {
+		const visited = /** @type {AST.VariableDeclaration} */ (next() ?? node);
+		// `var` is hoisted, so removing it changes what other code sees.
+		// An exported name is public no matter how this module uses it.
+		if (visited.kind === 'var' || path.at(-1)?.type.startsWith('Export')) {
+			return visited === node ? undefined : visited;
+		}
+
+		const kept = visited.declarations.filter((declarator) => {
+			if (declarator.id.type !== 'Identifier') return true;
+			const binding = declarations.get(declarator.id);
+			if (!binding || binding.kind !== 'normal' || !unused.has(binding)) return true;
+			// A name nothing reads is removable only if its initializer is pure.
+			return !!declarator.init && !is_pure_initializer(declarator.init, resolve);
+		});
+
+		if (kept.length === visited.declarations.length) {
+			return visited === node ? undefined : visited;
+		}
+
+		changed = true;
+		return kept.length === 0 ? removed_node : { ...visited, declarations: kept };
+	}
+
+	const next_ast = /** @type {AST.Program} */ (
+		walk(/** @type {AST.Node} */ (ast), null, /** @type {any} */ (visitors))
+	);
+
+	return { ast: next_ast, changed };
+}
+
+/**
+ * Folds statically known expressions and removes the code they prove dead.
+ * The pass is target-neutral.
+ * It runs on the parsed TSRX AST before any target transform.
+ * Every target therefore gets the same eliminations.
+ * It is opt-in through the `optimize` compile option.
+ * It must not run on the editor and Volar path.
+ * Those mappings have to match the authored source one for one.
+ *
+ * @param {AST.Program} ast
+ * @param {string | null | undefined} filename
+ * @param {OptimizeOptions} [options]
+ * @returns {OptimizeResult}
+ */
+export function optimize_tsrx(ast, filename, options = {}) {
+	const rounds = options.maxRounds ?? MAX_ROUNDS;
+	let current = ast;
+
+	for (let round = 0; round < rounds; round += 1) {
+		const result = run_round(current, filename ?? null);
+		current = result.ast;
+		if (!result.changed) break;
+	}
+
+	return { ast: current };
+}

--- a/packages/tsrx/tests/optimize/optimize.test.js
+++ b/packages/tsrx/tests/optimize/optimize.test.js
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { parseModule } from '../../src/index.js';
-import { evaluate_expression, value_to_node } from '../../src/optimize/evaluate.js';
+import {
+	evaluate_expression,
+	evaluate_truthiness,
+	value_to_node,
+} from '../../src/optimize/evaluate.js';
 import { optimize_tsrx } from '../../src/optimize/index.js';
 
 /** @import * as AST from 'estree' */
@@ -105,6 +109,38 @@ describe('static evaluation', () => {
 	it('reads the intrinsic globals', () => {
 		const ast = optimized(`export const flag = undefined === undefined;`);
 		expect(/** @type {any} */ (initializer(ast, 'flag')).value).toBe(true);
+	});
+});
+
+describe('truthiness evaluation', () => {
+	/**
+	 * @param {string} source
+	 * @returns {{ truthy: boolean, nullish: boolean, pure: boolean } | null}
+	 */
+	function truthiness(source) {
+		const ast = parseModule(`const value = ${source};`, 'App.tsrx');
+		return evaluate_truthiness(
+			/** @type {AST.Expression} */ (initializer(ast, 'value')),
+			() => null,
+		);
+	}
+
+	it('reads object-like literals as truthy', () => {
+		expect(truthiness('[]')).toEqual({ truthy: true, nullish: false, pure: true });
+		expect(truthiness('[compute()]')).toEqual({ truthy: true, nullish: false, pure: false });
+		expect(truthiness('{}')).toEqual({ truthy: true, nullish: false, pure: true });
+		expect(truthiness('() => 1')).toEqual({ truthy: true, nullish: false, pure: true });
+		expect(truthiness('/re/')).toEqual({ truthy: true, nullish: false, pure: true });
+	});
+
+	it('reads values it can evaluate outright', () => {
+		expect(truthiness('0')).toEqual({ truthy: false, nullish: false, pure: true });
+		expect(truthiness('null')).toEqual({ truthy: false, nullish: true, pure: true });
+	});
+
+	it('refuses expressions whose truthiness is unknown', () => {
+		expect(truthiness('compute()')).toBeNull();
+		expect(truthiness('source.value')).toBeNull();
 	});
 });
 

--- a/packages/tsrx/tests/optimize/optimize.test.js
+++ b/packages/tsrx/tests/optimize/optimize.test.js
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+import { parseModule } from '../../src/index.js';
+import { evaluate_expression, value_to_node } from '../../src/optimize/evaluate.js';
+import { optimize_tsrx } from '../../src/optimize/index.js';
+
+/** @import * as AST from 'estree' */
+
+/**
+ * Parse a module, run the pass over it, and hand back the optimized program.
+ *
+ * @param {string} source
+ * @returns {AST.Program}
+ */
+function optimized(source) {
+	return optimize_tsrx(parseModule(source, 'App.tsrx'), 'App.tsrx').ast;
+}
+
+/**
+ * The single expression of `const <name> = …` anywhere in a program.
+ *
+ * @param {AST.Program} ast
+ * @param {string} name
+ * @returns {AST.Node | null}
+ */
+function initializer(ast, name) {
+	/** @type {AST.Node | null} */
+	let found = null;
+
+	/** @param {any} node */
+	function visit(node) {
+		if (!node || typeof node !== 'object' || found) return;
+
+		if (
+			node.type === 'VariableDeclarator' &&
+			node.id?.type === 'Identifier' &&
+			node.id.name === name
+		) {
+			found = node.init ?? null;
+			return;
+		}
+
+		for (const key of Object.keys(node)) {
+			const child = node[key];
+			if (Array.isArray(child)) child.forEach(visit);
+			else if (child && typeof child === 'object') visit(child);
+		}
+	}
+
+	visit(ast);
+	return found;
+}
+
+/**
+ * Evaluate a standalone expression with no bindings in play.
+ *
+ * @param {string} source
+ * @returns {{ value: unknown } | null}
+ */
+function evaluate(source) {
+	const ast = parseModule(`const value = ${source};`, 'App.tsrx');
+	return evaluate_expression(/** @type {AST.Expression} */ (initializer(ast, 'value')), () => null);
+}
+
+describe('static evaluation', () => {
+	it('evaluates arithmetic, comparison and logical operators', () => {
+		expect(evaluate('2 + 3 * 4')).toEqual({ value: 14 });
+		expect(evaluate('10 % 4')).toEqual({ value: 2 });
+		expect(evaluate('2 ** 10')).toEqual({ value: 1024 });
+		expect(evaluate("'a' === 'a'")).toEqual({ value: true });
+		expect(evaluate('1 < 2 && 3 > 4')).toEqual({ value: false });
+		expect(evaluate("null ?? 'fallback'")).toEqual({ value: 'fallback' });
+		expect(evaluate('false || 7')).toEqual({ value: 7 });
+	});
+
+	it('evaluates unary operators', () => {
+		expect(evaluate('!0')).toEqual({ value: true });
+		expect(evaluate('-(2 + 3)')).toEqual({ value: -5 });
+		expect(evaluate("typeof 'text'")).toEqual({ value: 'string' });
+		expect(evaluate('~5')).toEqual({ value: -6 });
+	});
+
+	it('evaluates a template literal with static holes', () => {
+		expect(evaluate('`a${1 + 1}b`')).toEqual({ value: 'a2b' });
+	});
+
+	it('short-circuits before reading an unknown operand', () => {
+		expect(evaluate('false && missing')).toEqual({ value: false });
+		expect(evaluate('true || missing')).toEqual({ value: true });
+		expect(evaluate('true && missing')).toBeNull();
+	});
+
+	it('refuses values it cannot prove', () => {
+		expect(evaluate('missing')).toBeNull();
+		expect(evaluate('compute()')).toBeNull();
+		expect(evaluate('{ a: 1 }.a')).toBeNull();
+		expect(evaluate('[1, 2]')).toBeNull();
+		expect(evaluate('/re/')).toBeNull();
+		expect(evaluate("'text' in object")).toBeNull();
+	});
+
+	it('refuses an operation that would throw at runtime', () => {
+		expect(evaluate('1n + 1')).toBeNull();
+	});
+
+	it('reads the intrinsic globals', () => {
+		const ast = optimized(`export const flag = undefined === undefined;`);
+		expect(/** @type {any} */ (initializer(ast, 'flag')).value).toBe(true);
+	});
+});
+
+describe('value materialization', () => {
+	it('builds a literal for every representable value', () => {
+		expect(value_to_node('text')).toMatchObject({ type: 'Literal', value: 'text' });
+		expect(value_to_node(true)).toMatchObject({ type: 'Literal', value: true });
+		expect(value_to_node(null)).toMatchObject({ type: 'Literal', value: null });
+		expect(value_to_node(-3)).toMatchObject({ type: 'UnaryExpression', operator: '-' });
+		expect(value_to_node(undefined)).toMatchObject({ type: 'UnaryExpression', operator: 'void' });
+	});
+
+	it('refuses values with no literal form', () => {
+		expect(value_to_node(NaN)).toBeNull();
+		expect(value_to_node(Infinity)).toBeNull();
+		expect(value_to_node(-0)).toBeNull();
+	});
+});
+
+describe('optimize pass', () => {
+	it('propagates a constant through a chain of constants', () => {
+		const ast = optimized(`
+			const base = 2;
+			const doubled = base * 2;
+			export const total = doubled + 1;
+		`);
+
+		expect(/** @type {any} */ (initializer(ast, 'total')).value).toBe(5);
+	});
+
+	it('leaves a reassigned binding alone', () => {
+		const ast = optimized(`
+			let count = 1;
+			count = 2;
+			export const total = count + 1;
+		`);
+
+		expect(/** @type {any} */ (initializer(ast, 'total')).type).toBe('BinaryExpression');
+	});
+
+	it('leaves a mutated binding alone', () => {
+		const ast = optimized(`
+			const config = { on: true };
+			config.on = false;
+			export const state = config;
+		`);
+
+		expect(/** @type {any} */ (initializer(ast, 'state')).type).toBe('Identifier');
+	});
+
+	it('does not fold a shadowing declaration in an inner scope', () => {
+		const ast = optimized(`
+			const size = 1;
+			export function read(size) {
+				return size + 1;
+			}
+			export const outer = size + 1;
+		`);
+
+		expect(/** @type {any} */ (initializer(ast, 'outer')).value).toBe(2);
+
+		const read = /** @type {any} */ (
+			ast.body.find((statement) => /** @type {any} */ (statement).declaration?.id?.name === 'read')
+		);
+		expect(read.declaration.body.body[0].argument.type).toBe('BinaryExpression');
+	});
+
+	it('keeps a shorthand property intact', () => {
+		const ast = optimized(`
+			const x = 1;
+			export const wrapper = { x };
+		`);
+
+		const property = /** @type {any} */ (initializer(ast, 'wrapper')).properties[0];
+		expect(property.shorthand).toBe(true);
+		expect(property.key.type).toBe('Identifier');
+	});
+
+	it('does not fold a non-computed member property', () => {
+		const ast = optimized(`
+			const key = 1;
+			export const read = source.key;
+		`);
+
+		expect(/** @type {any} */ (initializer(ast, 'read')).property.type).toBe('Identifier');
+	});
+
+	it('settles even when a fold exposes another one', () => {
+		const ast = optimized(`
+			const a = 1;
+			const b = a + 1;
+			const c = b + 1;
+			const d = c + 1;
+			export const total = d + 1;
+		`);
+
+		expect(/** @type {any} */ (initializer(ast, 'total')).value).toBe(5);
+	});
+});

--- a/packages/tsrx/tests/optimize/optimize.test.js
+++ b/packages/tsrx/tests/optimize/optimize.test.js
@@ -1,33 +1,20 @@
 import { describe, expect, it } from 'vitest';
 import { parseModule } from '../../src/index.js';
-import {
-	evaluate_expression,
-	evaluate_truthiness,
-	value_to_node,
-} from '../../src/optimize/evaluate.js';
+import { evaluate_expression, evaluate_truthiness } from '../../src/optimize/evaluate.js';
+import { create_constant_resolver } from '../../src/optimize/constants.js';
 import { optimize_tsrx } from '../../src/optimize/index.js';
 
 /** @import * as AST from 'estree' */
 
 /**
- * Parse a module, run the pass over it, and hand back the optimized program.
+ * The initializer of `const <name> = …` anywhere in a program.
  *
- * @param {string} source
- * @returns {AST.Program}
- */
-function optimized(source) {
-	return optimize_tsrx(parseModule(source, 'App.tsrx'), 'App.tsrx').ast;
-}
-
-/**
- * The single expression of `const <name> = …` anywhere in a program.
- *
- * @param {AST.Program} ast
+ * @param {AST.Node} ast
  * @param {string} name
- * @returns {AST.Node | null}
+ * @returns {any}
  */
 function initializer(ast, name) {
-	/** @type {AST.Node | null} */
+	/** @type {any} */
 	let found = null;
 
 	/** @param {any} node */
@@ -62,7 +49,62 @@ function initializer(ast, name) {
  */
 function evaluate(source) {
 	const ast = parseModule(`const value = ${source};`, 'App.tsrx');
-	return evaluate_expression(/** @type {AST.Expression} */ (initializer(ast, 'value')), () => null);
+	return evaluate_expression(initializer(ast, 'value'), () => null);
+}
+
+/**
+ * Read the truthiness of a standalone expression.
+ *
+ * @param {string} source
+ * @returns {{ truthy: boolean, nullish: boolean, pure: boolean } | null}
+ */
+function truthiness(source) {
+	const ast = parseModule(`const value = ${source};`, 'App.tsrx');
+	return evaluate_truthiness(initializer(ast, 'value'), () => null);
+}
+
+/**
+ * Resolve a named constant the way the pass does when deciding a test.
+ *
+ * @param {string} source
+ * @param {string} name
+ * @returns {{ value: unknown } | null}
+ */
+function resolved(source, name) {
+	const ast = parseModule(source, 'App.tsrx');
+	const resolve = create_constant_resolver(ast, 'App.tsrx');
+
+	/** @type {any} */
+	let reference = null;
+
+	/** @param {any} node */
+	function visit(node) {
+		if (!node || typeof node !== 'object' || reference) return;
+
+		if (node.type === 'JSXExpressionContainer' && node.expression?.name === name) {
+			reference = node.expression;
+			return;
+		}
+
+		for (const key of Object.keys(node)) {
+			const child = node[key];
+			if (Array.isArray(child)) child.forEach(visit);
+			else if (child && typeof child === 'object') visit(child);
+		}
+	}
+
+	visit(ast);
+	return reference ? resolve(reference) : null;
+}
+
+/**
+ * Parse a module, run the pass over it, and hand back the optimized program.
+ *
+ * @param {string} source
+ * @returns {AST.Program}
+ */
+function optimized(source) {
+	return optimize_tsrx(parseModule(source, 'App.tsrx'), 'App.tsrx').ast;
 }
 
 describe('static evaluation', () => {
@@ -105,26 +147,9 @@ describe('static evaluation', () => {
 	it('refuses an operation that would throw at runtime', () => {
 		expect(evaluate('1n + 1')).toBeNull();
 	});
-
-	it('reads the intrinsic globals', () => {
-		const ast = optimized(`export const flag = undefined === undefined;`);
-		expect(/** @type {any} */ (initializer(ast, 'flag')).value).toBe(true);
-	});
 });
 
 describe('truthiness evaluation', () => {
-	/**
-	 * @param {string} source
-	 * @returns {{ truthy: boolean, nullish: boolean, pure: boolean } | null}
-	 */
-	function truthiness(source) {
-		const ast = parseModule(`const value = ${source};`, 'App.tsrx');
-		return evaluate_truthiness(
-			/** @type {AST.Expression} */ (initializer(ast, 'value')),
-			() => null,
-		);
-	}
-
 	it('reads object-like literals as truthy', () => {
 		expect(truthiness('[]')).toEqual({ truthy: true, nullish: false, pure: true });
 		expect(truthiness('[compute()]')).toEqual({ truthy: true, nullish: false, pure: false });
@@ -144,99 +169,100 @@ describe('truthiness evaluation', () => {
 	});
 });
 
-describe('value materialization', () => {
-	it('builds a literal for every representable value', () => {
-		expect(value_to_node('text')).toMatchObject({ type: 'Literal', value: 'text' });
-		expect(value_to_node(true)).toMatchObject({ type: 'Literal', value: true });
-		expect(value_to_node(null)).toMatchObject({ type: 'Literal', value: null });
-		expect(value_to_node(-3)).toMatchObject({ type: 'UnaryExpression', operator: '-' });
-		expect(value_to_node(undefined)).toMatchObject({ type: 'UnaryExpression', operator: 'void' });
+describe('constant resolution', () => {
+	it('resolves a chain of constants', () => {
+		const value = resolved(
+			`const base = 2;
+			const doubled = base * 2;
+			const total = doubled + 1;
+			export function App() @{
+				<span class="x">{total}</span>
+			}`,
+			'total',
+		);
+
+		expect(value).toEqual({ value: 5 });
 	});
 
-	it('refuses values with no literal form', () => {
-		expect(value_to_node(NaN)).toBeNull();
-		expect(value_to_node(Infinity)).toBeNull();
-		expect(value_to_node(-0)).toBeNull();
+	it('refuses a reassigned binding', () => {
+		const value = resolved(
+			`let count = 1;
+			count = 2;
+			export function App() @{
+				<span class="x">{count}</span>
+			}`,
+			'count',
+		);
+
+		expect(value).toBeNull();
+	});
+
+	it('refuses a mutated binding', () => {
+		const value = resolved(
+			`const config = { on: true };
+			config.on = false;
+			export function App() @{
+				<span class="x">{config}</span>
+			}`,
+			'config',
+		);
+
+		expect(value).toBeNull();
+	});
+
+	it('refuses a name shadowed by an inner binding', () => {
+		const value = resolved(
+			`const size = 1;
+			export function App({ size }) @{
+				<span class="x">{size}</span>
+			}`,
+			'size',
+		);
+
+		expect(value).toBeNull();
+	});
+
+	it('reads the intrinsic globals', () => {
+		const value = resolved(
+			`export function App() @{
+				<span class="x">{undefined}</span>
+			}`,
+			'undefined',
+		);
+
+		expect(value).toEqual({ value: undefined });
 	});
 });
 
 describe('optimize pass', () => {
-	it('propagates a constant through a chain of constants', () => {
+	it('leaves setup statements and plain JavaScript alone', () => {
 		const ast = optimized(`
-			const base = 2;
-			const doubled = base * 2;
-			export const total = doubled + 1;
-		`);
-
-		expect(/** @type {any} */ (initializer(ast, 'total')).value).toBe(5);
-	});
-
-	it('leaves a reassigned binding alone', () => {
-		const ast = optimized(`
-			let count = 1;
-			count = 2;
-			export const total = count + 1;
-		`);
-
-		expect(/** @type {any} */ (initializer(ast, 'total')).type).toBe('BinaryExpression');
-	});
-
-	it('leaves a mutated binding alone', () => {
-		const ast = optimized(`
-			const config = { on: true };
-			config.on = false;
-			export const state = config;
-		`);
-
-		expect(/** @type {any} */ (initializer(ast, 'state')).type).toBe('Identifier');
-	});
-
-	it('does not fold a shadowing declaration in an inner scope', () => {
-		const ast = optimized(`
-			const size = 1;
-			export function read(size) {
-				return size + 1;
+			const outside = 2 + 3;
+			export function App() @{
+				const inside = 2 + 3;
+				<span class="x">{inside}</span>
 			}
-			export const outer = size + 1;
 		`);
 
-		expect(/** @type {any} */ (initializer(ast, 'outer')).value).toBe(2);
-
-		const read = /** @type {any} */ (
-			ast.body.find((statement) => /** @type {any} */ (statement).declaration?.id?.name === 'read')
-		);
-		expect(read.declaration.body.body[0].argument.type).toBe('BinaryExpression');
+		expect(initializer(ast, 'outside').type).toBe('BinaryExpression');
+		expect(initializer(ast, 'inside').type).toBe('BinaryExpression');
 	});
 
-	it('keeps a shorthand property intact', () => {
+	it('settles when a collapse exposes another one', () => {
 		const ast = optimized(`
-			const x = 1;
-			export const wrapper = { x };
+			export function App({ label }) @{
+				@if (false) {
+					<b class="dead">{label}</b>
+				} @else {
+					@if (true) {
+						<i class="live">{label}</i>
+					}
+				}
+			}
 		`);
 
-		const property = /** @type {any} */ (initializer(ast, 'wrapper')).properties[0];
-		expect(property.shorthand).toBe(true);
-		expect(property.key.type).toBe('Identifier');
-	});
-
-	it('does not fold a non-computed member property', () => {
-		const ast = optimized(`
-			const key = 1;
-			export const read = source.key;
-		`);
-
-		expect(/** @type {any} */ (initializer(ast, 'read')).property.type).toBe('Identifier');
-	});
-
-	it('settles even when a fold exposes another one', () => {
-		const ast = optimized(`
-			const a = 1;
-			const b = a + 1;
-			const c = b + 1;
-			const d = c + 1;
-			export const total = d + 1;
-		`);
-
-		expect(/** @type {any} */ (initializer(ast, 'total')).value).toBe(5);
+		const render = /** @type {any} */ (ast.body[0]).declaration.body.render;
+		expect(render.type).toBe('JSXElement');
+		expect(render.openingElement.name.name).toBe('i');
 	});
 });

--- a/packages/tsrx/tests/shared/optimize.js
+++ b/packages/tsrx/tests/shared/optimize.js
@@ -190,6 +190,79 @@ export function runSharedOptimizeTests({ compile, compile_to_volar_mappings, nam
 			expect(code).not.toContain('dead');
 		});
 
+		it('renders the @empty clause when the iterable is empty', () => {
+			const code = compiled(
+				`export function App() @{
+					<ul>
+						@for (const item of []) {
+							<li class="row">{'rowbody'}</li>
+						} @empty {
+							<li class="none">{'emptybody'}</li>
+						}
+					</ul>
+				}`,
+				true,
+			);
+
+			expect(code).toContain('emptybody');
+			expect(code).not.toContain('rowbody');
+		});
+
+		it('keeps a loop header whose binding is never read', () => {
+			const code = compiled(
+				`export function count(items) {
+					let total = 0;
+					for (const entry of items) {
+						total += 1;
+					}
+					return total;
+				}`,
+				true,
+			);
+
+			expect(code).toContain('entry');
+		});
+
+		it('keeps an unused class whose evaluation has side effects', () => {
+			const code = compiled(
+				`export function App({ base, register }) @{
+					const Unused = class extends base() {
+						static field = register();
+					};
+					<span class="x">{'x'}</span>
+				}`,
+				true,
+			);
+
+			expect(code).toContain('Unused');
+		});
+
+		it('replaces a dead if in an unbraced arm with an empty statement', () => {
+			const code = compiled(
+				`export function run(ready) {
+					if (ready) if (false) dropped();
+					return ready;
+				}`,
+				true,
+			);
+
+			expect(code).not.toContain('dropped');
+			expect(code).toContain('if (ready)');
+		});
+
+		it('replaces a dead if in a loop body with an empty statement', () => {
+			const code = compiled(
+				`export function run(ready) {
+					while (ready) if (false) dropped();
+					return ready;
+				}`,
+				true,
+			);
+
+			expect(code).not.toContain('dropped');
+			expect(code).toContain('while (ready)');
+		});
+
 		it('removes statements that follow a return', () => {
 			const code = compiled(
 				`export function value() {

--- a/packages/tsrx/tests/shared/optimize.js
+++ b/packages/tsrx/tests/shared/optimize.js
@@ -190,6 +190,32 @@ export function runSharedOptimizeTests({ compile, compile_to_volar_mappings, nam
 			expect(code).not.toContain('dead');
 		});
 
+		it('picks the arm of a ternary whose test is always truthy', () => {
+			const code = compiled(
+				`export function pick(probe, hit, miss) {
+					return [probe()] ? hit() : miss();
+				}`,
+				true,
+			);
+
+			expect(code).toContain('probe()');
+			expect(code).toContain('hit()');
+			expect(code).not.toContain('miss()');
+		});
+
+		it('drops a side-effect free test instead of sequencing it', () => {
+			const code = compiled(
+				`export function pick(hit, miss) {
+					return [] ? hit() : miss();
+				}`,
+				true,
+			);
+
+			expect(code).toContain('hit()');
+			expect(code).not.toContain('miss()');
+			expect(code).not.toContain('[]');
+		});
+
 		it('renders the @empty clause when the iterable is empty', () => {
 			const code = compiled(
 				`export function App() @{

--- a/packages/tsrx/tests/shared/optimize.js
+++ b/packages/tsrx/tests/shared/optimize.js
@@ -1,0 +1,279 @@
+import { describe, expect, it } from 'vitest';
+
+/** @import { OptimizeHarness } from '../../types/index' */
+
+/**
+ * Shared coverage for the opt-in dead-code elimination pass.
+ * Every target runs the same target-neutral pass, so the expectations here are
+ * about what survives compilation rather than about generated syntax.
+ *
+ * @param {OptimizeHarness} harness
+ */
+export function runSharedOptimizeTests({ compile, compile_to_volar_mappings, name }) {
+	/**
+	 * @param {string} source
+	 * @param {boolean} optimize
+	 * @returns {string}
+	 */
+	function compiled(source, optimize) {
+		const result = compile(source, 'App.tsrx', { optimize });
+		expect(result.errors ?? []).toEqual([]);
+		return result.code;
+	}
+
+	describe(`[${name}] dead-code elimination`, () => {
+		it('is off unless the caller opts in', () => {
+			const source = `export function App() @{
+				const flag = false;
+				@if (flag) {
+					<div class="dead">{'dead'}</div>
+				} @else {
+					<div class="live">{'live'}</div>
+				}
+			}`;
+
+			expect(compiled(source, false)).toContain('dead');
+			expect(compiled(source, true)).not.toContain('dead');
+		});
+
+		it('folds a constant into the expressions that read it', () => {
+			const code = compiled(
+				`export function App() @{
+					const count = 2 + 3;
+					<span class="total">{count * 2}</span>
+				}`,
+				true,
+			);
+
+			expect(code).toContain('10');
+			expect(code).not.toContain('count');
+		});
+
+		it('folds a template literal built from constants', () => {
+			const code = compiled(
+				`export function App() @{
+					const who = 'world';
+					<span class="greeting">{\`hello \${who}\`}</span>
+				}`,
+				true,
+			);
+
+			expect(code).toContain('hello world');
+			expect(code).not.toContain('who');
+		});
+
+		it('keeps the branch a constant test selects and drops the other', () => {
+			const code = compiled(
+				`export function App() @{
+					@if (1 > 2) {
+						<div class="dead">{'dead'}</div>
+					} @else {
+						<div class="live">{'live'}</div>
+					}
+				}`,
+				true,
+			);
+
+			expect(code).toContain('live');
+			expect(code).not.toContain('dead');
+		});
+
+		it('drops a false branch of an @if that has no @else', () => {
+			const code = compiled(
+				`export function App() @{
+					<ul>
+						@if (false) {
+							<li class="dead">{'dead'}</li>
+						}
+						<li class="live">{'live'}</li>
+					</ul>
+				}`,
+				true,
+			);
+
+			expect(code).toContain('live');
+			expect(code).not.toContain('dead');
+		});
+
+		it('promotes a surviving @else if into the directive position', () => {
+			const code = compiled(
+				`export function App({ ready }) @{
+					@if (false) {
+						<div class="dead">{'dead'}</div>
+					} @else if (ready) {
+						<div class="ready">{'ready'}</div>
+					} @else {
+						<div class="waiting">{'waiting'}</div>
+					}
+				}`,
+				true,
+			);
+
+			expect(code).toContain('ready');
+			expect(code).toContain('waiting');
+			expect(code).not.toContain('dead');
+		});
+
+		it('keeps a directive whose test it cannot evaluate', () => {
+			const code = compiled(
+				`export function App({ ready }) @{
+					@if (ready) {
+						<div class="yes">{'yes'}</div>
+					} @else {
+						<div class="no">{'no'}</div>
+					}
+				}`,
+				true,
+			);
+
+			expect(code).toContain('yes');
+			expect(code).toContain('no');
+		});
+
+		it('selects the matching case of a constant @switch', () => {
+			const code = compiled(
+				`export function App() @{
+					const mode = 'b';
+					@switch (mode) {
+						@case 'a': {
+							<div class="alpha">{'alphacase'}</div>
+						}
+						@case 'b': {
+							<div class="bravo">{'bravocase'}</div>
+						}
+						@default: {
+							<div class="delta">{'deltacase'}</div>
+						}
+					}
+				}`,
+				true,
+			);
+
+			expect(code).toContain('bravocase');
+			expect(code).not.toContain('alphacase');
+			expect(code).not.toContain('deltacase');
+		});
+
+		it('falls back to @default when no case matches', () => {
+			const code = compiled(
+				`export function App() @{
+					@switch (9) {
+						@case 1: {
+							<div class="first">{'firstcase'}</div>
+						}
+						@default: {
+							<div class="fallback">{'fallbackcase'}</div>
+						}
+					}
+				}`,
+				true,
+			);
+
+			expect(code).toContain('fallbackcase');
+			expect(code).not.toContain('firstcase');
+		});
+
+		it('removes a @for over an empty iterable', () => {
+			const code = compiled(
+				`export function App() @{
+					<ul>
+						@for (const item of []) {
+							<li class="dead">{item}</li>
+						}
+						<li class="live">{'live'}</li>
+					</ul>
+				}`,
+				true,
+			);
+
+			expect(code).toContain('live');
+			expect(code).not.toContain('dead');
+		});
+
+		it('removes statements that follow a return', () => {
+			const code = compiled(
+				`export function value() {
+					return 1;
+					console.log('unreachable');
+				}`,
+				true,
+			);
+
+			expect(code).not.toContain('unreachable');
+		});
+
+		it('removes a binding nothing reads', () => {
+			const code = compiled(
+				`export function App() @{
+					const unused = 1 + 1;
+					<span class="x">{'x'}</span>
+				}`,
+				true,
+			);
+
+			expect(code).not.toContain('unused');
+		});
+
+		it('keeps a binding whose initializer has side effects', () => {
+			const code = compiled(
+				`export function App({ track }) @{
+					const unused = track();
+					<span class="x">{'x'}</span>
+				}`,
+				true,
+			);
+
+			expect(code).toContain('track()');
+		});
+
+		it('keeps an exported constant', () => {
+			const code = compiled(`export const VERSION = '1.0.0';`, true);
+
+			expect(code).toContain('VERSION');
+		});
+
+		it('keeps a constant a type refers to', () => {
+			const code = compiled(
+				`const LIMIT = 10;
+				type Limit = typeof LIMIT;
+				export function App({ max }: { max: Limit }) @{
+					<span class="max">{max}</span>
+				}`,
+				true,
+			);
+
+			expect(code).toContain('LIMIT');
+		});
+
+		it('keeps a branch that declares a hoisted name', () => {
+			const code = compiled(
+				`export function App() {
+					if (false) {
+						var hoisted = 1;
+					}
+					return typeof hoisted;
+				}`,
+				true,
+			);
+
+			expect(code).toContain('hoisted');
+		});
+
+		it('does not run on the editor mapping path', () => {
+			const { code } = compile_to_volar_mappings(
+				`export function App() @{
+					@if (false) {
+						<div class="dead">{'dead'}</div>
+					} @else {
+						<div class="live">{'live'}</div>
+					}
+				}`,
+				'App.tsrx',
+				/** @type {any} */ ({ optimize: true }),
+			);
+
+			expect(code).toContain('dead');
+			expect(code).toContain('live');
+		});
+	});
+}

--- a/packages/tsrx/tests/shared/optimize.js
+++ b/packages/tsrx/tests/shared/optimize.js
@@ -4,8 +4,8 @@ import { describe, expect, it } from 'vitest';
 
 /**
  * Shared coverage for the opt-in dead-code elimination pass.
- * Every target runs the same target-neutral pass, so the expectations here are
- * about what survives compilation rather than about generated syntax.
+ * The pass only rewrites the TSRX keyword directives, so these expectations are
+ * about which branches survive compilation and about what stays untouched.
  *
  * @param {OptimizeHarness} harness
  */
@@ -26,56 +26,30 @@ export function runSharedOptimizeTests({ compile, compile_to_volar_mappings, nam
 			const source = `export function App() @{
 				const flag = false;
 				@if (flag) {
-					<div class="dead">{'dead'}</div>
+					<div class="dead">{'deadtext'}</div>
 				} @else {
-					<div class="live">{'live'}</div>
+					<div class="live">{'livetext'}</div>
 				}
 			}`;
 
-			expect(compiled(source, false)).toContain('dead');
-			expect(compiled(source, true)).not.toContain('dead');
-		});
-
-		it('folds a constant into the expressions that read it', () => {
-			const code = compiled(
-				`export function App() @{
-					const count = 2 + 3;
-					<span class="total">{count * 2}</span>
-				}`,
-				true,
-			);
-
-			expect(code).toContain('10');
-			expect(code).not.toContain('count');
-		});
-
-		it('folds a template literal built from constants', () => {
-			const code = compiled(
-				`export function App() @{
-					const who = 'world';
-					<span class="greeting">{\`hello \${who}\`}</span>
-				}`,
-				true,
-			);
-
-			expect(code).toContain('hello world');
-			expect(code).not.toContain('who');
+			expect(compiled(source, false)).toContain('deadtext');
+			expect(compiled(source, true)).not.toContain('deadtext');
 		});
 
 		it('keeps the branch a constant test selects and drops the other', () => {
 			const code = compiled(
 				`export function App() @{
 					@if (1 > 2) {
-						<div class="dead">{'dead'}</div>
+						<div class="dead">{'deadtext'}</div>
 					} @else {
-						<div class="live">{'live'}</div>
+						<div class="live">{'livetext'}</div>
 					}
 				}`,
 				true,
 			);
 
-			expect(code).toContain('live');
-			expect(code).not.toContain('dead');
+			expect(code).toContain('livetext');
+			expect(code).not.toContain('deadtext');
 		});
 
 		it('drops a false branch of an @if that has no @else', () => {
@@ -83,51 +57,99 @@ export function runSharedOptimizeTests({ compile, compile_to_volar_mappings, nam
 				`export function App() @{
 					<ul>
 						@if (false) {
-							<li class="dead">{'dead'}</li>
+							<li class="dead">{'deadtext'}</li>
 						}
-						<li class="live">{'live'}</li>
+						<li class="live">{'livetext'}</li>
 					</ul>
 				}`,
 				true,
 			);
 
-			expect(code).toContain('live');
-			expect(code).not.toContain('dead');
+			expect(code).toContain('livetext');
+			expect(code).not.toContain('deadtext');
+		});
+
+		it('renders an empty fragment when the only output is removed', () => {
+			const code = compiled(
+				`export function App() @{
+					@if (false) {
+						<div class="dead">{'deadtext'}</div>
+					}
+				}`,
+				true,
+			);
+
+			expect(code).not.toContain('deadtext');
 		});
 
 		it('promotes a surviving @else if into the directive position', () => {
 			const code = compiled(
 				`export function App({ ready }) @{
 					@if (false) {
-						<div class="dead">{'dead'}</div>
+						<div class="dead">{'deadtext'}</div>
 					} @else if (ready) {
-						<div class="ready">{'ready'}</div>
+						<div class="ready">{'readytext'}</div>
 					} @else {
-						<div class="waiting">{'waiting'}</div>
+						<div class="waiting">{'waitingtext'}</div>
 					}
 				}`,
 				true,
 			);
 
-			expect(code).toContain('ready');
-			expect(code).toContain('waiting');
-			expect(code).not.toContain('dead');
+			expect(code).toContain('readytext');
+			expect(code).toContain('waitingtext');
+			expect(code).not.toContain('deadtext');
 		});
 
-		it('keeps a directive whose test it cannot evaluate', () => {
+		it('keeps a directive whose test it cannot decide', () => {
 			const code = compiled(
 				`export function App({ ready }) @{
 					@if (ready) {
-						<div class="yes">{'yes'}</div>
+						<div class="yes">{'yestext'}</div>
 					} @else {
-						<div class="no">{'no'}</div>
+						<div class="no">{'notext'}</div>
 					}
 				}`,
 				true,
 			);
 
-			expect(code).toContain('yes');
-			expect(code).toContain('no');
+			expect(code).toContain('yestext');
+			expect(code).toContain('notext');
+		});
+
+		it('keeps a directive whose test has side effects', () => {
+			const code = compiled(
+				`export function App({ probe }) @{
+					@if ([probe()]) {
+						<div class="yes">{'yestext'}</div>
+					} @else {
+						<div class="no">{'notext'}</div>
+					}
+				}`,
+				true,
+			);
+
+			expect(code).toContain('probe()');
+			expect(code).toContain('yestext');
+			expect(code).toContain('notext');
+		});
+
+		it('decides a directive test from a module constant', () => {
+			const code = compiled(
+				`const SHOW = false;
+				export function App({ label }) @{
+					<div class="wrap">
+						@if (SHOW) {
+							<b class="dead">{'deadtext'}</b>
+						}
+						<i class="live">{label}</i>
+					</div>
+				}`,
+				true,
+			);
+
+			expect(code).not.toContain('deadtext');
+			expect(code).toContain('const SHOW = false');
 		});
 
 		it('selects the matching case of a constant @switch', () => {
@@ -173,47 +195,40 @@ export function runSharedOptimizeTests({ compile, compile_to_volar_mappings, nam
 			expect(code).not.toContain('firstcase');
 		});
 
+		it('keeps a @switch whose discriminant it cannot read', () => {
+			const code = compiled(
+				`export function App({ mode }) @{
+					@switch (mode) {
+						@case 'a': {
+							<div class="alpha">{'alphacase'}</div>
+						}
+						@default: {
+							<div class="delta">{'deltacase'}</div>
+						}
+					}
+				}`,
+				true,
+			);
+
+			expect(code).toContain('alphacase');
+			expect(code).toContain('deltacase');
+		});
+
 		it('removes a @for over an empty iterable', () => {
 			const code = compiled(
 				`export function App() @{
 					<ul>
 						@for (const item of []) {
-							<li class="dead">{item}</li>
+							<li class="dead">{'rowtext'}</li>
 						}
-						<li class="live">{'live'}</li>
+						<li class="live">{'livetext'}</li>
 					</ul>
 				}`,
 				true,
 			);
 
-			expect(code).toContain('live');
-			expect(code).not.toContain('dead');
-		});
-
-		it('picks the arm of a ternary whose test is always truthy', () => {
-			const code = compiled(
-				`export function pick(probe, hit, miss) {
-					return [probe()] ? hit() : miss();
-				}`,
-				true,
-			);
-
-			expect(code).toContain('probe()');
-			expect(code).toContain('hit()');
-			expect(code).not.toContain('miss()');
-		});
-
-		it('drops a side-effect free test instead of sequencing it', () => {
-			const code = compiled(
-				`export function pick(hit, miss) {
-					return [] ? hit() : miss();
-				}`,
-				true,
-			);
-
-			expect(code).toContain('hit()');
-			expect(code).not.toContain('miss()');
-			expect(code).not.toContain('[]');
+			expect(code).toContain('livetext');
+			expect(code).not.toContain('rowtext');
 		});
 
 		it('renders the @empty clause when the iterable is empty', () => {
@@ -221,158 +236,121 @@ export function runSharedOptimizeTests({ compile, compile_to_volar_mappings, nam
 				`export function App() @{
 					<ul>
 						@for (const item of []) {
-							<li class="row">{'rowbody'}</li>
+							<li class="row">{'rowtext'}</li>
 						} @empty {
-							<li class="none">{'emptybody'}</li>
+							<li class="none">{'emptytext'}</li>
 						}
 					</ul>
 				}`,
 				true,
 			);
 
-			expect(code).toContain('emptybody');
-			expect(code).not.toContain('rowbody');
+			expect(code).toContain('emptytext');
+			expect(code).not.toContain('rowtext');
 		});
 
-		it('keeps a loop header whose binding is never read', () => {
+		it('optimizes a directive used directly as a function body', () => {
 			const code = compiled(
-				`export function count(items) {
-					let total = 0;
-					for (const entry of items) {
-						total += 1;
+				`export const Badge = ({ label }) => @if (false) {
+					<b class="dead">{'deadtext'}</b>
+				} @else {
+					<i class="live">{label}</i>
+				};`,
+				true,
+			);
+
+			expect(code).toContain('label');
+			expect(code).not.toContain('deadtext');
+		});
+
+		it('keeps a dead branch that declares a hoisted name', () => {
+			const code = compiled(
+				`export function App({ label }) @{
+					@if (false) {
+						function helper() {
+							return 1;
+						}
+						<b class="dead">{label}</b>
+					} @else {
+						<i class="live">{label}</i>
 					}
-					return total;
 				}`,
 				true,
 			);
 
-			expect(code).toContain('entry');
+			expect(code).toContain('helper');
 		});
 
-		it('keeps an unused class whose evaluation has side effects', () => {
-			const code = compiled(
-				`export function App({ base, register }) @{
-					const Unused = class extends base() {
-						static field = register();
-					};
-					<span class="x">{'x'}</span>
-				}`,
-				true,
-			);
-
-			expect(code).toContain('Unused');
-		});
-
-		it('replaces a dead if in an unbraced arm with an empty statement', () => {
-			const code = compiled(
-				`export function run(ready) {
-					if (ready) if (false) dropped();
-					return ready;
-				}`,
-				true,
-			);
-
-			expect(code).not.toContain('dropped');
-			expect(code).toContain('if (ready)');
-		});
-
-		it('replaces a dead if in a loop body with an empty statement', () => {
-			const code = compiled(
-				`export function run(ready) {
-					while (ready) if (false) dropped();
-					return ready;
-				}`,
-				true,
-			);
-
-			expect(code).not.toContain('dropped');
-			expect(code).toContain('while (ready)');
-		});
-
-		it('removes statements that follow a return', () => {
-			const code = compiled(
-				`export function value() {
-					return 1;
-					console.log('unreachable');
-				}`,
-				true,
-			);
-
-			expect(code).not.toContain('unreachable');
-		});
-
-		it('removes a binding nothing reads', () => {
+		it('leaves the setup statements of a block alone', () => {
 			const code = compiled(
 				`export function App() @{
-					const unused = 1 + 1;
-					<span class="x">{'x'}</span>
-				}`,
-				true,
-			);
-
-			expect(code).not.toContain('unused');
-		});
-
-		it('keeps a binding whose initializer has side effects', () => {
-			const code = compiled(
-				`export function App({ track }) @{
-					const unused = track();
-					<span class="x">{'x'}</span>
-				}`,
-				true,
-			);
-
-			expect(code).toContain('track()');
-		});
-
-		it('keeps an exported constant', () => {
-			const code = compiled(`export const VERSION = '1.0.0';`, true);
-
-			expect(code).toContain('VERSION');
-		});
-
-		it('keeps a constant a type refers to', () => {
-			const code = compiled(
-				`const LIMIT = 10;
-				type Limit = typeof LIMIT;
-				export function App({ max }: { max: Limit }) @{
-					<span class="max">{max}</span>
-				}`,
-				true,
-			);
-
-			expect(code).toContain('LIMIT');
-		});
-
-		it('keeps a branch that declares a hoisted name', () => {
-			const code = compiled(
-				`export function App() {
-					if (false) {
-						var hoisted = 1;
+					const flag = false;
+					const total = 2 + 3;
+					const untouched = 1 + 1;
+					@if (flag) {
+						<div class="dead">{'deadtext'}</div>
+					} @else {
+						<span class="total">{total}</span>
 					}
-					return typeof hoisted;
 				}`,
 				true,
 			);
 
-			expect(code).toContain('hoisted');
+			expect(code).not.toContain('deadtext');
+			expect(code).toContain('2 + 3');
+			expect(code).toContain('untouched');
+			expect(code).toContain('{total}');
+		});
+
+		it('leaves plain JavaScript alone', () => {
+			const code = compiled(
+				`export function plain() {
+					const flag = false;
+					const untouched = 1 + 1;
+					if (flag) {
+						deadcall();
+					} else {
+						livecall();
+					}
+					return 1;
+					aftercall();
+				}`,
+				true,
+			);
+
+			expect(code).toContain('untouched');
+			expect(code).toContain('deadcall');
+			expect(code).toContain('aftercall');
+		});
+
+		it('leaves expressions alone', () => {
+			const code = compiled(
+				`export function App({ probe, hit, miss }) @{
+					<span class="x">{[probe()] ? hit() : miss()}</span>
+				}`,
+				true,
+			);
+
+			expect(code).toContain('probe()');
+			expect(code).toContain('hit()');
+			expect(code).toContain('miss()');
 		});
 
 		it('does not run on the editor mapping path', () => {
 			const { code } = compile_to_volar_mappings(
 				`export function App() @{
 					@if (false) {
-						<div class="dead">{'dead'}</div>
+						<div class="dead">{'deadtext'}</div>
 					} @else {
-						<div class="live">{'live'}</div>
+						<div class="live">{'livetext'}</div>
 					}
 				}`,
 				'App.tsrx',
 				/** @type {any} */ ({ optimize: true }),
 			);
 
-			expect(code).toContain('dead');
-			expect(code).toContain('live');
+			expect(code).toContain('deadtext');
+			expect(code).toContain('livetext');
 		});
 	});
 }

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -2238,9 +2238,50 @@ export type RuntimeImportMode = 'compiler' | 'direct';
  * `suspenseSource`) intersect their own option type with this base when
  * declaring their `compile` export.
  */
+/**
+ * A value the optimizer can know at compile time.
+ * Object-like values are excluded.
+ * They have identity, so substituting one at two use sites would show up.
+ */
+export type StaticValue = string | number | boolean | bigint | null | undefined;
+
+/**
+ * The result of a static evaluation.
+ * The wrapper keeps an evaluated `undefined` distinct from "not knowable".
+ */
+export type StaticValueResult = { value: StaticValue } | null;
+
+/**
+ * Resolves an identifier to its compile-time value.
+ * Returns `null` when the pass cannot prove one.
+ */
+export type ResolveStaticIdentifier = (node: AST.Identifier) => StaticValueResult;
+
+export interface OptimizeOptions {
+	/**
+	 * Upper bound on optimization rounds.
+	 * One fold can expose the next, so the pass repeats until nothing changes.
+	 * This only bounds the loop.
+	 */
+	maxRounds?: number;
+}
+
+export interface OptimizeResult {
+	ast: AST.Program;
+}
+
 export interface BaseCompileOptions {
 	collect?: boolean;
 	loose?: boolean;
+	/**
+	 * Folds statically known expressions and removes the code they prove dead.
+	 * This covers `@if (false)` arms, statements after a `return`, and
+	 * constants nothing reads.
+	 * It is off by default.
+	 * The editor and Volar path never runs it, because those mappings have to
+	 * mirror the authored source.
+	 */
+	optimize?: boolean;
 	/**
 	 * Selects where generated runtime helper imports resolve from. The default
 	 * `'compiler'` mode preserves compiler-package compatibility subpaths;
@@ -2310,6 +2351,14 @@ export interface CompileHarness {
 	 * hashes. Defaults to `classAttrName`.
 	 */
 	generatedClassAttrName?: 'class' | 'className';
+}
+
+/** The per-target entry points the shared optimizer tests run against. */
+export interface OptimizeHarness {
+	compile: CompileFn;
+	compile_to_volar_mappings: VolarCompileFn;
+	/** The target's name, used in test titles. */
+	name: string;
 }
 
 /** The per-target entry points the shared source-mapping tests run against. */

--- a/packages/turbopack-plugin-react/src/css-loader.js
+++ b/packages/turbopack-plugin-react/src/css-loader.js
@@ -5,7 +5,7 @@ import { compile } from '@tsrx/react';
 /**
  * @typedef {{
  * 	resourcePath: string,
- * 	getOptions?: () => { runtimeImports?: RuntimeImportMode },
+ * 	getOptions?: () => { runtimeImports?: RuntimeImportMode, optimize?: boolean },
  * 	async: () => (err: unknown, output?: string | null, map?: unknown) => void,
  * }} LoaderContext
  */

--- a/packages/turbopack-plugin-react/src/index.js
+++ b/packages/turbopack-plugin-react/src/index.js
@@ -25,7 +25,7 @@ const CSS_QUERY = '?tsrx-css&lang.css';
  */
 
 /**
- * @typedef {{ runtimeImports?: RuntimeImportMode }} TsrxReactTurbopackOptions
+ * @typedef {{ runtimeImports?: RuntimeImportMode, optimize?: boolean }} TsrxReactTurbopackOptions
  */
 
 /**
@@ -65,7 +65,8 @@ export function create_tsrx_react_turbopack_css_rule(options = {}) {
  * @returns {string | { loader: string, options: TsrxReactTurbopackOptions }}
  */
 function with_loader_options(loader, options) {
-	return options.runtimeImports === undefined ? loader : { loader, options };
+	const has_options = options.runtimeImports !== undefined || options.optimize !== undefined;
+	return has_options ? { loader, options } : loader;
 }
 
 /**

--- a/packages/turbopack-plugin-react/src/loader.js
+++ b/packages/turbopack-plugin-react/src/loader.js
@@ -101,7 +101,7 @@ function prepend_css_import(code, resource_path) {
 /**
  * @typedef {{
  * 	resourcePath: string,
- * 	getOptions?: () => { runtimeImports?: RuntimeImportMode },
+ * 	getOptions?: () => { runtimeImports?: RuntimeImportMode, optimize?: boolean },
  * 	async: () => (err: unknown, output?: string | null, map?: unknown) => void,
  * }} LoaderContext
  */

--- a/packages/vite-plugin-preact/src/index.js
+++ b/packages/vite-plugin-preact/src/index.js
@@ -50,6 +50,7 @@ const CSS_QUERY = '?tsrx-css&lang.css';
  *   jsxImportSource?: string,
  *   suspenseSource?: string,
  *   runtimeImports?: RuntimeImportMode,
+ *   optimize?: boolean,
  * }} [options]
  * @returns {TsrxPreactPlugin}
  */
@@ -58,6 +59,7 @@ export function tsrxPreact(options = {}) {
 	const compile_options = {
 		suspenseSource: options.suspenseSource,
 		runtimeImports: options.runtimeImports,
+		optimize: options.optimize,
 	};
 
 	/** @type {Map<string, string>} */
@@ -164,7 +166,7 @@ export function tsrxPreact(options = {}) {
 
 /**
  * @param {string} jsxImportSource
- * @param {{ suspenseSource?: string, runtimeImports?: RuntimeImportMode }} compile_options
+ * @param {{ suspenseSource?: string, runtimeImports?: RuntimeImportMode, optimize?: boolean }} compile_options
  * @returns {DepScanTransformPlugin}
  */
 function create_dep_scan_plugin(jsxImportSource, compile_options) {

--- a/packages/vite-plugin-react/src/index.js
+++ b/packages/vite-plugin-react/src/index.js
@@ -50,12 +50,15 @@ const CSS_QUERY = '?tsrx-css&lang.css';
  * `jsx-runtime`. Per-component `<style>` blocks are emitted as virtual CSS
  * modules that are imported by the compiled JS output.
  *
- * @param {{ jsxImportSource?: string, runtimeImports?: RuntimeImportMode }} [options]
+ * @param {{ jsxImportSource?: string, runtimeImports?: RuntimeImportMode, optimize?: boolean }} [options]
  * @returns {TsrxReactPlugin}
  */
 export function tsrxReact(options = {}) {
 	const jsxImportSource = options.jsxImportSource ?? 'react';
-	const compile_options = { runtimeImports: options.runtimeImports };
+	const compile_options = {
+		runtimeImports: options.runtimeImports,
+		optimize: options.optimize,
+	};
 
 	/** @type {Map<string, string>} */
 	const css_cache = new Map();
@@ -151,7 +154,7 @@ export function tsrxReact(options = {}) {
 
 /**
  * @param {string} jsxImportSource
- * @param {{ runtimeImports?: RuntimeImportMode }} compile_options
+ * @param {{ runtimeImports?: RuntimeImportMode, optimize?: boolean }} compile_options
  * @returns {TsrxReactEnvironmentConfig}
  */
 function create_dep_scan_config(jsxImportSource, compile_options) {
@@ -175,7 +178,7 @@ function create_dep_scan_config(jsxImportSource, compile_options) {
 
 /**
  * @param {string} jsxImportSource
- * @param {{ runtimeImports?: RuntimeImportMode }} compile_options
+ * @param {{ runtimeImports?: RuntimeImportMode, optimize?: boolean }} compile_options
  * @returns {DepScanTransformPlugin}
  */
 function create_dep_scan_plugin(jsxImportSource, compile_options) {

--- a/packages/vite-plugin-solid/src/index.js
+++ b/packages/vite-plugin-solid/src/index.js
@@ -28,7 +28,10 @@ export function tsrxSolid(options = {}) {
 	let root_dir = process.cwd();
 
 	const include_pattern = options.include ?? DEFAULT_TSRX_PATTERN;
-	const compile_options = { runtimeImports: options.runtimeImports };
+	const compile_options = {
+		runtimeImports: options.runtimeImports,
+		optimize: options.optimize,
+	};
 
 	/**
 	 * Decide whether a real (on-disk) path should be treated as a tsrx

--- a/packages/vite-plugin-solid/types/index.d.ts
+++ b/packages/vite-plugin-solid/types/index.d.ts
@@ -5,6 +5,11 @@ export interface TsrxSolidOptions {
 	/** Direct mode requires `@tsrx/solid-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
 	/**
+	 * Folds statically known expressions and removes the code they prove dead.
+	 * Off by default.
+	 */
+	optimize?: boolean;
+	/**
 	 * Regular expression matched against file paths to decide which modules
 	 * the plugin should compile as tsrx sources. Defaults to `/\.tsrx$/`,
 	 * i.e. any file whose path ends in `.tsrx`. Override when you want to

--- a/packages/vite-plugin-vue/src/index.js
+++ b/packages/vite-plugin-vue/src/index.js
@@ -84,7 +84,10 @@ function create_tsrx_vue_plugin(options) {
 	let rootDir = process.cwd();
 
 	const includePattern = options.include ?? DEFAULT_TSRX_PATTERN;
-	const compile_options = { runtimeImports: options.runtimeImports };
+	const compile_options = {
+		runtimeImports: options.runtimeImports,
+		optimize: options.optimize,
+	};
 
 	/**
 	 * @param {string} path
@@ -226,7 +229,7 @@ function create_tsrx_vue_plugin(options) {
  *
  * @param {(id: string) => boolean} isVirtual
  * @param {(id: string) => string} toRealPath
- * @param {{ runtimeImports?: RuntimeImportMode }} compile_options
+ * @param {{ runtimeImports?: RuntimeImportMode, optimize?: boolean }} compile_options
  * @returns {DepScanLoadPlugin}
  */
 function create_tsrx_vue_scan_plugin(isVirtual, toRealPath, compile_options) {

--- a/packages/vite-plugin-vue/types/index.d.ts
+++ b/packages/vite-plugin-vue/types/index.d.ts
@@ -5,6 +5,11 @@ export interface TsrxVueOptions {
 	/** Direct mode requires `@tsrx/vue-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
 	/**
+	 * Folds statically known expressions and removes the code they prove dead.
+	 * Off by default.
+	 */
+	optimize?: boolean;
+	/**
 	 * Regular expression matched against file paths to decide which modules
 	 * the plugin should compile as tsrx sources. Defaults to `/\.tsrx$/`.
 	 */

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -352,6 +352,15 @@ export default defineConfig({
 			},
 			{
 				test: {
+					name: 'tsrx-optimize',
+					include: ['packages/tsrx/tests/optimize/**/*.test.js'],
+					environment: 'node',
+					globals: true,
+				},
+				plugins: [],
+			},
+			{
+				test: {
 					name: 'tsrx-vite',
 					include: ['packages/tsrx/tests/vite/**/*.test.js'],
 					environment: 'node',

--- a/website-tsrx/public/llms.txt
+++ b/website-tsrx/public/llms.txt
@@ -114,9 +114,9 @@ their TSRX compilation and install the target compiler package.
 
 ### Dead-code elimination
 
-The compiler can fold statically known expressions and remove the code they
-prove dead. This is off by default. Pass `optimize: true` to a target compiler
-or to any of its Vite, Rspack, Turbopack, or Bun integrations:
+The compiler can remove TSRX control-flow branches that it can prove will never
+render. This is off by default. Pass `optimize: true` to a target compiler or to
+any of its Vite, Rspack, Turbopack, or Bun integrations:
 
 ```js
 const result = compile(source, filename, { optimize: true });
@@ -127,25 +127,45 @@ const bunPlugin = tsrxReactBun({ optimize: true });
 const nextConfig = tsrxReactTurbopack({}, { optimize: true });
 ```
 
-The pass runs on the target-neutral AST, so every target eliminates the same
-code. It does the following:
+The pass only rewrites the TSRX keyword directives. It runs on the
+target-neutral AST, so every target eliminates the same branches. It does the
+following:
 
-- Folds literal expressions such as `2 + 3`, `!true`, and `` `a${1}b` ``.
-- Propagates a `const` that holds a literal and is never reassigned or mutated.
-- Picks the arm of a `?:`, `&&`, `||`, or `??` whose test has a known
-  truthiness. An array, object, function, or regex literal is always truthy, so
-  `[b()] ? c() : d()` becomes `([b()], c())`. The test stays in a sequence
-  because it still has to run. A side-effect free test is dropped instead.
 - Drops `@if` and `@else if` branches whose test is provably false.
-- Selects the matching case of a `@switch` with a known discriminant.
-- Removes a `@for` over an empty iterable.
-- Removes statements that follow a `return`, `throw`, `break`, or `continue`.
-- Removes a declaration nothing reads when its initializer is side-effect free.
+- Keeps the branch a provably true test selects and drops the rest of the chain.
+- Selects the matching case of a `@switch` with a known discriminant, falling
+  back to `@default`.
+- Removes a `@for` over an empty iterable, or renders its `@empty` clause.
 
-Anything the pass cannot prove is left alone. A branch that declares a `var` or
-a function is never removed, because those names hoist out of it. Editor
-tooling never runs the pass, so hovers and diagnostics still match the authored
-source.
+To decide a test the pass reads constants from the module. A `const` counts when
+it holds a literal and is never reassigned or mutated, so `@if (SHOW)` can be
+decided from a `const SHOW = false` declared anywhere in the file.
+
+```tsrx
+const SHOW = false;
+
+export function App({ label }) @{
+	<div class="wrap">
+		@if (SHOW) {
+			<b>never rendered</b>
+		}
+		<i>{label}</i>
+	</div>
+}
+```
+
+Everything else stays as authored. The pass does not fold expressions, remove
+unused declarations, drop unreachable statements, or touch plain JavaScript.
+Reading a constant to decide a test never rewrites the declaration it came from.
+
+Anything the pass cannot prove is left alone:
+
+- A test with side effects is kept, because choosing a branch would discard
+  those effects.
+- A branch that declares a `var` or a function is kept, because those names
+  hoist out of it.
+- Editor tooling never runs the pass, so hovers and diagnostics still match the
+  authored source.
 
 ### Octane setup
 

--- a/website-tsrx/public/llms.txt
+++ b/website-tsrx/public/llms.txt
@@ -112,6 +112,37 @@ For published components, keep the compiler and build integration in
 `runtimeImports: 'compiler'` mode remains appropriate for applications that own
 their TSRX compilation and install the target compiler package.
 
+### Dead-code elimination
+
+The compiler can fold statically known expressions and remove the code they
+prove dead. This is off by default. Pass `optimize: true` to a target compiler
+or to any of its Vite, Rspack, Turbopack, or Bun integrations:
+
+```js
+const result = compile(source, filename, { optimize: true });
+
+const vitePlugin = tsrxReact({ optimize: true });
+const rspackPlugin = new TsrxReactRspackPlugin({ optimize: true });
+const bunPlugin = tsrxReactBun({ optimize: true });
+const nextConfig = tsrxReactTurbopack({}, { optimize: true });
+```
+
+The pass runs on the target-neutral AST, so every target eliminates the same
+code. It does the following:
+
+- Folds literal expressions such as `2 + 3`, `!true`, and `` `a${1}b` ``.
+- Propagates a `const` that holds a literal and is never reassigned or mutated.
+- Drops `@if` and `@else if` branches whose test is provably false.
+- Selects the matching case of a `@switch` with a known discriminant.
+- Removes a `@for` over an empty iterable.
+- Removes statements that follow a `return`, `throw`, `break`, or `continue`.
+- Removes a declaration nothing reads when its initializer is side-effect free.
+
+Anything the pass cannot prove is left alone. A branch that declares a `var` or
+a function is never removed, because those names hoist out of it. Editor
+tooling never runs the pass, so hovers and diagnostics still match the authored
+source.
+
 ### Octane setup
 
 Octane is a compiler-first, React-compatible UI framework built on TSRX. It is

--- a/website-tsrx/public/llms.txt
+++ b/website-tsrx/public/llms.txt
@@ -132,6 +132,10 @@ code. It does the following:
 
 - Folds literal expressions such as `2 + 3`, `!true`, and `` `a${1}b` ``.
 - Propagates a `const` that holds a literal and is never reassigned or mutated.
+- Picks the arm of a `?:`, `&&`, `||`, or `??` whose test has a known
+  truthiness. An array, object, function, or regex literal is always truthy, so
+  `[b()] ? c() : d()` becomes `([b()], c())`. The test stays in a sequence
+  because it still has to run. A side-effect free test is dropped instead.
 - Drops `@if` and `@else if` branches whose test is provably false.
 - Selects the matching case of a `@switch` with a known discriminant.
 - Removes a `@for` over an empty iterable.


### PR DESCRIPTION
# feat(compiler): opt-in dead-code elimination

Adds a pass to `@tsrx/core` that removes TSRX control-flow branches it can prove
will never render. It sits behind a new `optimize` compile option and is off by
default.

## What it removes

The pass only rewrites the TSRX keyword directives.

- An `@if` or `@else if` branch whose test is provably false is dropped.
- A provably true test ends the chain, and its branch becomes the result.
- A `@switch` with a known discriminant keeps only the matching case, or
  `@default` when nothing matches.
- A `@for` over an empty iterable is removed, or renders its `@empty` clause.

To decide a test it reads constants from the module. A `const` counts when it
holds a literal and is never reassigned or mutated.

## Example

```tsrx
const SHOW = false;

export function App({ label }) @{
  const total = 2 + 3;
  <div class="wrap">
    @if (SHOW) {
      <b>never rendered</b>
    }
    <i>{label}{total}</i>
  </div>
}
```

The `@if` is gone. `SHOW` and `total` are untouched.

```jsx
const SHOW = false;

export function App({ label }) {
	const total = 2 + 3;
	return <div class="wrap"><i>{label}{total}</i></div>;
}
```

## What it does not touch

Everything outside a directive stays as authored.

- Expressions are not folded.
- Constants are read to decide a test, never substituted at their use sites.
- Unused declarations are kept.
- Unreachable statements are kept.
- Plain JavaScript is never rewritten.

Bundlers already handle that work after lowering. A directive is the part they
cannot see through, so that is the part the compiler handles.

## Safety

Anything the pass cannot prove is left alone.

- A test with side effects is refused. Choosing a branch discards the test, and
  a directive has no expression slot left to keep those effects in.
- A branch that declares a `var`, function, or class is kept, because those
  names hoist out of it.
- A directive in a slot that cannot drop a node is kept rather than replaced.
- `compile_to_volar_mappings` never runs the pass. Editor mappings have to match
  the authored source.

## Usage

```js
const result = compile(source, filename, { optimize: true });

const vitePlugin = tsrxReact({ optimize: true });
const rspackPlugin = new TsrxReactRspackPlugin({ optimize: true });
const bunPlugin = tsrxReactBun({ optimize: true });
const nextConfig = tsrxReactTurbopack({}, { optimize: true });
```

## Changes

- Adds `packages/tsrx/src/optimize/`, split into static evaluation, constant
  resolution, and the directive rewrite.
- Adds `optimize?: boolean` to `BaseCompileOptions`.
- Wires the option into `compile()` for `@tsrx/react`, `@tsrx/preact`,
  `@tsrx/solid`, and `@tsrx/vue`.
- Forwards the option from every Vite, Rspack, Turbopack, and Bun integration.
- Adds `runSharedOptimizeTests` to the shared compile harness and runs it on all
  four targets.
- Adds a `tsrx-optimize` vitest project for evaluation and constant-resolution
  unit tests.
- Documents the option in `website-tsrx/public/llms.txt`.

## Testing

- `pnpm test` passes 3361 tests, 92 more than before this branch.
- The 5 failing files are pre-existing. `eslint-plugin` imports
  `@tsrx/eslint-parser` through its `dist` export, which needs a build.
- `pnpm typecheck` is clean.
- `pnpm format:check` is clean.
- `pnpm changeset:check` is clean.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Compile-time AST rewrites can change emitted output when `optimize: true`; mitigations include opt-in default, conservative guards, and excluding the editor path, but wrong folding would still be a correctness bug.
> 
> **Overview**
> Adds an **opt-in** `optimize` compile flag (default off) that runs a new `@tsrx/core` pass after analysis and before target lowering. When enabled, `optimizeTsrx` strips TSRX keyword directives that can be proven dead: false `@if` / `@else if` arms, resolved `@switch` cases, and `@for` over empty iterables (or `@empty` instead).
> 
> The pass resolves module `const` chains and pure expression tests via static evaluation; it does not fold general JS, remove unused bindings, or rewrite plain `if`/`for`. **`compile_to_volar_mappings` intentionally skips optimization** so editor mappings stay aligned with authored source.
> 
> `optimize` is wired through React/Preact/Solid/Vue `compile()` and forwarded from Vite, Rspack, Turbopack, and Bun plugins. Shared and core unit tests cover behavior and safety (side-effect tests, hoisted declarations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5f11f29e74d2f1fbb793fb6610ccf721ee567c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->