### PR TITLE
fix(tsrx): recover an unclosed <style> in loose mode instead of failing the file

### DIFF
--- a/.changeset/unclosed-style-loose-recovery.md
+++ b/.changeset/unclosed-style-loose-recovery.md
@@ -1,0 +1,6 @@
+---
+'@tsrx/core': patch
+'@tsrx/language-server': patch
+---
+
+Recover an unclosed `<style>` or `<script>` in loose (editor) mode instead of failing the whole file. Inside a template the body runs up to the next tag start, so partial CSS reaches the loose CSS parser, which no longer throws on it, and the siblings after it keep their token mappings. Closing-tag auto-insert now keys off the typed `>` itself, so it works for `<style apply={…}>` without the fatal-compile fallback.

--- a/packages/language-server/src/autoInsertPlugin.js
+++ b/packages/language-server/src/autoInsertPlugin.js
@@ -71,9 +71,16 @@ export function createAutoInsertPlugin() {
 						return null;
 					}
 
-					// Map position back to source
+					// Map position back to source. The selection sits right after the typed
+					// `>`, and Volar maps it through completion-enabled mappings only, which
+					// the `>` token mapping is. `lastChange.rangeOffset` is instead mapped
+					// through the first mapping covering it, which for a style block can be
+					// the verify-only element mapping whose generated text differs from the
+					// source (`<style apply={…}>` prints as `<style data-tsrx-apply={…}>`),
+					// landing the change offset off the `>` token. Key the lookup on the
+					// selection.
 					const offset = document.offsetAt(position);
-					const mapping = virtualCode.findMappingByGeneratedRange(lastChange.rangeOffset, offset);
+					const mapping = virtualCode.findMappingByGeneratedRange(offset - 1, offset);
 
 					/** @type {number} */
 					let sourceOffset;
@@ -87,11 +94,11 @@ export function createAutoInsertPlugin() {
 						virtualCode.generatedCode === virtualCode.originalCode
 					) {
 						// Fatal-compile fallback: the raw source is served as the generated code under a
-						// single whole-file mapping, so offsets coincide. This is the normal state right
-						// after typing `<style>` — an unclosed style block is a fatal parse error (the
-						// CSS parser sees the rest of the file) — and it is exactly when the closing tag
+						// single whole-file mapping, so offsets coincide. Loose-mode recovery keeps token
+						// mappings for in-progress markup (an unclosed `<style>` included), but a file
+						// can still fail to parse mid-edit, and that is often exactly when a closing tag
 						// needs inserting, so keep going without token mappings.
-						sourceOffset = lastChange.rangeOffset;
+						sourceOffset = offset - 1;
 						isFallback = true;
 					} else {
 						return null;

--- a/packages/language-server/tests/autoInsertPlugin.test.js
+++ b/packages/language-server/tests/autoInsertPlugin.test.js
@@ -24,6 +24,119 @@ async function auto_insert_after_gt(before, after = '') {
 	});
 }
 
