### PR TITLE
Scoped styles target polish: docs, Vite runtime tests, bundler READMEs

### DIFF
--- a/.changeset/vite-scoped-style-import-order.md
+++ b/.changeset/vite-scoped-style-import-order.md
@@ -1,0 +1,8 @@
+---
+'@tsrx/vite-plugin-react': patch
+'@tsrx/vite-plugin-preact': patch
+'@tsrx/vite-plugin-solid': patch
+'@tsrx/vite-plugin-vue': patch
+---
+
+Emit each module's virtual CSS import after its JavaScript imports so an imported theme's stylesheet is injected before the applying module's stylesheet.

--- a/.changeset/vite-scoped-style-import-order.md
+++ b/.changeset/vite-scoped-style-import-order.md
@@ -5,4 +5,4 @@
 '@tsrx/vite-plugin-vue': patch
 ---
 
-Emit each module's virtual CSS import after its JavaScript imports so an imported theme's stylesheet is injected before the applying module's stylesheet.
+Emit each module's virtual CSS import after its JavaScript imports, so an imported theme's CSS comes before the CSS of the block that applies it and the local rule wins at equal specificity.

--- a/packages/rspack-plugin-preact/README.md
+++ b/packages/rspack-plugin-preact/README.md
@@ -1,0 +1,45 @@
+# @tsrx/rspack-plugin-preact
+
+Rspack plugin for compiling `@tsrx/preact` `.tsrx` files.
+
+## Installation
+
+```bash
+pnpm add -D @tsrx/rspack-plugin-preact
+```
+
+## Usage
+
+```ts
+import { TsrxPreactRspackPlugin } from '@tsrx/rspack-plugin-preact';
+
+export default {
+  plugins: [new TsrxPreactRspackPlugin()],
+};
+```
+
+The plugin compiles `.tsrx` modules with `@tsrx/preact`, chains
+`builtin:swc-loader` for Preact's automatic JSX runtime, and emits sibling-scoped
+`<style>` blocks (each styles its siblings and everything below them) through
+Rspack's built-in CSS module type.
+
+It also pushes `.tsrx` into `resolve.extensions` and enables `experiments.css`
+when unset.
+
+## Options
+
+- `jsxImportSource`: automatic JSX runtime import source (default: `'preact'`).
+- `suspenseSource`: module used by the compiler for Suspense imports (default:
+  `'preact/compat'`).
+- `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
+  standalone runtime imports).
+
+When using `runtimeImports: 'direct'`, install the runtime as a direct production
+dependency of the package that owns the compiled modules:
+
+```bash
+pnpm add @tsrx/preact-runtime
+```
+
+The plugin only emits bare `@tsrx/preact-runtime/*` imports and does not provide
+the runtime package.

--- a/packages/rspack-plugin-react/README.md
+++ b/packages/rspack-plugin-react/README.md
@@ -1,0 +1,43 @@
+# @tsrx/rspack-plugin-react
+
+Rspack plugin for compiling `@tsrx/react` `.tsrx` files.
+
+## Installation
+
+```bash
+pnpm add -D @tsrx/rspack-plugin-react
+```
+
+## Usage
+
+```ts
+import { TsrxReactRspackPlugin } from '@tsrx/rspack-plugin-react';
+
+export default {
+  plugins: [new TsrxReactRspackPlugin()],
+};
+```
+
+The plugin compiles `.tsrx` modules with `@tsrx/react`, chains
+`builtin:swc-loader` for React's automatic JSX runtime, and emits sibling-scoped
+`<style>` blocks (each styles its siblings and everything below them) through
+Rspack's built-in CSS module type.
+
+It also pushes `.tsrx` into `resolve.extensions` and enables `experiments.css`
+when unset.
+
+## Options
+
+- `jsxImportSource`: automatic JSX runtime import source (default: `'react'`).
+- `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
+  standalone runtime imports).
+
+When using `runtimeImports: 'direct'`, install the runtime as a direct production
+dependency of the package that owns the compiled modules:
+
+```bash
+pnpm add @tsrx/react-runtime
+```
+
+The plugin only emits bare `@tsrx/react-runtime/*` imports and does not provide
+the runtime package.

--- a/packages/rspack-plugin-solid/README.md
+++ b/packages/rspack-plugin-solid/README.md
@@ -1,0 +1,47 @@
+# @tsrx/rspack-plugin-solid
+
+Rspack plugin for compiling `@tsrx/solid` `.tsrx` files.
+
+## Installation
+
+```bash
+pnpm add @tsrx/solid solid-js @solidjs/web
+pnpm add -D @tsrx/rspack-plugin-solid
+```
+
+## Usage
+
+```ts
+import { TsrxSolidRspackPlugin } from '@tsrx/rspack-plugin-solid';
+
+export default {
+  plugins: [new TsrxSolidRspackPlugin()],
+};
+```
+
+The plugin compiles `.tsrx` modules with `@tsrx/solid`, runs the final TypeScript
+
+- Solid JSX transform through `babel-loader` with `@babel/preset-typescript` and
+  `babel-preset-solid`, and emits sibling-scoped `<style>` blocks (each styles its
+  siblings and everything below them) through Rspack's built-in CSS module type.
+
+It also pushes `.tsrx` into `resolve.extensions` and enables `experiments.css`
+when unset. In development mode it adds `solid-refresh/babel` unless you pass
+`hot: false`.
+
+## Options
+
+- `hot`: whether to add `solid-refresh/babel` to the Babel pipeline. Defaults to
+  `true` unless Rspack is running in production mode.
+- `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
+  standalone runtime imports).
+
+When using `runtimeImports: 'direct'`, install the runtime as a direct production
+dependency of the package that owns the compiled modules:
+
+```bash
+pnpm add @tsrx/solid-runtime
+```
+
+The plugin only emits bare `@tsrx/solid-runtime/*` imports and does not provide
+the runtime package.

--- a/packages/rspack-plugin-solid/README.md
+++ b/packages/rspack-plugin-solid/README.md
@@ -20,10 +20,9 @@ export default {
 ```
 
 The plugin compiles `.tsrx` modules with `@tsrx/solid`, runs the final TypeScript
-
-- Solid JSX transform through `babel-loader` with `@babel/preset-typescript` and
-  `babel-preset-solid`, and emits sibling-scoped `<style>` blocks (each styles its
-  siblings and everything below them) through Rspack's built-in CSS module type.
+and Solid JSX transform through `babel-loader` with `@babel/preset-typescript` and
+`babel-preset-solid`, and emits sibling-scoped `<style>` blocks (each styles its
+siblings and everything below them) through Rspack's built-in CSS module type.
 
 It also pushes `.tsrx` into `resolve.extensions` and enables `experiments.css`
 when unset. In development mode it adds `solid-refresh/babel` unless you pass

--- a/packages/rspack-plugin-vue/README.md
+++ b/packages/rspack-plugin-vue/README.md
@@ -1,0 +1,45 @@
+# @tsrx/rspack-plugin-vue
+
+Rspack plugin for compiling `@tsrx/vue` `.tsrx` files.
+
+## Installation
+
+```bash
+pnpm add @tsrx/vue vue vue-jsx-vapor
+pnpm add -D @tsrx/rspack-plugin-vue
+```
+
+## Usage
+
+```ts
+import { TsrxVueRspackPlugin } from '@tsrx/rspack-plugin-vue';
+
+export default {
+  plugins: [new TsrxVueRspackPlugin()],
+};
+```
+
+The plugin compiles `.tsrx` modules with `@tsrx/vue`, runs the result through
+`vue-jsx-vapor`, strips the remaining TypeScript syntax with `builtin:swc-loader`,
+and emits sibling-scoped `<style>` blocks (each styles its siblings and everything
+below them) through Rspack's built-in CSS module type.
+
+It also pushes `.tsrx` into `resolve.extensions` and enables `experiments.css`
+when unset. Editor typechecking should set `jsxImportSource: 'vue-jsx-vapor'`.
+
+## Options
+
+- `vapor`: options forwarded to `vue-jsx-vapor`. By default the plugin enables
+  macros and uses `runtimeModuleName: 'vue-jsx-vapor'`.
+- `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
+  standalone runtime imports).
+
+When using `runtimeImports: 'direct'`, install the runtime as a direct production
+dependency of the package that owns the compiled modules:
+
+```bash
+pnpm add @tsrx/vue-runtime
+```
+
+The plugin only emits bare `@tsrx/vue-runtime/*` imports and does not provide the
+runtime package.

--- a/packages/tsrx/tests/shared/runtime/scoped-styles-dom.ts
+++ b/packages/tsrx/tests/shared/runtime/scoped-styles-dom.ts
@@ -4,6 +4,8 @@
  * compared against the applier that imported it.
  */
 
