### PR TITLE
fix(intellij-plugin): use public api

### DIFF
--- a/.changeset/clean-plugin-loader.md
+++ b/.changeset/clean-plugin-loader.md
@@ -1,0 +1,5 @@
+---
+"@tsrx/intellij-plugin": patch
+---
+
+Replace an internal IntelliJ plugin lookup with the supported plugin-aware class loader API.

--- a/packages/intellij-plugin/src/main/kotlin/dev/tsrx/intellij_plugin/TsrxTextMateBundleProvider.kt
+++ b/packages/intellij-plugin/src/main/kotlin/dev/tsrx/intellij_plugin/TsrxTextMateBundleProvider.kt
@@ -1,6 +1,6 @@
 package dev.tsrx.intellij_plugin
 
-import com.intellij.ide.plugins.PluginManager
+import com.intellij.ide.plugins.cl.PluginAwareClassLoader
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.diagnostic.Logger
 import java.net.URL
@@ -38,7 +38,10 @@ class TsrxTextMateBundleProvider internal constructor(
 					.getResource("$BUNDLE_RESOURCE_ROOT/$relativePath")
 			},
 			pluginVersion = {
-				PluginManager.getPluginByClass(TsrxTextMateBundleProvider::class.java)?.version ?: "dev"
+				(TsrxTextMateBundleProvider::class.java.classLoader as? PluginAwareClassLoader)
+					?.pluginDescriptor
+					?.version
+					?: "dev"
 			},
 		)
 	}

--- a/packages/intellij-plugin/tests/package.test.js
+++ b/packages/intellij-plugin/tests/package.test.js
@@ -122,8 +122,10 @@ describe('@tsrx/intellij-plugin release contract', () => {
 
 		expect(descriptor).toContain('<id>tsrx.intellij-plugin</id>');
 		expect(provider).toContain(
-			'PluginManager.getPluginByClass(TsrxTextMateBundleProvider::class.java)',
+			'TsrxTextMateBundleProvider::class.java.classLoader as? PluginAwareClassLoader',
 		);
+		expect(provider).toContain('?.pluginDescriptor');
+		expect(provider).not.toContain('PluginManager');
 		expect(provider).not.toContain('PluginManagerCore');
 		expect(ignored).toBe(
 			"tsrx.intellij-plugin::Package 'com\\.intellij\\.platform\\.lsp' is not found.*\n",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small compatibility refactor to a public IntelliJ API with identical fallback behavior; no auth, data, or release pipeline logic changes.
> 
> **Overview**
> The IntelliJ plugin no longer uses the internal `PluginManager.getPluginByClass` API to read the plugin version for TextMate bundle cache versioning.
> 
> **`TsrxTextMateBundleProvider`** now resolves version via `PluginAwareClassLoader` on the provider’s class loader (`pluginDescriptor.version`), with the same `"dev"` fallback when that path is unavailable.
> 
> Release contract tests were updated to assert the new loader-based lookup and that `PluginManager` / `PluginManagerCore` are not referenced in the provider source. A patch changeset documents the swap to the supported plugin-aware class loader API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5037af008544f261db5d48393858c95720180604. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->