### PR TITLE
fix(bundlers): emit the module CSS import after its JS imports

### DIFF
--- a/.changeset/bundler-css-import-order.md
+++ b/.changeset/bundler-css-import-order.md
@@ -1,0 +1,13 @@
+---
+'@tsrx/rspack-plugin-react': patch
+'@tsrx/rspack-plugin-preact': patch
+'@tsrx/rspack-plugin-solid': patch
+'@tsrx/rspack-plugin-vue': patch
+'@tsrx/turbopack-plugin-react': patch
+'@tsrx/bun-plugin-react': patch
+'@tsrx/bun-plugin-preact': patch
+'@tsrx/bun-plugin-solid': patch
+'@tsrx/bun-plugin-vue': patch
+---
+
+Emit each module's virtual CSS import after its JavaScript imports, so an imported theme's CSS comes before the CSS of the block that applies it and the local rule wins at equal specificity. The Rspack and Turbopack loaders now keep the compiler's source map when a module has styles, since nothing above the import moves.

--- a/packages/bun-plugin-preact/src/index.js
+++ b/packages/bun-plugin-preact/src/index.js
@@ -131,7 +131,9 @@ export function tsrxPreact(options = {}) {
 					let output = code;
 					if (emit_css && css) {
 						css_cache.set(css_id, css);
-						output = `import ${JSON.stringify(css_id)};\n${code}`;
+						// After the module's own imports so imported themes' sheets load first
+						// and a rule in the applying module wins at equal specificity.
+						output = `${code}\nimport ${JSON.stringify(css_id)};\n`;
 					} else {
 						css_cache.delete(css_id);
 					}

--- a/packages/bun-plugin-preact/tests/basic.test.js
+++ b/packages/bun-plugin-preact/tests/basic.test.js
@@ -125,7 +125,9 @@ describe('@tsrx/bun-plugin-preact', () => {
 			const file_path = path.join(dir, 'App.tsrx');
 			await writeFile(
 				file_path,
-				`export function App() @{
+				`import './reset.css';
+
+					export function App() @{
 					<>
 						<div class="div">{'Hello world'}</div>
 
@@ -147,6 +149,10 @@ describe('@tsrx/bun-plugin-preact', () => {
 			expect(transformed?.loader).toBe('js');
 			expect(transformed?.contents).toContain('// transformed');
 			expect(transformed?.contents).toContain(css_id);
+			expect(String(transformed?.contents).indexOf('./reset.css')).toBeGreaterThan(-1);
+			expect(String(transformed?.contents).indexOf('./reset.css')).toBeLessThan(
+				String(transformed?.contents).indexOf(css_id),
+			);
 			expect(css.loader).toBe('css');
 			expect(css.contents).toContain('.div.');
 			expect(css.contents).toContain('color: red;');

--- a/packages/bun-plugin-react/src/index.js
+++ b/packages/bun-plugin-react/src/index.js
@@ -127,7 +127,9 @@ export function tsrxReact(options = {}) {
 					let output = code;
 					if (emit_css && css) {
 						css_cache.set(css_id, css);
-						output = `import ${JSON.stringify(css_id)};\n${code}`;
+						// After the module's own imports so imported themes' sheets load first
+						// and a rule in the applying module wins at equal specificity.
+						output = `${code}\nimport ${JSON.stringify(css_id)};\n`;
 					} else {
 						css_cache.delete(css_id);
 					}

--- a/packages/bun-plugin-react/tests/basic.test.js
+++ b/packages/bun-plugin-react/tests/basic.test.js
@@ -125,7 +125,9 @@ describe('@tsrx/bun-plugin-react', () => {
 			const file_path = path.join(dir, 'App.tsrx');
 			await writeFile(
 				file_path,
-				`export function App() @{
+				`import './reset.css';
+
+					export function App() @{
 					<>
 					<div className="div">{'Hello world'}</div>
 
@@ -147,6 +149,10 @@ describe('@tsrx/bun-plugin-react', () => {
 			expect(transformed?.loader).toBe('js');
 			expect(transformed?.contents).toContain('// transformed');
 			expect(transformed?.contents).toContain(css_id);
+			expect(String(transformed?.contents).indexOf('./reset.css')).toBeGreaterThan(-1);
+			expect(String(transformed?.contents).indexOf('./reset.css')).toBeLessThan(
+				String(transformed?.contents).indexOf(css_id),
+			);
 			expect(css.loader).toBe('css');
 			expect(css.contents).toContain('.div.');
 			expect(css.contents).toContain('color: red;');

--- a/packages/bun-plugin-solid/src/index.js
+++ b/packages/bun-plugin-solid/src/index.js
@@ -131,7 +131,9 @@ export function tsrxSolid(options = {}) {
 					let output = code;
 					if (emit_css && css) {
 						css_cache.set(css_id, css);
-						output = `import ${JSON.stringify(css_id)};\n${code}`;
+						// After the module's own imports so imported themes' sheets load first
+						// and a rule in the applying module wins at equal specificity.
+						output = `${code}\nimport ${JSON.stringify(css_id)};\n`;
 					} else {
 						css_cache.delete(css_id);
 					}

--- a/packages/bun-plugin-solid/tests/basic.test.js
+++ b/packages/bun-plugin-solid/tests/basic.test.js
@@ -77,7 +77,9 @@ describe('@tsrx/bun-plugin-solid', () => {
 			const file_path = path.join(dir, 'App.tsrx');
 			await writeFile(
 				file_path,
-				`export function App({ name }: { name: string }) @{ <>
+				`import './reset.css';
+
+				export function App({ name }: { name: string }) @{ <>
 					<div class="div">{name}</div>
 
 					<style>
@@ -99,6 +101,10 @@ describe('@tsrx/bun-plugin-solid', () => {
 			expect(transformed?.contents).toContain('template as _$template');
 			expect(transformed?.contents).toContain('insert as _$insert');
 			expect(transformed?.contents).toContain(css_id);
+			expect(String(transformed?.contents).indexOf('./reset.css')).toBeGreaterThan(-1);
+			expect(String(transformed?.contents).indexOf('./reset.css')).toBeLessThan(
+				String(transformed?.contents).indexOf(css_id),
+			);
 			expect(transformed?.contents).not.toContain('{ name }: { name: string }');
 			expect(css.loader).toBe('css');
 			expect(css.contents).toContain('.div.');

--- a/packages/bun-plugin-vue/src/index.js
+++ b/packages/bun-plugin-vue/src/index.js
@@ -165,7 +165,9 @@ export function tsrxVue(options = {}) {
 					let output = code;
 					if (emit_css && css) {
 						css_cache.set(css_id, css);
-						output = `import ${JSON.stringify(css_id)};\n${code}`;
+						// After the module's own imports so imported themes' sheets load first
+						// and a rule in the applying module wins at equal specificity.
+						output = `${code}\nimport ${JSON.stringify(css_id)};\n`;
 					} else {
 						css_cache.delete(css_id);
 					}

--- a/packages/bun-plugin-vue/tests/basic.test.js
+++ b/packages/bun-plugin-vue/tests/basic.test.js
@@ -138,7 +138,9 @@ describe('@tsrx/bun-plugin-vue', () => {
 			const file_path = path.join(dir, 'App.tsrx');
 			await writeFile(
 				file_path,
-				`export function App() @{
+				`import './reset.css';
+
+					export function App() @{
 					<>
 						<div class="div">{'Hello world'}</div>
 
@@ -162,6 +164,10 @@ describe('@tsrx/bun-plugin-vue', () => {
 			expect(transformed?.contents).toContain('defineVaporComponent');
 			expect(transformed?.contents).toContain('template as _template');
 			expect(transformed?.contents).toContain(css_id);
+			expect(String(transformed?.contents).indexOf('./reset.css')).toBeGreaterThan(-1);
+			expect(String(transformed?.contents).indexOf('./reset.css')).toBeLessThan(
+				String(transformed?.contents).indexOf(css_id),
+			);
 			expect(transformed?.contents).not.toContain('return <div>');
 			expect(css.loader).toBe('css');
 			expect(css.contents).toContain('.div.');

--- a/packages/rspack-plugin-preact/src/css-loader.js
+++ b/packages/rspack-plugin-preact/src/css-loader.js
@@ -7,7 +7,7 @@ import { compile } from '@tsrx/preact';
 /**
  * Re-runs the `@tsrx/preact` compiler against the `.tsrx` source to extract
  * the scoped CSS emitted by its `<style>` block. Invoked when rspack resolves
- * the sibling `?tsrx-css&lang.css` import prepended by the JS loader.
+ * the sibling `?tsrx-css&lang.css` import emitted by the JS loader.
  *
  * @this {LoaderContext<{ suspenseSource?: string, runtimeImports?: RuntimeImportMode }>}
  * @param {string} source

--- a/packages/rspack-plugin-preact/src/js-loader.js
+++ b/packages/rspack-plugin-preact/src/js-loader.js
@@ -6,7 +6,7 @@ import { compile } from '@tsrx/preact';
 
 /**
  * Compiles `.tsrx` source to TSX and, when a `<style>` block is present,
- * prepends an `import` to the sibling virtual CSS module so rspack can
+ * appends an `import` of the sibling virtual CSS module so rspack can
  * include the styles in the asset graph.
  *
  * @this {LoaderContext<{ suspenseSource?: string, runtimeImports?: RuntimeImportMode }>}
@@ -21,15 +21,16 @@ export default function jsLoader(source) {
 		const { code, map, css } = compile(source, resourcePath, this.getOptions?.());
 
 		let output = code;
-		/** @type {typeof map | null} */
-		let output_map = map;
 		if (css) {
+			// The import goes after the module's own imports so the stylesheets of
+			// imported themes are added to the asset graph first and a rule in the
+			// applying module wins at equal specificity. Nothing above it moves, so
+			// the compiler's source map still applies.
 			const cssImport = `${resourcePath}?tsrx-css&lang.css`;
-			output = `import ${JSON.stringify(cssImport)};\n${code}`;
-			output_map = null;
+			output = `${code}\nimport ${JSON.stringify(cssImport)};\n`;
 		}
 
-		callback(null, output, /** @type {any} */ (output_map ?? undefined));
+		callback(null, output, /** @type {any} */ (map ?? undefined));
 	} catch (/** @type {any} */ err) {
 		callback(err);
 	}

--- a/packages/rspack-plugin-preact/tests/basic.test.js
+++ b/packages/rspack-plugin-preact/tests/basic.test.js
@@ -33,9 +33,11 @@ function createLoaderContext(resourcePath, options = {}) {
 }
 
 describe('@tsrx/rspack-plugin-preact js-loader', () => {
-	it('prepends a virtual css import when a style block exists', async () => {
+	it('appends a virtual css import after the module imports when a style block exists', async () => {
 		const id = '/virtual/App.tsrx';
-		const source = `export function App() @{
+		const source = `import './reset.css';
+
+			export function App() @{
 			<>
 				<div>{'Hello world'}</div>
 
@@ -53,10 +55,12 @@ describe('@tsrx/rspack-plugin-preact js-loader', () => {
 
 		expect(err).toBeNull();
 		expect(output).toContain(`${id}?tsrx-css&lang.css`);
-		expect(map).toBeUndefined();
+		expect(output.indexOf('./reset.css')).toBeGreaterThan(-1);
+		expect(output.indexOf('./reset.css')).toBeLessThan(output.indexOf('tsrx-css'));
+		expect(map).toBeTruthy();
 	});
 
-	it('does not prepend a virtual css import when no style block exists', async () => {
+	it('does not append a virtual css import when no style block exists', async () => {
 		const id = '/virtual/App.tsrx';
 		const source = `export function App() @{
 			<div>{'Hello world'}</div>

--- a/packages/rspack-plugin-react/src/css-loader.js
+++ b/packages/rspack-plugin-react/src/css-loader.js
@@ -7,7 +7,7 @@ import { compile } from '@tsrx/react';
 /**
  * Re-runs the `@tsrx/react` compiler against the `.tsrx` source to extract
  * the scoped CSS emitted by its `<style>` block. Invoked when rspack resolves
- * the sibling `?tsrx-css&lang.css` import prepended by the JS loader.
+ * the sibling `?tsrx-css&lang.css` import emitted by the JS loader.
  *
  * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode }>}
  * @param {string} source

--- a/packages/rspack-plugin-react/src/js-loader.js
+++ b/packages/rspack-plugin-react/src/js-loader.js
@@ -6,7 +6,7 @@ import { compile } from '@tsrx/react';
 
 /**
  * Compiles `.tsrx` source to TSX and, when a `<style>` block is present,
- * prepends an `import` to the sibling virtual CSS module so rspack can
+ * appends an `import` of the sibling virtual CSS module so rspack can
  * include the styles in the asset graph.
  *
  * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode }>}
@@ -21,15 +21,16 @@ export default function jsLoader(source) {
 		const { code, map, css } = compile(source, resourcePath, this.getOptions?.());
 
 		let output = code;
-		/** @type {typeof map | null} */
-		let output_map = map;
 		if (css) {
+			// The import goes after the module's own imports so the stylesheets of
+			// imported themes are added to the asset graph first and a rule in the
+			// applying module wins at equal specificity. Nothing above it moves, so
+			// the compiler's source map still applies.
 			const cssImport = `${resourcePath}?tsrx-css&lang.css`;
-			output = `import ${JSON.stringify(cssImport)};\n${code}`;
-			output_map = null;
+			output = `${code}\nimport ${JSON.stringify(cssImport)};\n`;
 		}
 
-		callback(null, output, /** @type {any} */ (output_map ?? undefined));
+		callback(null, output, /** @type {any} */ (map ?? undefined));
 	} catch (/** @type {any} */ err) {
 		callback(err);
 	}

--- a/packages/rspack-plugin-react/tests/basic.test.js
+++ b/packages/rspack-plugin-react/tests/basic.test.js
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -35,9 +35,11 @@ function createLoaderContext(resourcePath) {
 }
 
 describe('@tsrx/rspack-plugin-react js-loader', () => {
-	it('prepends a virtual css import when a style block exists', async () => {
+	it('appends a virtual css import after the module imports when a style block exists', async () => {
 		const id = '/virtual/App.tsrx';
-		const source = `export function App() @{
+		const source = `import './reset.css';
+
+			export function App() @{
 			<>
 			<div>{'Hello world'}</div>
 
@@ -55,10 +57,12 @@ describe('@tsrx/rspack-plugin-react js-loader', () => {
 
 		expect(err).toBeNull();
 		expect(output).toContain(`${id}?tsrx-css&lang.css`);
-		expect(map).toBeUndefined();
+		expect(output.indexOf('./reset.css')).toBeGreaterThan(-1);
+		expect(output.indexOf('./reset.css')).toBeLessThan(output.indexOf('tsrx-css'));
+		expect(map).toBeTruthy();
 	});
 
-	it('does not prepend a virtual css import when no style block exists', async () => {
+	it('does not append a virtual css import when no style block exists', async () => {
 		const id = '/virtual/App.tsrx';
 		const source = `export function App() @{
 			<div>{'Hello world'}</div>
@@ -172,6 +176,75 @@ describe('@tsrx/rspack-plugin-react plugin', () => {
 
 		expect(compiler.options.experiments.css).toBe(false);
 		expect(compiler.options.experiments.deferImport).toBe(false);
+	});
+
+	it('emits an imported theme before the module that applies it in a Rspack 2 bundle', async () => {
+		const package_root = fileURLToPath(new URL('..', import.meta.url));
+		const output_path = mkdtempSync(path.join(tmpdir(), 'tsrx-rspack-apply-'));
+		const virtual_root = 'tests/virtual-apply';
+		const modules = {
+			[`${virtual_root}/entry.tsrx`]: `
+				export { Panel } from './panel.tsrx';
+			`,
+			[`${virtual_root}/theme.tsrx`]: `
+				export const theme = <style>
+					div {
+						--tsrx-theme-mark: theme;
+						color: green;
+					}
+				</style>;
+			`,
+			[`${virtual_root}/panel.tsrx`]: `
+				import { theme } from './theme.tsrx';
+
+				export function Panel() @{
+					<>
+						<style apply={theme}>
+							div {
+								--tsrx-applier-mark: applier;
+								color: black;
+							}
+						</style>
+						<div>{'Black: the local rule beats the theme'}</div>
+					</>
+				}
+			`,
+		};
+
+		try {
+			await new Promise((resolve, reject) => {
+				rspack(
+					{
+						context: package_root,
+						mode: 'development',
+						target: 'web',
+						entry: `./${virtual_root}/entry.tsrx`,
+						devtool: false,
+						optimization: { minimize: false },
+						output: { path: output_path, filename: 'main.js' },
+						plugins: [new experiments.VirtualModulesPlugin(modules), new TsrxReactRspackPlugin()],
+					},
+					(error, stats) => {
+						if (error) {
+							reject(error);
+						} else if (stats?.hasErrors()) {
+							reject(new Error(stats.toString({ all: false, errors: true })));
+						} else {
+							resolve(undefined);
+						}
+					},
+				);
+			});
+
+			const css = readFileSync(path.join(output_path, 'main.css'), 'utf8');
+			const theme_at = css.indexOf('--tsrx-theme-mark');
+			const applier_at = css.indexOf('--tsrx-applier-mark');
+			expect(theme_at).toBeGreaterThan(-1);
+			expect(applier_at).toBeGreaterThan(-1);
+			expect(theme_at).toBeLessThan(applier_at);
+		} finally {
+			rmSync(output_path, { recursive: true, force: true });
+		}
 	});
 
 	it('keeps static and dynamic deferred imports lazy in a Rspack 2 bundle', async () => {

--- a/packages/rspack-plugin-solid/src/css-loader.js
+++ b/packages/rspack-plugin-solid/src/css-loader.js
@@ -7,7 +7,7 @@ import { compile } from '@tsrx/solid';
 /**
  * Re-runs the `@tsrx/solid` compiler against the `.tsrx` source to extract
  * the scoped CSS emitted by its `<style>` block. Invoked when rspack resolves
- * the sibling `?tsrx-css&lang.css` import prepended by the JS loader.
+ * the sibling `?tsrx-css&lang.css` import emitted by the JS loader.
  *
  * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode }>}
  * @param {string} source

--- a/packages/rspack-plugin-solid/src/js-loader.js
+++ b/packages/rspack-plugin-solid/src/js-loader.js
@@ -6,7 +6,7 @@ import { compile } from '@tsrx/solid';
 
 /**
  * Compiles `.tsrx` source to TSX and, when a `<style>` block is present,
- * prepends an `import` to the sibling virtual CSS module so rspack can
+ * appends an `import` of the sibling virtual CSS module so rspack can
  * include the styles in the asset graph.
  *
  * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode }>}
@@ -21,15 +21,16 @@ export default function jsLoader(source) {
 		const { code, map, css } = compile(source, resourcePath, this.getOptions?.());
 
 		let output = code;
-		/** @type {typeof map | null} */
-		let output_map = map;
 		if (css) {
+			// The import goes after the module's own imports so the stylesheets of
+			// imported themes are added to the asset graph first and a rule in the
+			// applying module wins at equal specificity. Nothing above it moves, so
+			// the compiler's source map still applies.
 			const cssImport = `${resourcePath}?tsrx-css&lang.css`;
-			output = `import ${JSON.stringify(cssImport)};\n${code}`;
-			output_map = null;
+			output = `${code}\nimport ${JSON.stringify(cssImport)};\n`;
 		}
 
-		callback(null, output, /** @type {any} */ (output_map ?? undefined));
+		callback(null, output, /** @type {any} */ (map ?? undefined));
 	} catch (/** @type {any} */ err) {
 		callback(err);
 	}

--- a/packages/rspack-plugin-solid/tests/basic.test.js
+++ b/packages/rspack-plugin-solid/tests/basic.test.js
@@ -29,9 +29,11 @@ function createLoaderContext(resourcePath) {
 }
 
 describe('@tsrx/rspack-plugin-solid js-loader', () => {
-	it('prepends a virtual css import when a style block exists', async () => {
+	it('appends a virtual css import after the module imports when a style block exists', async () => {
 		const id = '/virtual/App.tsrx';
-		const source = `export function App() @{ <>
+		const source = `import './reset.css';
+
+			export function App() @{ <>
 			<div>{'Hello world'}</div>
 
 			<style>
@@ -47,10 +49,12 @@ describe('@tsrx/rspack-plugin-solid js-loader', () => {
 
 		expect(err).toBeNull();
 		expect(output).toContain(`${id}?tsrx-css&lang.css`);
-		expect(map).toBeUndefined();
+		expect(output.indexOf('./reset.css')).toBeGreaterThan(-1);
+		expect(output.indexOf('./reset.css')).toBeLessThan(output.indexOf('tsrx-css'));
+		expect(map).toBeTruthy();
 	});
 
-	it('does not prepend a virtual css import when no style block exists', async () => {
+	it('does not append a virtual css import when no style block exists', async () => {
 		const id = '/virtual/App.tsrx';
 		const source = `export function App({ name }: { name: string }) @{ <>
 			<div>{name}</div>

--- a/packages/rspack-plugin-vue/src/css-loader.js
+++ b/packages/rspack-plugin-vue/src/css-loader.js
@@ -7,7 +7,7 @@ import { compile } from '@tsrx/vue';
 /**
  * Re-runs the `@tsrx/vue` compiler against the `.tsrx` source to extract the
  * scoped CSS emitted by its `<style>` block. Invoked when rspack resolves the
- * sibling `?tsrx-css&lang.css` import prepended by the JS loader.
+ * sibling `?tsrx-css&lang.css` import emitted by the JS loader.
  *
  * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode }>}
  * @param {string} source

--- a/packages/rspack-plugin-vue/src/js-loader.js
+++ b/packages/rspack-plugin-vue/src/js-loader.js
@@ -6,7 +6,7 @@ import { compile } from '@tsrx/vue';
 
 /**
  * Compiles `.tsrx` source to Vue-flavoured TSX and, when a `<style>` block is
- * present, prepends an `import` to the sibling virtual CSS module so rspack can
+ * present, appends an `import` of the sibling virtual CSS module so rspack can
  * include the styles in the asset graph.
  *
  * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode }>}
@@ -21,15 +21,16 @@ export default function jsLoader(source) {
 		const { code, map, css } = compile(source, resourcePath, this.getOptions?.());
 
 		let output = code;
-		/** @type {typeof map | null} */
-		let output_map = map;
 		if (css) {
+			// The import goes after the module's own imports so the stylesheets of
+			// imported themes are added to the asset graph first and a rule in the
+			// applying module wins at equal specificity. Nothing above it moves, so
+			// the compiler's source map still applies.
 			const cssImport = `${resourcePath}?tsrx-css&lang.css`;
-			output = `import ${JSON.stringify(cssImport)};\n${code}`;
-			output_map = null;
+			output = `${code}\nimport ${JSON.stringify(cssImport)};\n`;
 		}
 
-		callback(null, output, /** @type {any} */ (output_map ?? undefined));
+		callback(null, output, /** @type {any} */ (map ?? undefined));
 	} catch (/** @type {any} */ err) {
 		callback(err);
 	}

--- a/packages/rspack-plugin-vue/tests/basic.test.js
+++ b/packages/rspack-plugin-vue/tests/basic.test.js
@@ -36,9 +36,11 @@ function createLoaderContext(resourcePath, options = {}) {
 }
 
 describe('@tsrx/rspack-plugin-vue js-loader', () => {
-	it('prepends a virtual css import when a style block exists', async () => {
+	it('appends a virtual css import after the module imports when a style block exists', async () => {
 		const id = '/virtual/App.tsrx';
-		const source = `export function App() @{
+		const source = `import './reset.css';
+
+			export function App() @{
 			<>
 				<div>{'Hello world'}</div>
 
@@ -57,7 +59,9 @@ describe('@tsrx/rspack-plugin-vue js-loader', () => {
 		expect(err).toBeNull();
 		expect(output).toContain(`${id}?tsrx-css&lang.css`);
 		expect(output).toContain('defineVaporComponent');
-		expect(map).toBeUndefined();
+		expect(output.indexOf('./reset.css')).toBeGreaterThan(-1);
+		expect(output.indexOf('./reset.css')).toBeLessThan(output.indexOf('tsrx-css'));
+		expect(map).toBeTruthy();
 	});
 
 	it('returns compiled TSX and a sourcemap when no style block exists', async () => {

--- a/packages/turbopack-plugin-react/src/css-loader.js
+++ b/packages/turbopack-plugin-react/src/css-loader.js
@@ -13,7 +13,7 @@ import { compile } from '@tsrx/react';
 /**
  * Re-runs the `@tsrx/react` compiler against the `.tsrx` source to extract
  * the scoped CSS emitted by its `<style>` block. Invoked when Turbopack
- * resolves the sibling `?tsrx-css&lang.css` import prepended by the JS loader.
+ * resolves the sibling `?tsrx-css&lang.css` import emitted by the JS loader.
  *
  * @this {LoaderContext}
  * @param {string} source

--- a/packages/turbopack-plugin-react/src/loader.js
+++ b/packages/turbopack-plugin-react/src/loader.js
@@ -5,97 +5,18 @@ import { compile } from '@tsrx/react';
 const CSS_QUERY = '?tsrx-css&lang.css';
 
 /**
- * @param {string} source
- * @param {number} index
- * @returns {number}
- */
-function skip_whitespace_and_comments(source, index) {
-	while (index < source.length) {
-		const char = source[index];
-		if (char === ' ' || char === '\t' || char === '\n' || char === '\r') {
-			index++;
-			continue;
-		}
-		if (char === '/' && source[index + 1] === '/') {
-			index += 2;
-			while (index < source.length && source[index] !== '\n') {
-				index++;
-			}
-			continue;
-		}
-		if (char === '/' && source[index + 1] === '*') {
-			index += 2;
-			while (index < source.length && !(source[index] === '*' && source[index + 1] === '/')) {
-				index++;
-			}
-			index = Math.min(index + 2, source.length);
-			continue;
-		}
-		break;
-	}
-	return index;
-}
-
-/**
- * @param {string} source
- * @param {number} index
- * @returns {number}
- */
-function read_directive_statement(source, index) {
-	const quote = source[index];
-	if (quote !== '"' && quote !== "'") {
-		return -1;
-	}
-
-	let cursor = index + 1;
-	let value = '';
-	while (cursor < source.length) {
-		const char = source[cursor];
-		if (char === '\\') {
-			value += source.slice(cursor, cursor + 2);
-			cursor += 2;
-			continue;
-		}
-		if (char === quote) {
-			cursor++;
-			break;
-		}
-		value += char;
-		cursor++;
-	}
-
-	if (cursor > source.length || !value.startsWith('use ')) {
-		return -1;
-	}
-
-	cursor = skip_whitespace_and_comments(source, cursor);
-	if (source[cursor] === ';') {
-		cursor++;
-	}
-	return skip_whitespace_and_comments(source, cursor);
-}
-
-/**
+ * Appends an import of the sibling virtual CSS resource. It goes after the
+ * module's own imports so the stylesheets of imported themes are added to the
+ * graph first and a rule in the applying module wins at equal specificity.
+ * Top-level directives such as `'use client'` stay first, and nothing above
+ * the import moves, so the compiler's source map still applies.
+ *
  * @param {string} code
  * @param {string} resource_path
  * @returns {string}
  */
-function prepend_css_import(code, resource_path) {
-	const css_import = `import ${JSON.stringify(resource_path + CSS_QUERY)};\n`;
-	const initial_index = skip_whitespace_and_comments(code, 0);
-	let insertion_index = initial_index;
-	let scan_index = initial_index;
-
-	while (scan_index < code.length) {
-		const next_index = read_directive_statement(code, scan_index);
-		if (next_index === -1) {
-			break;
-		}
-		insertion_index = next_index;
-		scan_index = next_index;
-	}
-
-	return `${code.slice(0, insertion_index)}${css_import}${code.slice(insertion_index)}`;
+function append_css_import(code, resource_path) {
+	return `${code}\nimport ${JSON.stringify(resource_path + CSS_QUERY)};\n`;
 }
 
 /**
@@ -109,7 +30,7 @@ function prepend_css_import(code, resource_path) {
 /**
  * Compile `.tsrx` files to TSX for consumption by Turbopack's built-in
  * TypeScript/React pipeline. When a component-local `<style>` block is
- * present, prepend an import to a sibling virtual CSS resource that is handled
+ * present, append an import of a sibling virtual CSS resource that is handled
  * by the Turbopack config helper's query-targeted CSS rule.
  *
  * @this {LoaderContext}
@@ -121,10 +42,9 @@ export default function tsrx_react_turbopack_loader(source) {
 
 	try {
 		const { code, map, css } = compile(source, this.resourcePath, this.getOptions?.());
-		const output = css ? prepend_css_import(code, this.resourcePath) : code;
-		const output_map = css ? null : map;
+		const output = css ? append_css_import(code, this.resourcePath) : code;
 
-		callback(null, output, /** @type {any} */ (output_map ?? undefined));
+		callback(null, output, /** @type {any} */ (map ?? undefined));
 	} catch (/** @type {any} */ err) {
 		callback(err);
 	}

--- a/packages/turbopack-plugin-react/tests/basic.test.js
+++ b/packages/turbopack-plugin-react/tests/basic.test.js
@@ -118,7 +118,36 @@ describe('@tsrx/turbopack-plugin-react loader', () => {
 		expect(err).toBeNull();
 		expect(output).toContain('import "/virtual/App.tsrx?tsrx-css&lang.css";');
 		expect(output).toContain('export function App()');
-		expect(map).toBeUndefined();
+		expect(map).toBeTruthy();
+	});
+
+	it('places the injected CSS import after the module imports', async () => {
+		const { context, promise } = create_loader_context('/virtual/App.tsrx');
+
+		tsrx_react_turbopack_loader.call(
+			context,
+			`import './reset.css';
+
+			export function App() @{
+				<>
+				<div>{'Hello world'}</div>
+
+				<style>
+					div {
+						color: red;
+					}
+				</style>
+				</>
+			}`,
+		);
+
+		const { err, output } = await promise;
+
+		expect(err).toBeNull();
+		expect(output.indexOf('./reset.css')).toBeGreaterThan(-1);
+		expect(output.indexOf('./reset.css')).toBeLessThan(
+			output.indexOf('import "/virtual/App.tsrx?tsrx-css&lang.css";'),
+		);
 	});
 
 	it('keeps top-level directives ahead of injected CSS imports', async () => {


### PR DESCRIPTION
Follow-up to #63 and RFC tsrx-org/RFCs#1.

The docs promise that a theme's CSS comes before the CSS of the block that applies it, so the local rule wins at equal specificity. #63 made the four Vite plugins honor that across modules by moving the virtual CSS import after the module's JS imports. The Rspack, Turbopack, and Bun plugins still prepended it, so on those bundlers an imported theme's stylesheet was emitted after the applying module's stylesheet and the theme's rule won.

## Changes
- `@tsrx/rspack-plugin-{react,preact,solid,vue}`, `@tsrx/turbopack-plugin-react`, `@tsrx/bun-plugin-{react,preact,solid,vue}`: append the `?tsrx-css&lang.css` import after the compiled module instead of prepending it. Directives such as `'use client'` stay first without the Turbopack directive scanner, which is removed.
- Rspack and Turbopack loaders keep the compiler's source map when a module has styles. Nothing above the import moves, so the map still applies; previously it was dropped.
- Loader tests in all nine packages assert the CSS import lands after an existing import and the map survives.
- New Rspack 2 bundle test: a theme module plus an applying module, asserting the emitted `main.css` lists the theme's rule before the applier's. It fails on the old loader.
- Patch changeset for the nine packages.

## Validation
- `vitest run` for the nine plugin projects: 9 files, 70 tests passed.
- `tsgo --noEmit` for the nine packages, `prettier --check` on changed files, `pnpm changeset:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global CSS emission order for Rspack/Turbopack/Bun builds, which can alter styling where apps depended on the previous (incorrect) cascade; scope is limited to bundler plugins and is covered by new ordering tests.
> 
> **Overview**
> Aligns **Rspack**, **Turbopack**, and **Bun** `.tsrx` plugins with the documented theme/apply CSS ordering (already fixed for Vite in #63): the virtual `?tsrx-css&lang.css` import is **appended after** the compiled module’s JS imports instead of prepended, so imported theme stylesheets enter the graph before the applying module’s scoped CSS and **local rules win at equal specificity**.
> 
> **Rspack** and **Turbopack** JS loaders now **preserve the compiler source map** when a `<style>` block exists (they no longer discard the map because nothing is injected above the compiled code). **Turbopack** drops the directive-scanning prepend helper in favor of a simple trailing import; `'use client'` and similar directives remain first because they stay in the compiled output.
> 
> Tests across all nine plugin packages assert import order (and maps where relevant). **Rspack React** adds an end-to-end bundle check that `main.css` lists theme rules before applier rules. A patch **changeset** covers the nine affected packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc9cfcf2f2cb9cdb7be54a8c6250c4ed8f7b511a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->