+describe('auto-insert plugin — element tags', () => {
+	it('closes <div> typed as the only template output', async () => {
+		const snippet = await auto_insert_after_gt('export function App() @{\n\t<div', '\n}');
+		expect(snippet).toBe('$0</div>');
+	});
+
+	it('closes <div> typed before existing siblings', async () => {
+		const snippet = await auto_insert_after_gt(
+			'export function App() @{\n\t<>\n\t\t<div',
+			'\n\t\t<span />\n\t</>\n}',
+		);
+		expect(snippet).toBe('$0</div>');
+	});
+
+	it('closes a tag nested inside an element', async () => {
+		const snippet = await auto_insert_after_gt(
+			'export function App() @{\n\t<section>\n\t\t<p',
+			'\n\t</section>\n}',
+		);
+		expect(snippet).toBe('$0</p>');
+	});
+
+	it('closes a tag with attributes', async () => {
+		const snippet = await auto_insert_after_gt(
+			'export function App() @{\n\t<>\n\t\t<div class="card" id="main"',
+			'\n\t</>\n}',
+		);
+		expect(snippet).toBe('$0</div>');
+	});
+
+	it('closes a tag whose attribute expression contains `>`', async () => {
+		const snippet = await auto_insert_after_gt(
+			'export function App(props) @{\n\t<>\n\t\t<div hidden={props.count > 1}',
+			'\n\t</>\n}',
+		);
+		expect(snippet).toBe('$0</div>');
+	});
+
+	it('closes a component tag', async () => {
+		const snippet = await auto_insert_after_gt(
+			'function Card() @{ <div /> }\nexport function App() @{\n\t<>\n\t\t<Card',
+			'\n\t</>\n}',
+		);
+		expect(snippet).toBe('$0</Card>');
+	});
+
+	it('closes a member-expression component tag', async () => {
+		const snippet = await auto_insert_after_gt(
+			'const UI = { Item() @{ <div /> } };\nexport function App() @{\n\t<>\n\t\t<UI.Item',
+			'\n\t</>\n}',
+		);
+		expect(snippet).toBe('$0</UI.Item>');
+	});
+
+	it('closes a tag inside a control-flow body', async () => {
+		const snippet = await auto_insert_after_gt(
+			'export function App(props) @{\n\t<>\n\t\t@if (props.open) {\n\t\t\t<div',
+			'\n\t\t}\n\t</>\n}',
+		);
+		expect(snippet).toBe('$0</div>');
+	});
+
+	it('closes a tag inside a plain TSX return', async () => {
+		const snippet = await auto_insert_after_gt('export function App() {\n\treturn <div', ';\n}');
+		expect(snippet).toBe('$0</div>');
+	});
+
+	it('closes a tag typed at the end of the file', async () => {
+		const snippet = await auto_insert_after_gt('export function App() @{\n\t<>\n\t\t<div');
+		expect(snippet).toBe('$0</div>');
+	});
+
+	it('does not close a void element', async () => {
+		const snippet = await auto_insert_after_gt(
+			'export function App() @{\n\t<>\n\t\t<input',
+			'\n\t</>\n}',
+		);
+		expect(snippet).toBeFalsy();
+	});
+
+	it('does not close a self-closed tag', async () => {
+		const snippet = await auto_insert_after_gt(
+			'export function App() @{\n\t<>\n\t\t<div /',
+			'\n\t</>\n}',
+		);
+		expect(snippet).toBeFalsy();
+	});
+
+	it('does not close a tag that already has its closing tag', async () => {
+		const snippet = await auto_insert_after_gt(
+			'export function App() @{\n\t<>\n\t\t<div',
+			'</div>\n\t</>\n}',
+		);
+		expect(snippet).toBeFalsy();
+	});
+
+	it('does not close a tag when the `>` is typed inside an attribute expression', async () => {
+		const snippet = await auto_insert_after_gt(
+			'export function App(props) @{\n\t<>\n\t\t<div hidden={props.count ',
+			' 1}></div>\n\t</>\n}',
+		);
+		expect(snippet).toBeFalsy();
+	});
+
+	it('does not close on a `>` typed as a comparison in script code', async () => {
+		const snippet = await auto_insert_after_gt(
+			'export function App(props) @{\n\tconst big = props.count ',
+			' 1;\n\t<div />\n}',
+		);
+		expect(snippet).toBeFalsy();
+	});
+});
+
 describe('auto-insert plugin — <style> tags', () => {
 	it('closes a plain element tag', async () => {
 		const snippet = await auto_insert_after_gt(

--- a/packages/language-server/tests/autoInsertPlugin.test.js
+++ b/packages/language-server/tests/autoInsertPlugin.test.js
@@ -41,6 +41,14 @@ describe('auto-insert plugin — <style> tags', () => {
 		expect(snippet).toBe('$0</style>');
 	});
 
+	it('closes a <style> tag that already has CSS typed after it', async () => {
+		const snippet = await auto_insert_after_gt(
+			'export function App() @{\n\t<>\n\t\t<div />\n\t\t<style',
+			'\n\t\t\t.a { color: red; }\n\t</>\n}',
+		);
+		expect(snippet).toBe('$0</style>');
+	});
+
 	it('closes <style apply={…}> when the expression contains `>`', async () => {
 		const snippet = await auto_insert_after_gt(
 			'const a = <style>.a { color: red; }</style>;\nconst b = <style>.b { color: red; }</style>;\nexport function App(props) @{\n\t<>\n\t\t<div />\n\t\t<style apply={props.x > 1 ? a : b}',

--- a/packages/tsrx/src/parse/style.js
+++ b/packages/tsrx/src/parse/style.js
@@ -163,13 +163,13 @@ function read_body(parser) {
 	const children = [];
 
 	while (parser.index < parser.template.length) {
-		allow_comment_or_whitespace(parser);
-
-		if (parser.index >= parser.template.length) {
-			break;
-		}
-
 		try {
+			allow_comment_or_whitespace(parser);
+
+			if (parser.index >= parser.template.length) {
+				break;
+			}
+
 			if (parser.match('@')) {
 				children.push(read_at_rule(parser));
 			} else {
@@ -179,9 +179,9 @@ function read_body(parser) {
 			if (!parser.loose) {
 				throw error;
 			}
-			// Partial CSS while typing (`.foo {`), or whatever follows an unclosed
-			// module-scope `<style>`, must not take the whole file down in loose
-			// mode: keep the rules parsed so far and drop the rest.
+			// Partial CSS while typing (`.foo {`, `/*`), or whatever follows an
+			// unclosed module-scope `<style>`, must not take the whole file down in
+			// loose mode: keep the rules parsed so far and drop the rest.
 			break;
 		}
 	}

--- a/packages/tsrx/src/parse/style.js
+++ b/packages/tsrx/src/parse/style.js
@@ -165,10 +165,24 @@ function read_body(parser) {
 	while (parser.index < parser.template.length) {
 		allow_comment_or_whitespace(parser);
 
-		if (parser.match('@')) {
-			children.push(read_at_rule(parser));
-		} else {
-			children.push(read_rule(parser));
+		if (parser.index >= parser.template.length) {
+			break;
+		}
+
+		try {
+			if (parser.match('@')) {
+				children.push(read_at_rule(parser));
+			} else {
+				children.push(read_rule(parser));
+			}
+		} catch (error) {
+			if (!parser.loose) {
+				throw error;
+			}
+			// Partial CSS while typing (`.foo {`), or whatever follows an unclosed
+			// module-scope `<style>`, must not take the whole file down in loose
+			// mode: keep the rules parsed so far and drop the rest.
+			break;
 		}
 	}
 

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -7,7 +7,11 @@
 import * as acorn from 'acorn';
 import { isWhitespaceTextNode, BINDING_TYPES, DestructuringErrors } from './parse/index.js';
 import { parse_style } from './parse/style.js';
-import { regex_newline_characters, regex_not_whitespace } from './utils/patterns.js';
+import {
+	regex_newline_characters,
+	regex_not_whitespace,
+	regex_raw_text_next_tag_start,
+} from './utils/patterns.js';
 import { error } from './errors.js';
 import { DIAGNOSTIC_CODES } from './diagnostics.js';
 import { TSRX_RETURN_STATEMENT_ERROR } from './analyze/validation.js';
@@ -2245,6 +2249,14 @@ export function TSRXPlugin(config) {
 			 * synthesize the closing element, and restore the tokenizer state past it.
 			 * Shared by `<style>` and `<script>`.
 			 *
+			 * Without a closing tag the element is unclosed and the rest of the input
+			 * is its body, except that in loose mode inside a template the body stops
+			 * at the next tag start (`<x`, `</x>`, `</>`): while `<style>` is being
+			 * typed, partial CSS reaches the loose CSS parser, and the tokenizer
+			 * resumes at the following sibling or closing tag so the rest of the file
+			 * keeps its mappings. Outside a template only JS follows, with no marker to
+			 * resume at, so the body runs to the end of the input.
+			 *
 			 * @param {ESTreeJSX.TSRXJSXOpeningElement & AST.NodeWithLocation} open
 			 * @param {AST.JSXStyleElement | AST.TSRXJSXElement} node
 			 * @param {'style' | 'script'} tagName
@@ -2257,17 +2269,42 @@ export function TSRXPlugin(config) {
 				const closeTag = `</${tagName}>`;
 				const contentStart = open.end;
 				const input = this.input.slice(contentStart);
-				const relativeCloseStart = input.indexOf(closeTag);
-				const content = relativeCloseStart === -1 ? input : input.slice(0, relativeCloseStart);
+				const parent = this.#path.at(-2);
+				const insideTemplate = this.#isNativeTemplateNode(parent);
+				let relativeCloseStart = input.indexOf(closeTag);
+				const unclosed = relativeCloseStart === -1;
 
+				if (unclosed) {
+					this.#report_broken_markup_error(
+						open.end,
+						`Unclosed tag '<${tagName}>'. Expected '${closeTag}' before end of template.`,
+					);
+					node.unclosed = true;
+					relativeCloseStart = input.length;
+					if (!this.#loose) {
+						const newLines = input.match(regex_newline_characters)?.length;
+						if (newLines) {
+							this.curLine = open.loc.end.line + newLines;
+							this.lineStart = contentStart + input.lastIndexOf('\n') + 1;
+						}
+						return input;
+					}
+					if (insideTemplate) {
+						const nextTagStart = input.search(regex_raw_text_next_tag_start);
+						if (nextTagStart !== -1) relativeCloseStart = nextTagStart;
+					}
+				}
+
+				const content = input.slice(0, relativeCloseStart);
 				const newLines = content.match(regex_newline_characters)?.length;
 				if (newLines) {
 					this.curLine = open.loc.end.line + newLines;
 					this.lineStart = contentStart + content.lastIndexOf('\n') + 1;
 				}
 
-				if (relativeCloseStart !== -1) {
-					const closingStart = contentStart + content.length;
+				const closingStart = contentStart + content.length;
+				let closingEnd = closingStart;
+				if (!unclosed) {
 					const closingLineInfo = get_line_info(this, closingStart);
 					const closingStartLoc = new acorn.Position(closingLineInfo.line, closingLineInfo.column);
 					const nameStart = closingStart + 2;
@@ -2287,7 +2324,7 @@ export function TSRXPlugin(config) {
 						nameEnd,
 						new acorn.Position(nameEndInfo.line, nameEndInfo.column),
 					);
-					const closingEnd = closingStart + closeTag.length;
+					closingEnd = closingStart + closeTag.length;
 					const closingEndInfo = get_line_info(this, closingEnd);
 					const closingElement =
 						/** @type {ESTreeJSX.TSRXJSXClosingElement & AST.NodeWithLocation} */ (
@@ -2301,49 +2338,44 @@ export function TSRXPlugin(config) {
 						new acorn.Position(closingEndInfo.line, closingEndInfo.column),
 					);
 					node.closingElement = closingElement;
-					const parent = this.#path.at(-2);
-					const insideTemplate = this.#isNativeTemplateNode(parent);
-					if (this.curContext() === tstc.tc_expr && !insideTemplate) {
+				}
+
+				if (this.curContext() === tstc.tc_expr && !insideTemplate) {
+					this.context.pop();
+				}
+				this.exprAllowed = false;
+				this.pos = closingEnd;
+				const closingEndInfo = get_line_info(this, closingEnd);
+				this.curLine = closingEndInfo.line;
+				this.lineStart = closingEnd - closingEndInfo.column;
+				if (insideTemplate && relativeCloseStart === 0) {
+					// Acorn has already tokenized the adjacent tag start (this element's
+					// closing tag, or, when unclosed, the next sibling or parent close);
+					// the element resumes there manually, so drop the stale tag context.
+					if (this.curContext() === tstc.tc_oTag) {
 						this.context.pop();
 					}
-					this.exprAllowed = false;
-					this.pos = closingEnd;
-					this.curLine = closingEndInfo.line;
-					this.lineStart = closingEnd - closingEndInfo.column;
-					if (insideTemplate && relativeCloseStart === 0) {
-						// Acorn has already tokenized the adjacent closing tag; TSRX
-						// synthesizes that close manually, so drop the stale tag context.
-						if (this.curContext() === tstc.tc_oTag) {
-							this.context.pop();
-						}
-						if (this.curContext() === tstc.tc_expr) {
-							this.context.pop();
-						}
+					if (this.curContext() === tstc.tc_expr) {
+						this.context.pop();
 					}
-					if (!insideTemplate && this.#path.at(-1) === node) {
-						// Outside a template (a `@{ … }` body, a `@case` body, a statement),
-						// the element must leave the tokenizer context exactly where it
-						// began — like a balanced element does after its closing tag — so
-						// the following `}`, `@case`, or sibling tokenizes as code, not as
-						// JSX text of a children context this element's `<` opened.
-						if (contextDepth !== undefined && this.context.length > contextDepth) {
-							this.context.length = contextDepth;
-						}
-						this.#path.pop();
-						try {
-							this.next();
-						} finally {
-							this.#path.push(node);
-						}
-					} else {
+				}
+				if (!insideTemplate && this.#path.at(-1) === node) {
+					// Outside a template (a `@{ … }` body, a `@case` body, a statement),
+					// the element must leave the tokenizer context exactly where it
+					// began — like a balanced element does after its closing tag — so
+					// the following `}`, `@case`, or sibling tokenizes as code, not as
+					// JSX text of a children context this element's `<` opened.
+					if (contextDepth !== undefined && this.context.length > contextDepth) {
+						this.context.length = contextDepth;
+					}
+					this.#path.pop();
+					try {
 						this.next();
+					} finally {
+						this.#path.push(node);
 					}
 				} else {
-					this.#report_broken_markup_error(
-						open.end,
-						`Unclosed tag '<${tagName}>'. Expected '${closeTag}' before end of template.`,
-					);
-					node.unclosed = true;
+					this.next();
 				}
 
 				return content;
@@ -4887,11 +4919,30 @@ export function TSRXPlugin(config) {
 					}
 				}
 
-				if ((is_style || is_script) && /** @type {AST.JSXStyleElement} */ (node).closingElement) {
-					const closing = /** @type {ESTreeJSX.JSXClosingElement & AST.NodeWithLocation} */ (
-						/** @type {AST.JSXStyleElement} */ (node).closingElement
-					);
-					return this.finishNodeAt(node, node.type, closing.end, closing.loc.end);
+				if (is_style || is_script) {
+					const raw_text = /** @type {AST.JSXStyleElement} */ (node);
+					if (raw_text.closingElement) {
+						const closing = /** @type {ESTreeJSX.JSXClosingElement & AST.NodeWithLocation} */ (
+							raw_text.closingElement
+						);
+						return this.finishNodeAt(node, node.type, closing.end, closing.loc.end);
+					}
+					if (raw_text.unclosed && this.#loose) {
+						// Loose recovery captured a body without a closing tag: the element
+						// ends where its body ends, not at whatever token was read next.
+						const script = /** @type {AST.TSRXJSXElement} */ (/** @type {unknown} */ (node));
+						const body = (is_style ? raw_text.css : script.content) ?? '';
+						const body_end =
+							/** @type {ESTreeJSX.TSRXJSXOpeningElement & AST.NodeWithLocation} */ (open).end +
+							body.length;
+						const body_end_info = get_line_info(this, body_end);
+						return this.finishNodeAt(
+							node,
+							node.type,
+							body_end,
+							new acorn.Position(body_end_info.line, body_end_info.column),
+						);
+					}
 				}
 
 				return this.finishNode(node, node.type);

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -7,11 +7,7 @@
 import * as acorn from 'acorn';
 import { isWhitespaceTextNode, BINDING_TYPES, DestructuringErrors } from './parse/index.js';
 import { parse_style } from './parse/style.js';
-import {
-	regex_newline_characters,
-	regex_not_whitespace,
-	regex_raw_text_next_tag_start,
-} from './utils/patterns.js';
+import { regex_newline_characters, regex_not_whitespace } from './utils/patterns.js';
 import { error } from './errors.js';
 import { DIAGNOSTIC_CODES } from './diagnostics.js';
 import { TSRX_RETURN_STATEMENT_ERROR } from './analyze/validation.js';
@@ -2290,8 +2286,12 @@ export function TSRXPlugin(config) {
 						return input;
 					}
 					if (insideTemplate) {
-						const nextTagStart = input.search(regex_raw_text_next_tag_start);
-						if (nextTagStart !== -1) relativeCloseStart = nextTagStart;
+						// A `<` inside CSS text (`content: "<"`, `<!--`) is not a tag start.
+						let lt = input.indexOf('<');
+						while (lt !== -1 && !can_start_tag_after_lt(input, lt)) {
+							lt = input.indexOf('<', lt + 1);
+						}
+						if (lt !== -1) relativeCloseStart = lt;
 					}
 				}
 

--- a/packages/tsrx/src/transform/jsx/style-scopes.js
+++ b/packages/tsrx/src/transform/jsx/style-scopes.js
@@ -822,9 +822,21 @@ export function type_only_style(block) {
 			value: { ...attr.value, expression: value },
 		};
 	});
+	// An unclosed `<style>` has no closing element. The stand-in still has to
+	// be valid TSX or the virtual file loses every mapping after the tag.
+	// Self-closing apply tags already print as `<style … />` — leave those.
+	const closingElement =
+		block.closingElement ??
+		(block.openingElement.selfClosing
+			? null
+			: b.jsx_closing_element(
+					clone_ast_node(block.openingElement.name),
+					has_location(block.openingElement) ? block.openingElement : undefined,
+				));
 	return {
 		...block,
 		children: [],
 		openingElement: { ...block.openingElement, attributes },
+		closingElement,
 	};
 }

--- a/packages/tsrx/src/transform/segments.js
+++ b/packages/tsrx/src/transform/segments.js
@@ -158,10 +158,15 @@ function visit_source_ast(ast, src_line_offsets, { regions, css_element_info, sc
 				).loc;
 				const cssStart = loc_to_offset(openLoc.end.line, openLoc.end.column, src_line_offsets);
 
-				const closeLoc = /** @type {ESTreeJSX.JSXClosingElement & AST.NodeWithLocation} */ (
-					node.closingElement
-				).loc;
-				const cssEnd = loc_to_offset(closeLoc.start.line, closeLoc.start.column, src_line_offsets);
+				const closeLoc =
+					/** @type {(ESTreeJSX.JSXClosingElement & AST.NodeWithLocation) | null} */ (
+						node.closingElement
+					)?.loc;
+				// An unclosed block recovered in loose mode has no closing tag; its
+				// body ends where the captured CSS ends.
+				const cssEnd = closeLoc
+					? loc_to_offset(closeLoc.start.line, closeLoc.start.column, src_line_offsets)
+					: cssStart + node.css.length;
 
 				regions.push({
 					start: cssStart,

--- a/packages/tsrx/src/utils/patterns.js
+++ b/packages/tsrx/src/utils/patterns.js
@@ -14,6 +14,8 @@ export const regex_only_whitespaces = /^[ \t\n\r\f]+$/;
 
 export const regex_newline_characters = /\n/g;
 export const regex_not_newline_characters = /[^\n]/g;
+/** The next `<` that opens a tag (`<x`, `</x>`, `</>`), skipping a `<` inside CSS text such as `content: "<"` or `<!--`. */
+export const regex_raw_text_next_tag_start = /<(?=[A-Za-z/>])/;
 
 export const regex_is_valid_identifier = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
 // used in replace all to remove all invalid chars from a literal identifier

--- a/packages/tsrx/src/utils/patterns.js
+++ b/packages/tsrx/src/utils/patterns.js
@@ -14,8 +14,6 @@ export const regex_only_whitespaces = /^[ \t\n\r\f]+$/;
 
 export const regex_newline_characters = /\n/g;
 export const regex_not_newline_characters = /[^\n]/g;
-/** The next `<` that opens a tag (`<x`, `</x>`, `</>`), skipping a `<` inside CSS text such as `content: "<"` or `<!--`. */
-export const regex_raw_text_next_tag_start = /<(?=[A-Za-z/>])/;
 
 export const regex_is_valid_identifier = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
 // used in replace all to remove all invalid chars from a literal identifier

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -83,6 +83,89 @@ export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, na
 			expect(code).toContain('void <style data-tsrx-apply={theme.$class} />');
 			expect(code).toContain('void <style></style>');
 		});
+
+		it('recovers an unclosed <style> in loose type-only compile without losing mappings', function () {
+			// While typing `<style>` there is no `</style>` yet. The raw-text path
+			// used to feed the rest of the file to the CSS parser, which threw
+			// `Expected identifier` and collapsed every token mapping to a
+			// whole-file 1:1 fallback. An unclosed `<span>` already recovered.
+			const source = `export function App() @{
+	<>
+		<style>
+		<div />
+	</>
+}`;
+			const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+
+			expect(
+				result.errors.filter(function (error) {
+					return error.type === 'fatal';
+				}),
+			).toEqual([]);
+			expect(
+				result.errors
+					.map(function (error) {
+						return error.message;
+					})
+					.join('\n'),
+			).not.toContain('Expected identifier');
+			expect(result.mappings.length).toBeGreaterThan(1);
+
+			const whole_file = result.mappings.find(function (mapping) {
+				return mapping.sourceOffsets[0] === 0 && mapping.lengths[0] === source.length;
+			});
+			expect(whole_file).toBeUndefined();
+
+			/** @param {string} token */
+			function is_mapped(token) {
+				const offset = source.indexOf(token);
+				return result.mappings.some(function (mapping) {
+					const start = mapping.sourceOffsets[0];
+					return offset >= start && offset < start + mapping.lengths[0];
+				});
+			}
+
+			expect(is_mapped('App')).toBe(true);
+			expect(is_mapped('div')).toBe(true);
+			expect(result.code).toContain('<style></style>');
+			expect(virtual_parse_diagnostics(result.code)).toEqual([]);
+		});
+
+		it('keeps partial CSS after an unclosed <style> out of the template in loose type-only compile', function () {
+			// Without auto-insert the CSS gets typed before the closing tag exists.
+			// The body up to the next tag start is the style's CSS, so it never
+			// tokenizes as JSX, and the sibling after it keeps its mapping.
+			const source = `export function App() @{
+	<>
+		<style>
+			.foo { color: red; }
+			.bar {
+		<div />
+	</>
+}`;
+			const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+
+			expect(
+				result.errors.filter(function (error) {
+					return error.type === 'fatal';
+				}),
+			).toEqual([]);
+
+			/** @param {string} token */
+			function is_mapped(token) {
+				const offset = source.indexOf(token);
+				return result.mappings.some(function (mapping) {
+					const start = mapping.sourceOffsets[0];
+					return offset >= start && offset < start + mapping.lengths[0];
+				});
+			}
+
+			expect(is_mapped('App')).toBe(true);
+			expect(is_mapped('div')).toBe(true);
+			expect(result.code).not.toContain('.foo');
+			expect(result.code).toContain('<style></style>');
+			expect(virtual_parse_diagnostics(result.code)).toEqual([]);
+		});
 	});
 
 	describe(`[${name}] compile diagnostics`, () => {

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -1621,6 +1621,256 @@ abc
 		expect(node_children(returned.children[0]).map((child) => child.type)).toEqual(['StyleSheet']);
 	});
 
+	it('recovers an unclosed style in loose mode and keeps later siblings', function () {
+		/** @type {CompileError[]} */
+		const errors = [];
+		const ast = parseModule(
+			`export function App() @{
+				<>
+					<style>
+					<div />
+				</>
+			}`,
+			'App.tsrx',
+			{ loose: true, collect: true, errors },
+		);
+
+		assert_type(ast, 'Program');
+		expect(
+			errors
+				.map(function (error) {
+					return error.message;
+				})
+				.join('\n'),
+		).not.toContain('Expected identifier');
+
+		const fragment = find_first(ast, function (node) {
+			return node.type === 'JSXFragment';
+		});
+		assert_type(fragment, 'JSXFragment');
+		expect(
+			fragment.children.map(function (child) {
+				return child.type;
+			}),
+		).toEqual(['JSXStyleElement', 'JSXElement']);
+		const style = child(fragment, 0, 'JSXStyleElement');
+		expect(style.css?.trim()).toBe('');
+		expect(style.unclosed).toBe(true);
+		expect(style.closingElement).toBeNull();
+		expect(openingName(child(fragment, 1, 'JSXElement')).name).toBe('div');
+	});
+
+	it('captures partial CSS after an unclosed style up to the next sibling', function () {
+		const source = `export function App() @{
+	<>
+		<style>
+			.foo { color: red; }
+			.bar {
+		<div />
+	</>
+}`;
+		/** @type {CompileError[]} */
+		const errors = [];
+		const ast = parseModule(source, 'App.tsrx', { loose: true, collect: true, errors });
+
+		assert_type(ast, 'Program');
+		expect(errors).toEqual([]);
+
+		const fragment = find_first(ast, function (node) {
+			return node.type === 'JSXFragment';
+		});
+		assert_type(fragment, 'JSXFragment');
+		expect(
+			fragment.children.map(function (child) {
+				return child.type;
+			}),
+		).toEqual(['JSXStyleElement', 'JSXElement']);
+
+		const style = child(fragment, 0, 'JSXStyleElement');
+		expect(style.unclosed).toBe(true);
+		expect(style.css).toBe('\n\t\t\t.foo { color: red; }\n\t\t\t.bar {\n\t\t');
+		expect(style.end).toBe(source.indexOf('<div />'));
+		expect(style.loc?.end.line).toBe(6);
+		expect(style.loc?.end.column).toBe(2);
+		const sheet = /** @type {{ type: string; children: Array<{ type: string }> }} */ (
+			style.children[0]
+		);
+		expect(sheet.type).toBe('StyleSheet');
+		expect(sheet.children.map((rule) => rule.type)).toEqual(['Rule']);
+
+		const div = child(fragment, 1, 'JSXElement');
+		expect(openingName(div).name).toBe('div');
+		expect(div.loc?.start.line).toBe(6);
+		expect(div.loc?.start.column).toBe(2);
+	});
+
+	it('captures the rest of the file after an unclosed module-scope style', function () {
+		const source = `const theme = <style>
+	.card { color: red; }
+export function App() @{ <div /> }`;
+		/** @type {CompileError[]} */
+		const errors = [];
+		const ast = parseModule(source, 'App.tsrx', { loose: true, collect: true, errors });
+
+		assert_type(ast, 'Program');
+		expect(errors).toEqual([]);
+		expect(ast.body.map((statement) => statement.type)).toEqual(['VariableDeclaration']);
+
+		const style = find_first(ast, function (node) {
+			return node.type === 'JSXStyleElement';
+		});
+		assert_type(style, 'JSXStyleElement');
+		expect(style.unclosed).toBe(true);
+		expect(style.css).toBe(source.slice(source.indexOf('>') + 1));
+		expect(style.end).toBe(source.length);
+	});
+
+	it('recovers an unclosed script in loose mode and keeps later siblings', function () {
+		const source = `export function App() @{
+	<>
+		<script>
+			console.log(1);
+		<div />
+	</>
+}`;
+		/** @type {CompileError[]} */
+		const errors = [];
+		const ast = parseModule(source, 'App.tsrx', { loose: true, collect: true, errors });
+
+		assert_type(ast, 'Program');
+		expect(errors).toEqual([]);
+
+		const fragment = find_first(ast, function (node) {
+			return node.type === 'JSXFragment';
+		});
+		assert_type(fragment, 'JSXFragment');
+		expect(
+			fragment.children.map(function (child) {
+				return child.type;
+			}),
+		).toEqual(['JSXElement', 'JSXElement']);
+
+		const script = child(fragment, 0, 'JSXElement');
+		expect(openingName(script).name).toBe('script');
+		expect(script.unclosed).toBe(true);
+		expect(script.content).toBe('\n\t\t\tconsole.log(1);\n\t\t');
+		expect(script.end).toBe(source.indexOf('<div />'));
+		expect(openingName(child(fragment, 1, 'JSXElement')).name).toBe('div');
+	});
+
+	it('keeps an unclosed style inside an element so later siblings stay JSX children', function () {
+		/** @type {CompileError[]} */
+		const errors = [];
+		const ast = parseModule(
+			`export function App() @{
+				<section>
+					<style>
+					<span />
+				</section>
+			}`,
+			'App.tsrx',
+			{ loose: true, collect: true, errors },
+		);
+
+		assert_type(ast, 'Program');
+		expect(
+			errors
+				.map(function (error) {
+					return error.message;
+				})
+				.join('\n'),
+		).not.toContain('Expected identifier');
+
+		const section = find_first(ast, function (node) {
+			return (
+				node.type === 'JSXElement' &&
+				node.openingElement?.name?.type === 'JSXIdentifier' &&
+				node.openingElement.name.name === 'section'
+			);
+		});
+		assert_type(section, 'JSXElement');
+		expect(
+			section.children.map(function (child) {
+				return child.type;
+			}),
+		).toEqual(['JSXStyleElement', 'JSXElement']);
+		expect(child(section, 0, 'JSXStyleElement').unclosed).toBe(true);
+		expect(openingName(child(section, 1, 'JSXElement')).name).toBe('span');
+		expect(section.unclosed).toBeFalsy();
+	});
+
+	it('keeps same-line siblings after an unclosed style on the opening-tag line', function () {
+		const source = `export function App() @{ <><style><span /></>
+}`;
+		/** @type {CompileError[]} */
+		const errors = [];
+		const ast = parseModule(source, 'App.tsrx', { loose: true, collect: true, errors });
+
+		assert_type(ast, 'Program');
+		expect(
+			errors
+				.map(function (error) {
+					return error.message;
+				})
+				.join('\n'),
+		).not.toContain('Expected identifier');
+
+		const fragment = find_first(ast, function (node) {
+			return node.type === 'JSXFragment';
+		});
+		assert_type(fragment, 'JSXFragment');
+		const style = child(fragment, 0, 'JSXStyleElement');
+		const span = child(fragment, 1, 'JSXElement');
+		expect(style.unclosed).toBe(true);
+		expect(openingName(span).name).toBe('span');
+		expect(span.loc?.start.line).toBe(style.loc?.end.line);
+		expect(span.loc?.start.column).toBeGreaterThanOrEqual(0);
+		expect(span.loc?.start.column).toBe(style.loc?.end.column);
+	});
+
+	it('recovers when an unclosed style is immediately followed by a parent close', function () {
+		// `<style>` then `</div>` with no body: expect('>') has already
+		// tokenized the parent `</` and pushed its tag contexts. Recovery
+		// must not pop those frames (that used to read `/` as a regexp).
+		const source = 'export function App() @{ <div><style></div> }';
+		/** @type {CompileError[]} */
+		const errors = [];
+		const ast = parseModule(source, 'App.tsrx', { loose: true, collect: true, errors });
+
+		assert_type(ast, 'Program');
+		expect(
+			errors
+				.map(function (error) {
+					return error.message;
+				})
+				.join('\n'),
+		).not.toContain('Expected identifier');
+		expect(
+			errors
+				.map(function (error) {
+					return error.message;
+				})
+				.join('\n'),
+		).not.toContain('Unterminated regular expression');
+
+		const div = find_first(ast, function (node) {
+			return (
+				node.type === 'JSXElement' &&
+				node.openingElement?.name?.type === 'JSXIdentifier' &&
+				node.openingElement.name.name === 'div'
+			);
+		});
+		assert_type(div, 'JSXElement');
+		expect(
+			div.children.map(function (child) {
+				return child.type;
+			}),
+		).toEqual(['JSXStyleElement']);
+		expect(child(div, 0, 'JSXStyleElement').unclosed).toBe(true);
+		expect(div.unclosed).toBeFalsy();
+		expect(div.closingElement).toBeTruthy();
+	});
+
 	it('parses module-scope style expressions followed by JavaScript statements', () => {
 		const source = `const styles = <style>
 			.card {

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -1704,6 +1704,67 @@ abc
 		expect(div.loc?.start.column).toBe(2);
 	});
 
+	it('stops the unclosed style body at a dynamic tag start', function () {
+		const source = `const Tag = 'b';
+export function App() @{
+	<>
+		<style>
+			.foo { color: red; }
+		<{Tag} />
+	</>
+}`;
+		/** @type {CompileError[]} */
+		const errors = [];
+		const ast = parseModule(source, 'App.tsrx', { loose: true, collect: true, errors });
+
+		assert_type(ast, 'Program');
+		expect(errors).toEqual([]);
+
+		const fragment = find_first(ast, function (node) {
+			return node.type === 'JSXFragment';
+		});
+		assert_type(fragment, 'JSXFragment');
+		expect(
+			fragment.children.map(function (child) {
+				return child.type;
+			}),
+		).toEqual(['JSXStyleElement', 'JSXElement']);
+		expect(child(fragment, 0, 'JSXStyleElement').css).toBe('\n\t\t\t.foo { color: red; }\n\t\t');
+		expect(child(fragment, 1, 'JSXElement').isDynamic).toBe(true);
+	});
+
+	it('keeps a `<` inside CSS text in the unclosed style body', function () {
+		const source = `export function App() @{
+	<>
+		<style>
+			.foo::before { content: "<"; }
+			/* < is not a tag */
+		<div />
+	</>
+}`;
+		/** @type {CompileError[]} */
+		const errors = [];
+		const ast = parseModule(source, 'App.tsrx', { loose: true, collect: true, errors });
+
+		assert_type(ast, 'Program');
+		expect(errors).toEqual([]);
+
+		const fragment = find_first(ast, function (node) {
+			return node.type === 'JSXFragment';
+		});
+		assert_type(fragment, 'JSXFragment');
+		expect(
+			fragment.children.map(function (child) {
+				return child.type;
+			}),
+		).toEqual(['JSXStyleElement', 'JSXElement']);
+		const style = child(fragment, 0, 'JSXStyleElement');
+		expect(style.css).toContain('content: "<";');
+		expect(style.css).toContain('/* < is not a tag */');
+		expect(style.end).toBe(source.indexOf('<div />'));
+		expect(openingName(child(fragment, 1, 'JSXElement')).name).toBe('div');
+	});
+
 	it('captures the rest of the file after an unclosed module-scope style', function () {
 		const source = `const theme = <style>
 	.card { color: red; }

--- a/packages/tsrx/tests/utils/style-parse.test.js
+++ b/packages/tsrx/tests/utils/style-parse.test.js
@@ -24,6 +24,24 @@ describe('parseStyle loose recovery', function () {
 		expect(sheet.children[0].type).toBe('Rule');
 	});
 
+	it('keeps the rules parsed before an unclosed comment', function () {
+		const sheet = parseStyle('.foo { color: red; }\n/* typing a comment', LOCATION, {
+			loose: true,
+		});
+
+		expect(sheet.children).toHaveLength(1);
+		expect(sheet.children[0].type).toBe('Rule');
+	});
+
+	it.each(['/* comment', '<!-- comment', '.foo { color: red; } <!--', '.foo { /* comment'])(
+		'does not throw on an unclosed comment %j',
+		function (css) {
+			expect(function () {
+				parseStyle(css, LOCATION, { loose: true });
+			}).not.toThrow();
+		},
+	);
+
 	it.each([
 		'.foo {',
 		'.foo { color',

--- a/packages/tsrx/tests/utils/style-parse.test.js
+++ b/packages/tsrx/tests/utils/style-parse.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { parseStyle } from '../../src/index.js';
+
+const LOCATION = { filename: 'App.tsrx', line: 1, column: 0 };
+
+describe('parseStyle loose recovery', function () {
+	it('does not throw on leftover markup after an unclosed style body', function () {
+		expect(function () {
+			parseStyle('\n\t\t<div />\n\t</>\n}', LOCATION, { loose: true });
+		}).not.toThrow();
+	});
+
+	it('does not throw on a partial rule', function () {
+		const sheet = parseStyle('.foo', LOCATION, { loose: true });
+
+		expect(sheet.type).toBe('StyleSheet');
+		expect(sheet.source).toBe('.foo');
+	});
+
+	it('keeps the rules parsed before a partial one', function () {
+		const sheet = parseStyle('.foo { color: red; }\n.bar { color', LOCATION, { loose: true });
+
+		expect(sheet.children).toHaveLength(1);
+		expect(sheet.children[0].type).toBe('Rule');
+	});
+
+	it.each([
+		'.foo {',
+		'.foo { color',
+		'.foo { color: red',
+		'@media (max-width: 10px) {',
+		'.foo { &:hover {',
+	])('does not throw or hang on %j', function (css) {
+		expect(function () {
+			parseStyle(css, LOCATION, { loose: true });
+		}).not.toThrow();
+	});
+
+	it('still throws on partial input when loose is off', function () {
+		expect(function () {
+			parseStyle('\n\t\t<div />\n\t</>\n}', LOCATION, { loose: false });
+		}).toThrow('Expected identifier');
+	});
+
+	it('still parses a balanced rule', function () {
+		const sheet = parseStyle('.foo { color: red; }', LOCATION, { loose: false });
+
+		expect(sheet.children).toHaveLength(1);
+		expect(sheet.children[0].type).toBe('Rule');
+	});
+});


### PR DESCRIPTION
Fixes #47. Supersedes #60, which carried the whole scoped-styles branch; the CSS-parser recovery, the closed type-only stand-in, and the parser regression tests from that PR are kept here (thanks @jonkwheeler).

## Problem

While `<style>` is being typed there is no `</style>` yet. The parser handed the rest of the file to the CSS parser, which threw a fatal `Expected identifier`, so both compilers fell back to a whole-file 1:1 mapping and every token mapping disappeared until the closing tag existed. An unclosed `<span>` already recovered in loose mode.

## Approach

#60 emptied the body and kept tokenizing right after `<style>`. That fixes the auto-insert moment, but any CSS typed before the closing tag exists (no auto-insert, a deleted `</style>`, a paste) is then tokenized as JSX and still goes fatal, and the loose CSS parser never actually sees partial input. This PR instead routes unclosed raw-text elements through the same tokenizer-restoration path a closed `<style>` / `<script>` uses, with a zero-length close:

- **Inside a template** the body runs up to the next tag start (`<x`, `</x>`, `</>`). Partial CSS reaches the loose CSS parser, and the siblings and closing tags after it keep their mappings. The element ends where its body ends.
- **Outside a template** (a module-scope theme) only JS follows, with no marker to resume at, so the rest of the input is the body and the declaration keeps its mapping instead of the file going fatal.
- **Loose CSS parser** keeps the rules parsed so far and drops a partial one instead of throwing. Strict parsing is unchanged.
- **Type-only stand-in** prints `<style></style>` for an unclosed block so the virtual TSX stays parseable; the CSS embedded region ends at the captured body when there is no closing tag.

Compared with #60 this drops the separate context-popping helper and the "keep line tracking at the opening tag" special case, since the shared close path already handles both.

## Language server

`packages/language-server/src/autoInsertPlugin.js` now keys the `>` token lookup on the selection rather than on the change offset. Volar maps the selection through completion-enabled mappings only, but maps the change offset through the first covering mapping, which for `<style apply={…}>` is the verify-only element mapping whose generated text differs from the source. The two `<style apply={…}>` auto-insert tests only passed before because the fatal-compile fallback made offsets coincide; #60 fails them too (its checks never ran the test workflow). The fallback stays for files that still fail to parse mid-edit, with its comment corrected.

## Tests

- Shared `compile_to_volar_mappings`: unclosed `<style>` before a sibling has no fatal error, is not a whole-file mapping, maps `App` and `div`, and emits `<style></style>`; same with partial CSS typed after the tag, which never reaches the generated code.
- Parser: unclosed `<style>` keeps later siblings (empty body, inside `<section>`, same line, immediately before a parent close); partial CSS is captured up to the next sibling with the element ending at its body; a module-scope unclosed `<style>` captures the rest of the file; unclosed `<script>` recovers the same way.
- `parseStyle`: loose mode keeps complete rules before a partial one and does not throw or hang on `.foo {`, `.foo { color`, `@media (…) {`, nested partials; strict mode still throws.
- Auto-insert: closes `<style>` when CSS already follows it, plus the existing `<style apply={…}>` cases now passing without the fallback.

Not covered: an unclosed `<style>` at the very end of an unclosed function body still fails, the same way an unclosed `<span>` there does today.

## Validation

```
pnpm vitest run --project tsrx-utils --project tsrx-analyze --project tsrx-react --project tsrx-preact --project tsrx-solid --project tsrx-vue --project language-server --project typescript-plugin --project prettier-plugin --project eslint-parser --project eslint-plugin
pnpm typecheck
pnpm changeset:check
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core JSX/style parsing, virtual-file generation, and LSP offset mapping—high editor impact but scoped to loose mode with strict behavior unchanged and heavy regression coverage.
> 
> **Overview**
> **Fixes editor-time fatal parses** when `<style>` or `<script>` has no closing tag yet. Previously the rest of the file was fed to the CSS parser (or treated as raw text to EOF), causing fatal errors and a whole-file 1:1 Volar mapping fallback so IDE features broke until `</style>` existed.
> 
> In **loose mode inside templates**, unclosed raw-text elements now capture body text only up to the next real tag start (ignoring `<` inside CSS), run that through a **tolerant CSS parser** that keeps complete rules and stops on partial input, then **resume tokenization** so siblings and closing tags keep source mappings. Module-scope unclosed `<style>` still consumes the remainder of the input. Transforms emit a synthetic `</style>` stand-in and correct CSS region bounds when there is no closing tag.
> 
> The **language server auto-insert** plugin maps the typed `>` via the cursor/selection offset instead of the change range, avoiding wrong offsets when verify-only mappings rewrite `apply` to `data-tsrx-apply`—so closing-tag insertion works for `<style apply={…}>` without relying on fatal-compile fallback.
> 
> Patch releases for `@tsrx/core` and `@tsrx/language-server`; broad parser, compile-mapping, auto-insert, and `parseStyle` tests added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d2cb77d025d0397a17efc182b8cfd33a67ee1ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->