### PR TITLE
Fix off-by-one mappings for recovered unclosed tags

### DIFF
--- a/.changeset/unclosed-tag-mappings.md
+++ b/.changeset/unclosed-tag-mappings.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Fix loose-mode Volar mappings for recovered unclosed tags: the synthesized closing name now maps to the opening tag name (`span`) instead of `<spa`, and the opening `<` keeps its mapping.

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -3587,20 +3587,27 @@ function to_jsx_element(
 		? opening_element_node
 		: set_loc(opening_element_node, node.openingElement || node);
 
-	const closingElement = selfClosing
-		? null
-		: set_loc(
+	let closingElement = null;
+	if (!selfClosing) {
+		const authored_closing = node.closingElement;
+		if (authored_closing) {
+			// Clone from the actual closing name when there is one: a dynamic
+			// tag's closing expression (`</{Tag}>`) has its own source positions,
+			// which editor mappings need.
+			closingElement = set_loc(
 				b.jsx_closing_element(
-					// Clone from the actual closing name when there is one: a dynamic
-					// tag's closing expression (`</{Tag}>`) has its own source positions,
-					// which editor mappings need.
-					clone_jsx_name(
-						node.closingElement?.name ?? name,
-						node.closingElement?.name || node.closingElement || node,
-					),
+					clone_jsx_name(authored_closing.name ?? name, authored_closing.name || authored_closing),
 				),
-				node.closingElement || node,
+				authored_closing,
 			);
+		} else {
+			// Recovered unclosed tags have no authored close. Map the synthesized
+			// name to the opening name token so rename/hover land on `span`, not
+			// `<spa`, and leave the closing element itself unlocated so it does
+			// not steal the opening `<` mapping.
+			closingElement = b.jsx_closing_element(clone_jsx_name(name, source_opening.name));
+		}
+	}
 
 	const element = set_loc(b.jsx_element_fresh(openingElement, closingElement, children), node);
 	if (node.metadata?.dynamicElement === true) {

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -261,6 +261,55 @@ function App({ tag }: { tag: string }) @{
 
 			expect(mapping?.data.completion).toBe(true);
 		});
+		it('maps recovered unclosed tags without an off-by-one close name', () => {
+			const source = `export function App() @{
+	<>
+		<span>
+		<div />
+	</>
+}`;
+			const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+			const open_lt = source.indexOf('<span>');
+			const name_offset = open_lt + 1;
+			const generated_open = result.code.indexOf('<span>');
+			const generated_close = result.code.lastIndexOf('</span>');
+
+			expect(generated_open).toBeGreaterThan(-1);
+			expect(generated_close).toBeGreaterThan(generated_open);
+
+			const mapped_source = function (entry) {
+				return source.slice(entry.sourceOffsets[0], entry.sourceOffsets[0] + entry.lengths[0]);
+			};
+			const open_lt_mapping = result.mappings.find(function (entry) {
+				return (
+					entry.sourceOffsets[0] === open_lt &&
+					entry.lengths[0] === 1 &&
+					result.code[entry.generatedOffsets[0]] === '<'
+				);
+			});
+			const early_name_mapping = result.mappings.find(function (entry) {
+				return entry.sourceOffsets[0] === open_lt && entry.lengths[0] === 'span'.length;
+			});
+			const close_name_mappings = result.mappings.filter(function (entry) {
+				return (
+					entry.generatedOffsets[0] === generated_close + 2 &&
+					result.code.slice(
+						entry.generatedOffsets[0],
+						entry.generatedOffsets[0] + entry.generatedLengths[0],
+					) === 'span'
+				);
+			});
+
+			expect(open_lt_mapping, 'opening `<` should keep a mapping').toBeDefined();
+			expect(open_lt_mapping?.generatedOffsets[0]).toBe(generated_open);
+			expect(mapped_source(open_lt_mapping)).toBe('<');
+			expect(early_name_mapping, 'close name must not map to `<spa`').toBeUndefined();
+			expect(source.slice(name_offset, name_offset + 'span'.length)).toBe('span');
+			for (const mapping of close_name_mappings) {
+				expect(mapped_source(mapping)).toBe('span');
+				expect(mapping.sourceOffsets[0]).toBe(name_offset);
+			}
+		});
 		it('keeps DOM attribute completions when scoped styles are present', () => {
 			const source = `function C() @{
 	<>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #48.

When loose-mode recovery synthesizes a closing element for an unclosed tag (for example `<span>` typed without `</span>`), `to_jsx_element` was attaching the whole element's location to that close. The generated name `span` then mapped to source `<spa`, and the opening `<` lost its mapping. Editor features keyed on the tag name (auto-close, rename, hover) landed one character early.

This PR leaves the synthesized closing element unlocated and clones its name from the opening tag name token, so:

- the synthesized `</span>` name maps to `span`, not `<spa`
- the opening `<` keeps a mapping like a balanced element

A shared `compile_to_volar_mappings` regression test covers the recovered-unclosed-tag offsets. Scope is #48 only; style-specific fatal CSS (#47) is left alone.

## Verification

The issue repro now maps as follows:

- source `<` of `<span>` (offset 31) → generated `<` of `<span>`
- source `span` (offset 32) → both the opening name and the synthesized `</span>` name
- no mapping of length 4 starting at `<` (`<spa`)

The new test passed on React, Preact, Solid, and Vue. Related shared source-mapping tests also passed (368).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-018f10de-e1a9-4623-a61a-3a50a58074c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-018f10de-e1a9-4623-a61a-3a50a58074c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