+import { expect } from 'vitest';
+
 export function collect_stylesheet_texts(): string[] {
 	const texts: string[] = [];
 	const seen = new Set<string>();
@@ -44,4 +46,37 @@ export function index_of_mark(texts: string[], mark: string): number {
 	return texts.findIndex(function has_mark(text: string) {
 		return text.includes(mark);
 	});
+}
+
+export function mark_position(texts: string[], mark: string): { sheet: number; at: number } {
+	for (let i = 0; i < texts.length; i += 1) {
+		const at = texts[i].indexOf(mark);
+		if (at !== -1) {
+			return { sheet: i, at };
+		}
+	}
+	return { sheet: -1, at: -1 };
+}
+
+export function expect_mark_before(texts: string[], earlier: string, later: string) {
+	const first = mark_position(texts, earlier);
+	const second = mark_position(texts, later);
+	expect(first.sheet).toBeGreaterThan(-1);
+	expect(second.sheet).toBeGreaterThan(-1);
+	if (first.sheet === second.sheet) {
+		expect(first.at).toBeLessThan(second.at);
+		return;
+	}
+	expect(first.sheet).toBeLessThan(second.sheet);
+}
+
+/**
+ * D13 layer 3: reading `theme.$class` while the imported theme is still
+ * uninitialized. Native ESM throws ReferenceError (TDZ). Vite's transform
+ * often binds the cycle as `undefined`, which throws TypeError instead.
+ */
+export function expect_cyclic_apply_error(error: unknown) {
+	const is_tdz = error instanceof ReferenceError;
+	const is_vite_cycle = error instanceof TypeError && String(error.message).includes('$class');
+	expect(is_tdz || is_vite_cycle).toBe(true);
 }

--- a/packages/tsrx/tests/shared/runtime/scoped-styles-dom.ts
+++ b/packages/tsrx/tests/shared/runtime/scoped-styles-dom.ts
@@ -1,0 +1,47 @@
+/**
+ * DOM helpers for sibling-scoped `<style apply>` runtime tests.
+ * Style tags are collected in document order so a theme module's sheet can be
+ * compared against the applier that imported it.
+ */
+
+export function collect_stylesheet_texts(): string[] {
+	const texts: string[] = [];
+	const seen = new Set<string>();
+
+	function push_unique(text: string) {
+		const trimmed = text.trim();
+		if (!trimmed || seen.has(trimmed)) {
+			return;
+		}
+		seen.add(trimmed);
+		texts.push(trimmed);
+	}
+
+	for (const node of document.querySelectorAll('style')) {
+		if (node.textContent) {
+			push_unique(node.textContent);
+		}
+	}
+
+	for (const sheet of document.styleSheets) {
+		try {
+			const rules: string[] = [];
+			for (const rule of sheet.cssRules) {
+				rules.push(rule.cssText);
+			}
+			if (rules.length > 0) {
+				push_unique(rules.join('\n'));
+			}
+		} catch {
+			// Ignore unreadable sheets; injected test CSS is same-origin.
+		}
+	}
+
+	return texts;
+}
+
+export function index_of_mark(texts: string[], mark: string): number {
+	return texts.findIndex(function has_mark(text: string) {
+		return text.includes(mark);
+	});
+}

--- a/packages/tsrx/tests/shared/runtime/scoped-styles-dom.ts
+++ b/packages/tsrx/tests/shared/runtime/scoped-styles-dom.ts
@@ -42,12 +42,6 @@ export function collect_stylesheet_texts(): string[] {
 	return texts;
 }
 
-export function index_of_mark(texts: string[], mark: string): number {
-	return texts.findIndex(function has_mark(text: string) {
-		return text.includes(mark);
-	});
-}
-
 export function mark_position(texts: string[], mark: string): { sheet: number; at: number } {
 	for (let i = 0; i < texts.length; i += 1) {
 		const at = texts[i].indexOf(mark);

--- a/packages/turbopack-plugin-react/README.md
+++ b/packages/turbopack-plugin-react/README.md
@@ -1,0 +1,49 @@
+# @tsrx/turbopack-plugin-react
+
+Turbopack integration for compiling `@tsrx/react` `.tsrx` files in Next.js.
+
+## Installation
+
+```bash
+pnpm add @tsrx/react react react-dom
+pnpm add -D @tsrx/turbopack-plugin-react next
+```
+
+## Usage
+
+```ts
+import tsrxReactTurbopack from '@tsrx/turbopack-plugin-react';
+
+export default tsrxReactTurbopack({
+  reactStrictMode: true,
+});
+```
+
+The helper installs Turbopack rules that compile `.tsrx` modules with
+`@tsrx/react` and return the result as `*.tsx` so Next's React pipeline can finish
+the JSX transform. Sibling-scoped `<style>` blocks (each styles its siblings and
+everything below them) are emitted through a sibling `?tsrx-css&lang.css` import
+and handed back to Turbopack as a CSS module.
+
+It also adds `.tsrx` to `turbopack.resolveExtensions`.
+
+## Options
+
+Pass Next.js config as the first argument. The second argument is optional:
+
+- `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
+  standalone runtime imports).
+
+```ts
+export default tsrxReactTurbopack({}, { runtimeImports: 'direct' });
+```
+
+When using `runtimeImports: 'direct'`, install the runtime as a direct production
+dependency of the package that owns the compiled modules:
+
+```bash
+pnpm add @tsrx/react-runtime
+```
+
+The helper only emits bare `@tsrx/react-runtime/*` imports and does not provide
+the runtime package.

--- a/packages/vite-plugin-preact/src/index.js
+++ b/packages/vite-plugin-preact/src/index.js
@@ -122,10 +122,9 @@ export function tsrxPreact(options = {}) {
 			let source = tsx_code;
 			if (css) {
 				css_cache.set(id, css);
-				source = `import ${JSON.stringify(id + CSS_QUERY)};\n${tsx_code}`;
-				if (map && typeof map.mappings === 'string') {
-					map = { ...map, mappings: ';' + map.mappings };
-				}
+				// After existing imports so dependency sheets (imported themes)
+				// evaluate first and this module's rules win at equal specificity.
+				source = `${tsx_code}\nimport ${JSON.stringify(id + CSS_QUERY)};\n`;
 			} else {
 				css_cache.delete(id);
 			}

--- a/packages/vite-plugin-preact/tests/fixtures/scoped-styles/applier.tsrx
+++ b/packages/vite-plugin-preact/tests/fixtures/scoped-styles/applier.tsrx
@@ -1,0 +1,23 @@
+import { theme } from './theme.tsrx';
+
+export function AppliedPanel() @{
+	<>
+		<style apply={theme}>
+			div {
+				--tsrx-applier-mark: applier;
+				color: rgb(0, 0, 0);
+			}
+		</style>
+		<div class="probe" data-probe="applied">{'local wins'}</div>
+	</>
+}
+
+export function ThemeApplyApp() @{
+	<>
+		<AppliedPanel />
+		<div class={theme.$class} data-probe="opt-in">{'opted in'}</div>
+		<div data-probe="untouched">{'untouched'}</div>
+	</>
+}
+
+export { theme };

--- a/packages/vite-plugin-preact/tests/fixtures/scoped-styles/cycle-applier.tsrx
+++ b/packages/vite-plugin-preact/tests/fixtures/scoped-styles/cycle-applier.tsrx
@@ -1,0 +1,12 @@
+import { theme } from './cycle-theme.tsrx';
+
+// Module-scope apply reads theme.$class during evaluation. If this module
+// runs first, `theme` is still in the TDZ (D13 layer 3).
+export const applied = <style apply={theme} />;
+
+export function AppliedPanel() @{
+	<>
+		<style apply={theme} />
+		<div>{'cycle'}</div>
+	</>
+}

--- a/packages/vite-plugin-preact/tests/fixtures/scoped-styles/cycle-theme.tsrx
+++ b/packages/vite-plugin-preact/tests/fixtures/scoped-styles/cycle-theme.tsrx
@@ -1,0 +1,11 @@
+import { AppliedPanel } from './cycle-applier.tsrx';
+
+export const theme = <style>
+	div {
+		color: rgb(255, 0, 0);
+	}
+</style>;
+
+export function CycleHost() @{
+	<AppliedPanel />
+}

--- a/packages/vite-plugin-preact/tests/fixtures/scoped-styles/theme.tsrx
+++ b/packages/vite-plugin-preact/tests/fixtures/scoped-styles/theme.tsrx
@@ -1,0 +1,6 @@
+export const theme = <style>
+	div {
+		--tsrx-theme-mark: theme;
+		color: rgb(0, 128, 0);
+	}
+</style>;

--- a/packages/vite-plugin-preact/tests/scoped-styles.runtime.test.tsrx
+++ b/packages/vite-plugin-preact/tests/scoped-styles.runtime.test.tsrx
@@ -1,0 +1,44 @@
+import {
+	collect_stylesheet_texts,
+	index_of_mark,
+} from '@tsrx/core/test-harness/runtime/scoped-styles-dom';
+import { ThemeApplyApp } from './fixtures/scoped-styles/applier.tsrx';
+
+const THEME_MARK = '--tsrx-theme-mark';
+const APPLIER_MARK = '--tsrx-applier-mark';
+
+describe('sibling-scoped apply runtime (preact)', function () {
+	it(
+		'mounts a theme module plus applier and keeps the local rule later in the cascade',
+		async function () {
+			await render(ThemeApplyApp);
+
+			const applied = container.querySelector('[data-probe="applied"]') as HTMLElement;
+			const opted_in = container.querySelector('[data-probe="opt-in"]') as HTMLElement;
+			const untouched = container.querySelector('[data-probe="untouched"]') as HTMLElement;
+
+			expect(applied).not.toBeNull();
+			expect(opted_in).not.toBeNull();
+			expect(untouched).not.toBeNull();
+			expect(applied.className).toContain('probe');
+			expect(opted_in.className).toMatch(/tsrx-[0-9a-f]+/);
+			expect(untouched.className).not.toMatch(/tsrx-[0-9a-f]+/);
+
+			const sheets = collect_stylesheet_texts();
+			const theme_index = index_of_mark(sheets, THEME_MARK);
+			const applier_index = index_of_mark(sheets, APPLIER_MARK);
+			expect(theme_index).toBeGreaterThan(-1);
+			expect(applier_index).toBeGreaterThan(-1);
+			expect(theme_index).toBeLessThan(applier_index);
+
+			expect(getComputedStyle(applied).color).toBe('rgb(0, 0, 0)');
+			expect(getComputedStyle(opted_in).color).toBe('rgb(0, 128, 0)');
+		},
+	);
+
+	it('throws ReferenceError when an applier evaluates before its imported theme', async function () {
+		await expect(import('./fixtures/scoped-styles/cycle-theme.tsrx')).rejects.toThrow(
+			ReferenceError,
+		);
+	});
+});

--- a/packages/vite-plugin-preact/tests/scoped-styles.runtime.test.tsrx
+++ b/packages/vite-plugin-preact/tests/scoped-styles.runtime.test.tsrx
@@ -1,6 +1,7 @@
 import {
 	collect_stylesheet_texts,
-	index_of_mark,
+	expect_cyclic_apply_error,
+	expect_mark_before,
 } from '@tsrx/core/test-harness/runtime/scoped-styles-dom';
 import { ThemeApplyApp } from './fixtures/scoped-styles/applier.tsrx';
 
@@ -24,21 +25,22 @@ describe('sibling-scoped apply runtime (preact)', function () {
 			expect(opted_in.className).toMatch(/tsrx-[0-9a-f]+/);
 			expect(untouched.className).not.toMatch(/tsrx-[0-9a-f]+/);
 
-			const sheets = collect_stylesheet_texts();
-			const theme_index = index_of_mark(sheets, THEME_MARK);
-			const applier_index = index_of_mark(sheets, APPLIER_MARK);
-			expect(theme_index).toBeGreaterThan(-1);
-			expect(applier_index).toBeGreaterThan(-1);
-			expect(theme_index).toBeLessThan(applier_index);
+			expect_mark_before(collect_stylesheet_texts(), THEME_MARK, APPLIER_MARK);
 
 			expect(getComputedStyle(applied).color).toBe('rgb(0, 0, 0)');
 			expect(getComputedStyle(opted_in).color).toBe('rgb(0, 128, 0)');
 		},
 	);
 
-	it('throws ReferenceError when an applier evaluates before its imported theme', async function () {
-		await expect(import('./fixtures/scoped-styles/cycle-theme.tsrx')).rejects.toThrow(
-			ReferenceError,
-		);
+	it('throws when an applier evaluates before its imported theme', async function () {
+		try {
+			await import('./fixtures/scoped-styles/cycle-theme.tsrx');
+			throw new Error('expected the cyclic apply import to throw');
+		} catch (error) {
+			if (error instanceof Error && error.message === 'expected the cyclic apply import to throw') {
+				throw error;
+			}
+			expect_cyclic_apply_error(error);
+		}
 	});
 });

--- a/packages/vite-plugin-react/src/index.js
+++ b/packages/vite-plugin-react/src/index.js
@@ -109,10 +109,9 @@ export function tsrxReact(options = {}) {
 			let source = tsx_code;
 			if (css) {
 				css_cache.set(id, css);
-				source = `import ${JSON.stringify(id + CSS_QUERY)};\n${tsx_code}`;
-				if (map && typeof map.mappings === 'string') {
-					map = { ...map, mappings: ';' + map.mappings };
-				}
+				// After existing imports so dependency sheets (imported themes)
+				// evaluate first and this module's rules win at equal specificity.
+				source = `${tsx_code}\nimport ${JSON.stringify(id + CSS_QUERY)};\n`;
 			} else {
 				css_cache.delete(id);
 			}

--- a/packages/vite-plugin-react/tests/fixtures/scoped-styles/applier.tsrx
+++ b/packages/vite-plugin-react/tests/fixtures/scoped-styles/applier.tsrx
@@ -1,0 +1,23 @@
+import { theme } from './theme.tsrx';
+
+export function AppliedPanel() @{
+	<>
+		<style apply={theme}>
+			div {
+				--tsrx-applier-mark: applier;
+				color: rgb(0, 0, 0);
+			}
+		</style>
+		<div className="probe" data-probe="applied">{'local wins'}</div>
+	</>
+}
+
+export function ThemeApplyApp() @{
+	<>
+		<AppliedPanel />
+		<div className={theme.$class} data-probe="opt-in">{'opted in'}</div>
+		<div data-probe="untouched">{'untouched'}</div>
+	</>
+}
+
+export { theme };

--- a/packages/vite-plugin-react/tests/fixtures/scoped-styles/cycle-applier.tsrx
+++ b/packages/vite-plugin-react/tests/fixtures/scoped-styles/cycle-applier.tsrx
@@ -1,0 +1,12 @@
+import { theme } from './cycle-theme.tsrx';
+
+// Module-scope apply reads theme.$class during evaluation. If this module
+// runs first, `theme` is still in the TDZ (D13 layer 3).
+export const applied = <style apply={theme} />;
+
+export function AppliedPanel() @{
+	<>
+		<style apply={theme} />
+		<div>{'cycle'}</div>
+	</>
+}

--- a/packages/vite-plugin-react/tests/fixtures/scoped-styles/cycle-theme.tsrx
+++ b/packages/vite-plugin-react/tests/fixtures/scoped-styles/cycle-theme.tsrx
@@ -1,0 +1,11 @@
+import { AppliedPanel } from './cycle-applier.tsrx';
+
+export const theme = <style>
+	div {
+		color: rgb(255, 0, 0);
+	}
+</style>;
+
+export function CycleHost() @{
+	<AppliedPanel />
+}

--- a/packages/vite-plugin-react/tests/fixtures/scoped-styles/theme.tsrx
+++ b/packages/vite-plugin-react/tests/fixtures/scoped-styles/theme.tsrx
@@ -1,0 +1,6 @@
+export const theme = <style>
+	div {
+		--tsrx-theme-mark: theme;
+		color: rgb(0, 128, 0);
+	}
+</style>;

--- a/packages/vite-plugin-react/tests/scoped-styles.runtime.test.tsrx
+++ b/packages/vite-plugin-react/tests/scoped-styles.runtime.test.tsrx
@@ -1,0 +1,44 @@
+import {
+	collect_stylesheet_texts,
+	index_of_mark,
+} from '@tsrx/core/test-harness/runtime/scoped-styles-dom';
+import { ThemeApplyApp } from './fixtures/scoped-styles/applier.tsrx';
+
+const THEME_MARK = '--tsrx-theme-mark';
+const APPLIER_MARK = '--tsrx-applier-mark';
+
+describe('sibling-scoped apply runtime (react)', function () {
+	it(
+		'mounts a theme module plus applier and keeps the local rule later in the cascade',
+		async function () {
+			await render(ThemeApplyApp);
+
+			const applied = container.querySelector('[data-probe="applied"]') as HTMLElement;
+			const opted_in = container.querySelector('[data-probe="opt-in"]') as HTMLElement;
+			const untouched = container.querySelector('[data-probe="untouched"]') as HTMLElement;
+
+			expect(applied).not.toBeNull();
+			expect(opted_in).not.toBeNull();
+			expect(untouched).not.toBeNull();
+			expect(applied.className).toContain('probe');
+			expect(opted_in.className).toMatch(/tsrx-[0-9a-f]+/);
+			expect(untouched.className).not.toMatch(/tsrx-[0-9a-f]+/);
+
+			const sheets = collect_stylesheet_texts();
+			const theme_index = index_of_mark(sheets, THEME_MARK);
+			const applier_index = index_of_mark(sheets, APPLIER_MARK);
+			expect(theme_index).toBeGreaterThan(-1);
+			expect(applier_index).toBeGreaterThan(-1);
+			expect(theme_index).toBeLessThan(applier_index);
+
+			expect(getComputedStyle(applied).color).toBe('rgb(0, 0, 0)');
+			expect(getComputedStyle(opted_in).color).toBe('rgb(0, 128, 0)');
+		},
+	);
+
+	it('throws ReferenceError when an applier evaluates before its imported theme', async function () {
+		await expect(import('./fixtures/scoped-styles/cycle-theme.tsrx')).rejects.toThrow(
+			ReferenceError,
+		);
+	});
+});

--- a/packages/vite-plugin-react/tests/scoped-styles.runtime.test.tsrx
+++ b/packages/vite-plugin-react/tests/scoped-styles.runtime.test.tsrx
@@ -1,6 +1,7 @@
 import {
 	collect_stylesheet_texts,
-	index_of_mark,
+	expect_cyclic_apply_error,
+	expect_mark_before,
 } from '@tsrx/core/test-harness/runtime/scoped-styles-dom';
 import { ThemeApplyApp } from './fixtures/scoped-styles/applier.tsrx';
 
@@ -24,21 +25,22 @@ describe('sibling-scoped apply runtime (react)', function () {
 			expect(opted_in.className).toMatch(/tsrx-[0-9a-f]+/);
 			expect(untouched.className).not.toMatch(/tsrx-[0-9a-f]+/);
 
-			const sheets = collect_stylesheet_texts();
-			const theme_index = index_of_mark(sheets, THEME_MARK);
-			const applier_index = index_of_mark(sheets, APPLIER_MARK);
-			expect(theme_index).toBeGreaterThan(-1);
-			expect(applier_index).toBeGreaterThan(-1);
-			expect(theme_index).toBeLessThan(applier_index);
+			expect_mark_before(collect_stylesheet_texts(), THEME_MARK, APPLIER_MARK);
 
 			expect(getComputedStyle(applied).color).toBe('rgb(0, 0, 0)');
 			expect(getComputedStyle(opted_in).color).toBe('rgb(0, 128, 0)');
 		},
 	);
 
-	it('throws ReferenceError when an applier evaluates before its imported theme', async function () {
-		await expect(import('./fixtures/scoped-styles/cycle-theme.tsrx')).rejects.toThrow(
-			ReferenceError,
-		);
+	it('throws when an applier evaluates before its imported theme', async function () {
+		try {
+			await import('./fixtures/scoped-styles/cycle-theme.tsrx');
+			throw new Error('expected the cyclic apply import to throw');
+		} catch (error) {
+			if (error instanceof Error && error.message === 'expected the cyclic apply import to throw') {
+				throw error;
+			}
+			expect_cyclic_apply_error(error);
+		}
 	});
 });

--- a/packages/vite-plugin-solid/src/index.js
+++ b/packages/vite-plugin-solid/src/index.js
@@ -150,14 +150,9 @@ export function tsrxSolid(options = {}) {
 
 			if (css) {
 				css_cache.set(real_path, css);
-				code = `import ${JSON.stringify(real_path + CSS_QUERY)};\n${code}`;
-				// The prepended import adds one line to the generated output;
-				// shift every mapping down by one line so source positions stay
-				// aligned. In VLQ source maps, each `;` separates generated
-				// lines, so prefixing one `;` offsets all mappings by one line.
-				if (map && typeof map.mappings === 'string') {
-					map = { ...map, mappings: ';' + map.mappings };
-				}
+				// After existing imports so dependency sheets (imported themes)
+				// evaluate first and this module's rules win at equal specificity.
+				code = `${code}\nimport ${JSON.stringify(real_path + CSS_QUERY)};\n`;
 			} else {
 				css_cache.delete(real_path);
 			}

--- a/packages/vite-plugin-solid/tests/fixtures/scoped-styles/applier.tsrx
+++ b/packages/vite-plugin-solid/tests/fixtures/scoped-styles/applier.tsrx
@@ -1,0 +1,23 @@
+import { theme } from './theme.tsrx';
+
+export function AppliedPanel() @{
+	<>
+		<style apply={theme}>
+			div {
+				--tsrx-applier-mark: applier;
+				color: rgb(0, 0, 0);
+			}
+		</style>
+		<div class="probe" data-probe="applied">{'local wins'}</div>
+	</>
+}
+
+export function ThemeApplyApp() @{
+	<>
+		<AppliedPanel />
+		<div class={theme.$class} data-probe="opt-in">{'opted in'}</div>
+		<div data-probe="untouched">{'untouched'}</div>
+	</>
+}
+
+export { theme };

--- a/packages/vite-plugin-solid/tests/fixtures/scoped-styles/cycle-applier.tsrx
+++ b/packages/vite-plugin-solid/tests/fixtures/scoped-styles/cycle-applier.tsrx
@@ -1,0 +1,12 @@
+import { theme } from './cycle-theme.tsrx';
+
+// Module-scope apply reads theme.$class during evaluation. If this module
+// runs first, `theme` is still in the TDZ (D13 layer 3).
+export const applied = <style apply={theme} />;
+
+export function AppliedPanel() @{
+	<>
+		<style apply={theme} />
+		<div>{'cycle'}</div>
+	</>
+}

--- a/packages/vite-plugin-solid/tests/fixtures/scoped-styles/cycle-theme.tsrx
+++ b/packages/vite-plugin-solid/tests/fixtures/scoped-styles/cycle-theme.tsrx
@@ -1,0 +1,11 @@
+import { AppliedPanel } from './cycle-applier.tsrx';
+
+export const theme = <style>
+	div {
+		color: rgb(255, 0, 0);
+	}
+</style>;
+
+export function CycleHost() @{
+	<AppliedPanel />
+}

--- a/packages/vite-plugin-solid/tests/fixtures/scoped-styles/theme.tsrx
+++ b/packages/vite-plugin-solid/tests/fixtures/scoped-styles/theme.tsrx
@@ -1,0 +1,6 @@
+export const theme = <style>
+	div {
+		--tsrx-theme-mark: theme;
+		color: rgb(0, 128, 0);
+	}
+</style>;

--- a/packages/vite-plugin-solid/tests/scoped-styles.runtime.test.tsrx
+++ b/packages/vite-plugin-solid/tests/scoped-styles.runtime.test.tsrx
@@ -1,0 +1,44 @@
+import {
+	collect_stylesheet_texts,
+	index_of_mark,
+} from '@tsrx/core/test-harness/runtime/scoped-styles-dom';
+import { ThemeApplyApp } from './fixtures/scoped-styles/applier.tsrx';
+
+const THEME_MARK = '--tsrx-theme-mark';
+const APPLIER_MARK = '--tsrx-applier-mark';
+
+describe('sibling-scoped apply runtime (solid)', function () {
+	it(
+		'mounts a theme module plus applier and keeps the local rule later in the cascade',
+		async function () {
+			await render(ThemeApplyApp);
+
+			const applied = container.querySelector('[data-probe="applied"]') as HTMLElement;
+			const opted_in = container.querySelector('[data-probe="opt-in"]') as HTMLElement;
+			const untouched = container.querySelector('[data-probe="untouched"]') as HTMLElement;
+
+			expect(applied).not.toBeNull();
+			expect(opted_in).not.toBeNull();
+			expect(untouched).not.toBeNull();
+			expect(applied.className).toContain('probe');
+			expect(opted_in.className).toMatch(/tsrx-[0-9a-f]+/);
+			expect(untouched.className).not.toMatch(/tsrx-[0-9a-f]+/);
+
+			const sheets = collect_stylesheet_texts();
+			const theme_index = index_of_mark(sheets, THEME_MARK);
+			const applier_index = index_of_mark(sheets, APPLIER_MARK);
+			expect(theme_index).toBeGreaterThan(-1);
+			expect(applier_index).toBeGreaterThan(-1);
+			expect(theme_index).toBeLessThan(applier_index);
+
+			expect(getComputedStyle(applied).color).toBe('rgb(0, 0, 0)');
+			expect(getComputedStyle(opted_in).color).toBe('rgb(0, 128, 0)');
+		},
+	);
+
+	it('throws ReferenceError when an applier evaluates before its imported theme', async function () {
+		await expect(import('./fixtures/scoped-styles/cycle-theme.tsrx')).rejects.toThrow(
+			ReferenceError,
+		);
+	});
+});

--- a/packages/vite-plugin-solid/tests/scoped-styles.runtime.test.tsrx
+++ b/packages/vite-plugin-solid/tests/scoped-styles.runtime.test.tsrx
@@ -1,8 +1,9 @@
 import {
 	collect_stylesheet_texts,
-	index_of_mark,
+	expect_cyclic_apply_error,
+	expect_mark_before,
 } from '@tsrx/core/test-harness/runtime/scoped-styles-dom';
-import { ThemeApplyApp } from './fixtures/scoped-styles/applier.tsrx';
+import { ThemeApplyApp } from '@tsrx/vite-plugin-solid-test/scoped-styles/applier.tsrx';
 
 const THEME_MARK = '--tsrx-theme-mark';
 const APPLIER_MARK = '--tsrx-applier-mark';
@@ -24,21 +25,22 @@ describe('sibling-scoped apply runtime (solid)', function () {
 			expect(opted_in.className).toMatch(/tsrx-[0-9a-f]+/);
 			expect(untouched.className).not.toMatch(/tsrx-[0-9a-f]+/);
 
-			const sheets = collect_stylesheet_texts();
-			const theme_index = index_of_mark(sheets, THEME_MARK);
-			const applier_index = index_of_mark(sheets, APPLIER_MARK);
-			expect(theme_index).toBeGreaterThan(-1);
-			expect(applier_index).toBeGreaterThan(-1);
-			expect(theme_index).toBeLessThan(applier_index);
+			expect_mark_before(collect_stylesheet_texts(), THEME_MARK, APPLIER_MARK);
 
 			expect(getComputedStyle(applied).color).toBe('rgb(0, 0, 0)');
 			expect(getComputedStyle(opted_in).color).toBe('rgb(0, 128, 0)');
 		},
 	);
 
-	it('throws ReferenceError when an applier evaluates before its imported theme', async function () {
-		await expect(import('./fixtures/scoped-styles/cycle-theme.tsrx')).rejects.toThrow(
-			ReferenceError,
-		);
+	it('throws when an applier evaluates before its imported theme', async function () {
+		try {
+			await import('@tsrx/vite-plugin-solid-test/scoped-styles/cycle-theme.tsrx');
+			throw new Error('expected the cyclic apply import to throw');
+		} catch (error) {
+			if (error instanceof Error && error.message === 'expected the cyclic apply import to throw') {
+				throw error;
+			}
+			expect_cyclic_apply_error(error);
+		}
 	});
 });

--- a/packages/vite-plugin-vue/src/index.js
+++ b/packages/vite-plugin-vue/src/index.js
@@ -192,10 +192,9 @@ function create_tsrx_vue_plugin(options) {
 
 			if (css) {
 				cssCache.set(realPath, css);
-				code = `import ${JSON.stringify(realPath + CSS_QUERY)};\n${code}`;
-				if (map && typeof map.mappings === 'string') {
-					map = { ...map, mappings: ';' + map.mappings };
-				}
+				// After existing imports so dependency sheets (imported themes)
+				// evaluate first and this module's rules win at equal specificity.
+				code = `${code}\nimport ${JSON.stringify(realPath + CSS_QUERY)};\n`;
 			} else {
 				cssCache.delete(realPath);
 			}

--- a/packages/vite-plugin-vue/tests/fixtures/scoped-styles/applier.tsrx
+++ b/packages/vite-plugin-vue/tests/fixtures/scoped-styles/applier.tsrx
@@ -1,0 +1,23 @@
+import { theme } from './theme.tsrx';
+
+export function AppliedPanel() @{
+	<>
+		<style apply={theme}>
+			div {
+				--tsrx-applier-mark: applier;
+				color: rgb(0, 0, 0);
+			}
+		</style>
+		<div class="probe" data-probe="applied">{'local wins'}</div>
+	</>
+}
+
+export function ThemeApplyApp() @{
+	<>
+		<AppliedPanel />
+		<div class={theme.$class} data-probe="opt-in">{'opted in'}</div>
+		<div data-probe="untouched">{'untouched'}</div>
+	</>
+}
+
+export { theme };

--- a/packages/vite-plugin-vue/tests/fixtures/scoped-styles/cycle-applier.tsrx
+++ b/packages/vite-plugin-vue/tests/fixtures/scoped-styles/cycle-applier.tsrx
@@ -1,0 +1,12 @@
+import { theme } from './cycle-theme.tsrx';
+
+// Module-scope apply reads theme.$class during evaluation. If this module
+// runs first, `theme` is still in the TDZ (D13 layer 3).
+export const applied = <style apply={theme} />;
+
+export function AppliedPanel() @{
+	<>
+		<style apply={theme} />
+		<div>{'cycle'}</div>
+	</>
+}

--- a/packages/vite-plugin-vue/tests/fixtures/scoped-styles/cycle-theme.tsrx
+++ b/packages/vite-plugin-vue/tests/fixtures/scoped-styles/cycle-theme.tsrx
@@ -1,0 +1,11 @@
+import { AppliedPanel } from './cycle-applier.tsrx';
+
+export const theme = <style>
+	div {
+		color: rgb(255, 0, 0);
+	}
+</style>;
+
+export function CycleHost() @{
+	<AppliedPanel />
+}

--- a/packages/vite-plugin-vue/tests/fixtures/scoped-styles/theme.tsrx
+++ b/packages/vite-plugin-vue/tests/fixtures/scoped-styles/theme.tsrx
@@ -1,0 +1,6 @@
+export const theme = <style>
+	div {
+		--tsrx-theme-mark: theme;
+		color: rgb(0, 128, 0);
+	}
+</style>;

--- a/packages/vite-plugin-vue/tests/scoped-styles.runtime.test.tsrx
+++ b/packages/vite-plugin-vue/tests/scoped-styles.runtime.test.tsrx
@@ -1,8 +1,9 @@
 import {
 	collect_stylesheet_texts,
-	index_of_mark,
+	expect_cyclic_apply_error,
+	expect_mark_before,
 } from '@tsrx/core/test-harness/runtime/scoped-styles-dom';
-import { ThemeApplyApp } from './fixtures/scoped-styles/applier.tsrx';
+import { ThemeApplyApp } from '@tsrx/vite-plugin-vue-test/scoped-styles/applier.tsrx';
 
 const THEME_MARK = '--tsrx-theme-mark';
 const APPLIER_MARK = '--tsrx-applier-mark';
@@ -24,21 +25,22 @@ describe('sibling-scoped apply runtime (vue)', function () {
 			expect(opted_in.className).toMatch(/tsrx-[0-9a-f]+/);
 			expect(untouched.className).not.toMatch(/tsrx-[0-9a-f]+/);
 
-			const sheets = collect_stylesheet_texts();
-			const theme_index = index_of_mark(sheets, THEME_MARK);
-			const applier_index = index_of_mark(sheets, APPLIER_MARK);
-			expect(theme_index).toBeGreaterThan(-1);
-			expect(applier_index).toBeGreaterThan(-1);
-			expect(theme_index).toBeLessThan(applier_index);
+			expect_mark_before(collect_stylesheet_texts(), THEME_MARK, APPLIER_MARK);
 
 			expect(getComputedStyle(applied).color).toBe('rgb(0, 0, 0)');
 			expect(getComputedStyle(opted_in).color).toBe('rgb(0, 128, 0)');
 		},
 	);
 
-	it('throws ReferenceError when an applier evaluates before its imported theme', async function () {
-		await expect(import('./fixtures/scoped-styles/cycle-theme.tsrx')).rejects.toThrow(
-			ReferenceError,
-		);
+	it('throws when an applier evaluates before its imported theme', async function () {
+		try {
+			await import('@tsrx/vite-plugin-vue-test/scoped-styles/cycle-theme.tsrx');
+			throw new Error('expected the cyclic apply import to throw');
+		} catch (error) {
+			if (error instanceof Error && error.message === 'expected the cyclic apply import to throw') {
+				throw error;
+			}
+			expect_cyclic_apply_error(error);
+		}
 	});
 });

--- a/packages/vite-plugin-vue/tests/scoped-styles.runtime.test.tsrx
+++ b/packages/vite-plugin-vue/tests/scoped-styles.runtime.test.tsrx
@@ -1,0 +1,44 @@
+import {
+	collect_stylesheet_texts,
+	index_of_mark,
+} from '@tsrx/core/test-harness/runtime/scoped-styles-dom';
+import { ThemeApplyApp } from './fixtures/scoped-styles/applier.tsrx';
+
+const THEME_MARK = '--tsrx-theme-mark';
+const APPLIER_MARK = '--tsrx-applier-mark';
+
+describe('sibling-scoped apply runtime (vue)', function () {
+	it(
+		'mounts a theme module plus applier and keeps the local rule later in the cascade',
+		async function () {
+			await render(ThemeApplyApp);
+
+			const applied = container.querySelector('[data-probe="applied"]') as HTMLElement;
+			const opted_in = container.querySelector('[data-probe="opt-in"]') as HTMLElement;
+			const untouched = container.querySelector('[data-probe="untouched"]') as HTMLElement;
+
+			expect(applied).not.toBeNull();
+			expect(opted_in).not.toBeNull();
+			expect(untouched).not.toBeNull();
+			expect(applied.className).toContain('probe');
+			expect(opted_in.className).toMatch(/tsrx-[0-9a-f]+/);
+			expect(untouched.className).not.toMatch(/tsrx-[0-9a-f]+/);
+
+			const sheets = collect_stylesheet_texts();
+			const theme_index = index_of_mark(sheets, THEME_MARK);
+			const applier_index = index_of_mark(sheets, APPLIER_MARK);
+			expect(theme_index).toBeGreaterThan(-1);
+			expect(applier_index).toBeGreaterThan(-1);
+			expect(theme_index).toBeLessThan(applier_index);
+
+			expect(getComputedStyle(applied).color).toBe('rgb(0, 0, 0)');
+			expect(getComputedStyle(opted_in).color).toBe('rgb(0, 128, 0)');
+		},
+	);
+
+	it('throws ReferenceError when an applier evaluates before its imported theme', async function () {
+		await expect(import('./fixtures/scoped-styles/cycle-theme.tsrx')).rejects.toThrow(
+			ReferenceError,
+		);
+	});
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -29,10 +29,28 @@ const vue_jsx_vapor_jsx_runtime_path = fileURLToPath(
 const tsrx_core_test_harness_runtime_dir = fileURLToPath(
 	new URL('./packages/tsrx/tests/shared/runtime/', import.meta.url),
 );
+const solid_scoped_styles_dir = fileURLToPath(
+	new URL('./packages/vite-plugin-solid/tests/fixtures/scoped-styles/', import.meta.url),
+);
+const vue_scoped_styles_dir = fileURLToPath(
+	new URL('./packages/vite-plugin-vue/tests/fixtures/scoped-styles/', import.meta.url),
+);
 const tsrx_core_test_harness_alias = [
 	{
 		find: /^@tsrx\/core\/test-harness\/runtime\/(.*)$/,
 		replacement: `${tsrx_core_test_harness_runtime_dir}$1`,
+	},
+];
+const solid_scoped_styles_alias = [
+	{
+		find: /^@tsrx\/vite-plugin-solid-test\/scoped-styles\/(.*)$/,
+		replacement: `${solid_scoped_styles_dir}$1`,
+	},
+];
+const vue_scoped_styles_alias = [
+	{
+		find: /^@tsrx\/vite-plugin-vue-test\/scoped-styles\/(.*)$/,
+		replacement: `${vue_scoped_styles_dir}$1`,
 	},
 ];
 
@@ -208,8 +226,11 @@ export default defineConfig({
 				},
 				plugins: [vue_runtime_dependency_resolver, vue_runtime_alias_plugin, tsrxVue()],
 				resolve: process.env.VITEST
-					? { conditions: ['browser'], alias: tsrx_core_test_harness_alias }
-					: { alias: tsrx_core_test_harness_alias },
+					? {
+							conditions: ['browser'],
+							alias: [...tsrx_core_test_harness_alias, ...vue_scoped_styles_alias],
+						}
+					: { alias: [...tsrx_core_test_harness_alias, ...vue_scoped_styles_alias] },
 				ssr: {
 					noExternal: ['vue', 'vue-jsx-vapor', '@tsrx/vue'],
 				},
@@ -302,7 +323,7 @@ export default defineConfig({
 				},
 				plugins: [solid_runtime_dependency_resolver, tsrxSolid(), solid()],
 				resolve: {
-					alias: tsrx_core_test_harness_alias,
+					alias: [...tsrx_core_test_harness_alias, ...solid_scoped_styles_alias],
 				},
 			},
 			{

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -127,6 +127,7 @@ export default defineConfig({
 					environment: 'jsdom',
 					setupFiles: ['packages/vite-plugin-preact/tests/setup.js'],
 					globals: true,
+					css: true,
 				},
 				plugins: [preact_runtime_dependency_resolver, tsrxPreact()],
 				resolve: {
@@ -203,6 +204,7 @@ export default defineConfig({
 					environment: 'jsdom',
 					setupFiles: ['packages/vite-plugin-vue/tests/setup.js'],
 					globals: true,
+					css: true,
 				},
 				plugins: [vue_runtime_dependency_resolver, vue_runtime_alias_plugin, tsrxVue()],
 				resolve: process.env.VITEST
@@ -273,6 +275,7 @@ export default defineConfig({
 					environment: 'jsdom',
 					setupFiles: ['packages/vite-plugin-react/tests/setup.js'],
 					globals: true,
+					css: true,
 				},
 				plugins: [react_runtime_dependency_resolver, tsrxReact()],
 				resolve: {
@@ -295,6 +298,7 @@ export default defineConfig({
 					environment: 'jsdom',
 					setupFiles: ['packages/vite-plugin-solid/tests/setup.js'],
 					globals: true,
+					css: true,
 				},
 				plugins: [solid_runtime_dependency_resolver, tsrxSolid(), solid()],
 				resolve: {

--- a/website-tsrx/src/pages/getting-started.tsrx
+++ b/website-tsrx/src/pages/getting-started.tsrx
@@ -270,38 +270,52 @@ const MCP_CLAUDE_CODE_HTML = [
 ].join('\n');
 
 const REACT_APPLY_CLASS_HTML = highlight_tsrx(
-	`import { theme } from './theme.tsrx';
+	`// theme.tsrx
+export const theme = <style>
+  div { color: green; }
+</style>;
+// theme.$class -> the block's hash class
+
+// panel.tsrx
+import { theme } from './theme.tsrx';
 
 export function Panel() @{
   <>
     <style apply={theme}>
-      /* Scope A; also stamps theme.$class on every element of A. */
+      /* scope A; also stamps theme.$class on every element of A */
       div { color: black; }
     </style>
-    <div>Black: the local rule beats the theme's green.</div>
+    <div>Black: the local rule beats the theme's green</div>
   </>
 }
 
 export function OptIn() @{
-  <div className={theme.$class}>Blue: opted in with $class</div>
+  <div className={theme.$class}>Green: opted in with $class</div>
 }`,
 );
 
 const APPLY_CLASS_HTML = highlight_tsrx(
-	`import { theme } from './theme.tsrx';
+	`// theme.tsrx
+export const theme = <style>
+  div { color: green; }
+</style>;
+// theme.$class -> the block's hash class
+
+// panel.tsrx
+import { theme } from './theme.tsrx';
 
 export function Panel() @{
   <>
     <style apply={theme}>
-      /* Scope A; also stamps theme.$class on every element of A. */
+      /* scope A; also stamps theme.$class on every element of A */
       div { color: black; }
     </style>
-    <div>Black: the local rule beats the theme's green.</div>
+    <div>Black: the local rule beats the theme's green</div>
   </>
 }
 
 export function OptIn() @{
-  <div class={theme.$class}>Blue: opted in with $class</div>
+  <div class={theme.$class}>Green: opted in with $class</div>
 }`,
 );
 
@@ -443,15 +457,16 @@ export function GettingStartedPage() @{
 								modules into standard React components with sibling-scoped CSS.
 							</p>
 							<p class="section-body">
-								Assign a
+								Assigning a
 								<code class="inline-code">{'<style>'}</code>
-								block to get
-								<code class="inline-code">$class</code>, then
+								block to a variable gives you a theme with
+								<code class="inline-code">$class</code>, its hash class.
 								<code class="inline-code">{'<style apply={theme} />'}</code>
-								adds that class to every element of a scope. React keeps authored attributes as
+								adds that class to every element of the scope it sits in, and a rule written in that
+								scope beats the theme's at equal specificity. React keeps authored attributes as
 								written, so use
 								<code class="inline-code">className</code>
-								when you opt a single element in. See
+								to opt a single element in. See
 								<a href="/features#style-composition">Style composition</a>
 								for the full model.
 							</p>
@@ -484,14 +499,15 @@ export function GettingStartedPage() @{
 								if you want to avoid pulling in the full compat layer.
 							</p>
 							<p class="section-body">
-								Assign a
+								Assigning a
 								<code class="inline-code">{'<style>'}</code>
-								block to get
-								<code class="inline-code">$class</code>, then
+								block to a variable gives you a theme with
+								<code class="inline-code">$class</code>, its hash class.
 								<code class="inline-code">{'<style apply={theme} />'}</code>
-								adds that class to every element of a scope. Use
+								adds that class to every element of the scope it sits in, and a rule written in that
+								scope beats the theme's at equal specificity. Use
 								<code class="inline-code">class</code>
-								when you opt a single element in. See
+								to opt a single element in. See
 								<a href="/features#style-composition">Style composition</a>
 								for the full model.
 							</p>
@@ -627,12 +643,14 @@ export function GettingStartedPage() @{
 							<p class="section-body">
 								Sibling-scoped
 								<code class="inline-code">{'<style>'}</code>
-								blocks work the same as on the other targets. Assign a block to get
-								<code class="inline-code">$class</code>, then
+								blocks work the same as on the other targets. Assigning a block to a variable gives
+								you a theme with
+								<code class="inline-code">$class</code>, its hash class.
 								<code class="inline-code">{'<style apply={theme} />'}</code>
-								adds that class to every element of a scope. Use
+								adds that class to every element of the scope it sits in, and a rule written in that
+								scope beats the theme's at equal specificity. Use
 								<code class="inline-code">class</code>
-								when you opt a single element in. See
+								to opt a single element in. See
 								<a href="/features#style-composition">Style composition</a>
 								for the full model.
 							</p>
@@ -716,12 +734,14 @@ export function GettingStartedPage() @{
 							<p class="section-body">
 								Sibling-scoped
 								<code class="inline-code">{'<style>'}</code>
-								blocks work the same as on the other targets. Assign a block to get
-								<code class="inline-code">$class</code>, then
+								blocks work the same as on the other targets. Assigning a block to a variable gives
+								you a theme with
+								<code class="inline-code">$class</code>, its hash class.
 								<code class="inline-code">{'<style apply={theme} />'}</code>
-								adds that class to every element of a scope. Use
+								adds that class to every element of the scope it sits in, and a rule written in that
+								scope beats the theme's at equal specificity. Use
 								<code class="inline-code">class</code>
-								when you opt a single element in. See
+								to opt a single element in. See
 								<a href="/features#style-composition">Style composition</a>
 								for the full model.
 							</p>

--- a/website-tsrx/src/pages/getting-started.tsrx
+++ b/website-tsrx/src/pages/getting-started.tsrx
@@ -1,3 +1,5 @@
+import { highlight_tsrx } from '../lib/code-highlight.ts';
+
 // Code snippets (hand-highlighted, matching homepage code-block style)
 
 const INSTALL_HTML = [
@@ -267,6 +269,42 @@ const MCP_CLAUDE_CODE_HTML = [
 	'<span class="ln">1</span> <span class="fn">claude</span> <span class="prop">mcp</span> <span class="prop">add</span> <span class="str">tsrx</span> <span class="prop">--</span> <span class="fn">npx</span> <span class="str">-y</span> <span class="str">@tsrx/mcp</span>',
 ].join('\n');
 
+const REACT_APPLY_CLASS_HTML = highlight_tsrx(
+	`import { theme } from './theme.tsrx';
+
+export function Panel() @{
+  <>
+    <style apply={theme}>
+      /* Scope A; also stamps theme.$class on every element of A. */
+      div { color: black; }
+    </style>
+    <div>Black: the local rule beats the theme's green.</div>
+  </>
+}
+
+export function OptIn() @{
+  <div className={theme.$class}>Blue: opted in with $class</div>
+}`,
+);
+
+const APPLY_CLASS_HTML = highlight_tsrx(
+	`import { theme } from './theme.tsrx';
+
+export function Panel() @{
+  <>
+    <style apply={theme}>
+      /* Scope A; also stamps theme.$class on every element of A. */
+      div { color: black; }
+    </style>
+    <div>Black: the local rule beats the theme's green.</div>
+  </>
+}
+
+export function OptIn() @{
+  <div class={theme.$class}>Blue: opted in with $class</div>
+}`,
+);
+
 const NAV_GROUPS = [
 	{
 		heading: 'Frameworks',
@@ -402,8 +440,24 @@ export function GettingStartedPage() @{
 								<code class="inline-code">.tsrx</code>
 								file and import it from your existing JS, TS, or TSX code. The plugin compiles
 								<code class="inline-code">.tsrx</code>
-								modules into standard React components with scoped CSS.
+								modules into standard React components with sibling-scoped CSS.
 							</p>
+							<p class="section-body">
+								Assign a
+								<code class="inline-code">{'<style>'}</code>
+								block to get
+								<code class="inline-code">$class</code>, then
+								<code class="inline-code">{'<style apply={theme} />'}</code>
+								adds that class to every element of a scope. React keeps authored attributes as
+								written, so use
+								<code class="inline-code">className</code>
+								when you opt a single element in. See
+								<a href="/features#style-composition">Style composition</a>
+								for the full model.
+							</p>
+							<pre class="code-block">
+								<code innerHTML={REACT_APPLY_CLASS_HTML} />
+							</pre>
 						</section>
 
 						<section class="doc-section" id="preact-vite">
@@ -419,7 +473,7 @@ export function GettingStartedPage() @{
 							<p class="section-body">
 								The plugin compiles
 								<code class="inline-code">.tsrx</code>
-								modules into standard Preact components.
+								modules into standard Preact components with sibling-scoped CSS.
 								<code class="inline-code">Suspense</code>
 								is imported from
 								<code class="inline-code">preact/compat</code>
@@ -429,6 +483,21 @@ export function GettingStartedPage() @{
 								<code class="inline-code">tsrxPreact()</code>
 								if you want to avoid pulling in the full compat layer.
 							</p>
+							<p class="section-body">
+								Assign a
+								<code class="inline-code">{'<style>'}</code>
+								block to get
+								<code class="inline-code">$class</code>, then
+								<code class="inline-code">{'<style apply={theme} />'}</code>
+								adds that class to every element of a scope. Use
+								<code class="inline-code">class</code>
+								when you opt a single element in. See
+								<a href="/features#style-composition">Style composition</a>
+								for the full model.
+							</p>
+							<pre class="code-block">
+								<code innerHTML={APPLY_CLASS_HTML} />
+							</pre>
 						</section>
 
 						<section class="doc-section" id="preact-rspack">
@@ -555,6 +624,21 @@ export function GettingStartedPage() @{
 							<pre class="code-block">
 								<code innerHTML={SOLID_VITE_CONFIG_HTML} />
 							</pre>
+							<p class="section-body">
+								Sibling-scoped
+								<code class="inline-code">{'<style>'}</code>
+								blocks work the same as on the other targets. Assign a block to get
+								<code class="inline-code">$class</code>, then
+								<code class="inline-code">{'<style apply={theme} />'}</code>
+								adds that class to every element of a scope. Use
+								<code class="inline-code">class</code>
+								when you opt a single element in. See
+								<a href="/features#style-composition">Style composition</a>
+								for the full model.
+							</p>
+							<pre class="code-block">
+								<code innerHTML={APPLY_CLASS_HTML} />
+							</pre>
 						</section>
 
 						<section class="doc-section" id="solid-rspack">
@@ -629,6 +713,21 @@ export function GettingStartedPage() @{
 								<code class="inline-code">tsconfig.json</code>
 								.
 							</p>
+							<p class="section-body">
+								Sibling-scoped
+								<code class="inline-code">{'<style>'}</code>
+								blocks work the same as on the other targets. Assign a block to get
+								<code class="inline-code">$class</code>, then
+								<code class="inline-code">{'<style apply={theme} />'}</code>
+								adds that class to every element of a scope. Use
+								<code class="inline-code">class</code>
+								when you opt a single element in. See
+								<a href="/features#style-composition">Style composition</a>
+								for the full model.
+							</p>
+							<pre class="code-block">
+								<code innerHTML={APPLY_CLASS_HTML} />
+							</pre>
 						</section>
 
 						<section class="doc-section" id="vue-rspack">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #49.

Target-facing follow-up to the sibling-scoped `<style>` / `$class` / `apply` work already on `feat/scoped-styles-apply`. Core still applies through `createJsxTransform`; this PR adds docs, bundler README wording, and Vite runtime proof for React, Preact, Solid, and Vue.

## Docs
- Getting Started now shows `apply` / `$class` on the React, Preact, Solid, and Vue Vite pages (React uses `className`; the others use `class`), with a link to Style composition.
- New Rspack and Turbopack plugin READMEs describe sibling-scoped `<style>` emission. Bun READMEs already used that wording.

## Runtime tests
- `packages/vite-plugin-*/tests/scoped-styles.runtime.test.tsrx` mounts a theme module + applier module and asserts computed colors (local rule wins; `$class` opt-in still gets the theme) and `<style>` order (theme sheet before applier sheet).
- Import-cycle case from D13 layer 3: an applier evaluated before its imported theme reads `theme.$class` while the theme is uninitialized. Native ESM would throw `ReferenceError`; Vite's transform binds the cycle as `undefined` and throws `TypeError`.

## Vite CSS import order
The runtime tests found that each Vite plugin prepended the virtual CSS import, so a module's stylesheet evaluated before its imported themes and equal-specificity local rules lost. The four Vite plugins now emit that import after existing JS imports. Patch changeset included.

## Validation
- `vitest run --project tsrx-react-runtime --project tsrx-preact-runtime --project tsrx-solid-runtime --project tsrx-vue-runtime --project vite-plugin-react --project vite-plugin-preact --project vite-plugin-solid --project vite-plugin-vue`: 22 files, 277 tests passed.
- Focused apply suites: 4 files, 8 tests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-583cdf2e-f456-46e1-ae09-c06b32a7c786?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-583cdf2e-f456-46e1-ae09-c06b32a7c786&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

