### PR TITLE
fix(tsrx): give analyzeCss :global placement errors file-relative positions

### DIFF
--- a/.changeset/analyze-css-global-positions.md
+++ b/.changeset/analyze-css-global-positions.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+`analyzeCss` now reports `:global` placement errors with file-relative `pos`, `end`, and `loc` anchored on the misplaced `:global` selector, and accepts `{ filename, errors, comments }` to collect them instead of throwing. `parseStyle` takes an optional `body` origin (the style body's file offset, line, and column) and records it on the sheet as `sourceStart` and a file-relative `loc`; CSS node `start` / `end` stay body-relative. Sheets produced by `parseModule` carry the origin, so direct `analyzeCss` callers can place editor diagnostics without going through `compile`.

--- a/packages/language-server/tests/compileErrorDiagnosticPlugin.test.js
+++ b/packages/language-server/tests/compileErrorDiagnosticPlugin.test.js
@@ -66,6 +66,29 @@ export function App() @{
 		expect(document.getText(diagnostics[0].range)).toBe('themes.light');
 	});
 
+	it('reports CSS_GLOBAL_PLACEMENT on the style block that holds the :global', async () => {
+		// The type-only output has no tokens inside a CSS body, so the transform
+		// anchors the block's diagnostic on the `<style>` element (the mapped
+		// stand-in), not on the selector.
+		const { document, diagnostics } = await diagnostics_for(
+			`export function App() @{
+	<>
+		<style>
+			.a :global(.b) .c { color: red; }
+		</style>
+		<div>{'x'}</div>
+	</>
+}`,
+		);
+
+		expect(diagnostics).toHaveLength(1);
+		const [diagnostic] = diagnostics;
+		expect(diagnostic.code).toBe('tsrx-css-global-placement');
+		expect(document.getText(diagnostic.range)).toBe(
+			'<style>\n\t\t\t.a :global(.b) .c { color: red; }\n\t\t</style>',
+		);
+	});
+
 	it('reports nothing for a valid apply', async () => {
 		const { diagnostics } = await diagnostics_for(
 			`const theme = <style>.a { color: red; }</style>;

--- a/packages/tsrx/README.md
+++ b/packages/tsrx/README.md
@@ -64,7 +64,12 @@ here and keeps package docs focused on the core parser API.
   (`import`, `prop`, `let`, `const`, `function`, `for_pattern`, …).
 - **AST utilities** — pattern walkers, identifier extraction, builders, location
   helpers, obfuscation helpers.
-- **CSS support** — `parseStyle`, `analyzeCss`, `renderStylesheets`.
+- **CSS support** — `parseStyle`, `analyzeCss`, `renderStylesheets`. CSS node
+  offsets are relative to the style body; a sheet parsed with a `body` origin
+  (every sheet `parseModule` produces) records `sourceStart` and a file-relative
+  `loc`, and `analyzeCss` anchors its `:global` placement diagnostics on the
+  selector with file-relative positions. Pass `{ errors, comments }` to collect
+  them instead of throwing.
 - **Scoped styles** — `analyzeTsrx` resolves every `<style>` block. A standalone
   block is a child of an element or fragment and is scoped to its siblings: it
   styles the items beside it and everything below them, never the element that

--- a/packages/tsrx/src/analyze/css-analyze.js
+++ b/packages/tsrx/src/analyze/css-analyze.js
@@ -1,8 +1,10 @@
 /** @import * as AST from 'estree' */
+/** @import { CompileError } from '../../types/index' */
 
 import { walk } from 'zimmerframe';
 import { error } from '../errors.js';
 import { DIAGNOSTIC_CODES } from '../diagnostics.js';
+import { css_node_source_position } from '../parse/style.js';
 import {
 	TSRX_CSS_GLOBAL_MIDDLE_PLACEMENT_ERROR,
 	TSRX_CSS_GLOBAL_NESTED_IN_PSEUDOCLASS_ERROR,
@@ -41,10 +43,41 @@ function is_global(relative_selector) {
 }
 
 /**
- * Analyze CSS and set metadata for global selectors
+ * Analyze CSS and set metadata for global selectors.
+ *
+ * `:global` placement problems are reported through `error()` with the
+ * `CSS_GLOBAL_PLACEMENT` code: pushed onto `errors` when given (and skipped
+ * over a suppressing comment when `comments` is given too), thrown otherwise.
+ * When `css` is a sheet parsed with a `body` origin (every sheet `parseModule`
+ * produces), the diagnostic carries file-relative `pos` / `end` / `loc`; the
+ * `fileName` defaults to the sheet's.
+ *
  * @param {AST.CSS.Node} css - The CSS AST
+ * @param {{
+ *   filename?: string | null,
+ *   errors?: CompileError[],
+ *   comments?: AST.CommentWithLocation[],
+ * }} [options]
  */
-export function analyze_css(css) {
+export function analyze_css(css, options = {}) {
+	const sheet = css.type === 'StyleSheet' ? css : null;
+	const filename = options.filename ?? sheet?.filename ?? null;
+
+	/**
+	 * @param {string} message
+	 * @param {AST.CSS.Node} node
+	 */
+	function report(message, node) {
+		error(
+			message,
+			filename,
+			css_node_source_position(sheet, node),
+			options.errors,
+			options.comments,
+			DIAGNOSTIC_CODES.CSS_GLOBAL_PLACEMENT,
+		);
+	}
+
 	walk(css, /** @type {{ rule: AST.CSS.Rule | null }} */ ({ rule: null }), {
 		Rule(node, context) {
 			node.metadata.parent_rule = context.state.rule;
@@ -104,14 +137,7 @@ export function analyze_css(css) {
 						is_nested &&
 						!(/** @type {AST.CSS.PseudoClassSelector} */ (global.selectors[0]).args)
 					) {
-						error(
-							TSRX_CSS_GLOBAL_NESTED_IN_PSEUDOCLASS_ERROR,
-							null,
-							/** @type {AST.Node} */ (/** @type {unknown} */ (global)),
-							undefined,
-							undefined,
-							DIAGNOSTIC_CODES.CSS_GLOBAL_PLACEMENT,
-						);
+						report(TSRX_CSS_GLOBAL_NESTED_IN_PSEUDOCLASS_ERROR, global.selectors[0]);
 					}
 
 					const idx = node.children.indexOf(global);
@@ -120,14 +146,8 @@ export function analyze_css(css) {
 						// ensure `:global(...)` is not used in the middle of a selector (but multiple `global(...)` in sequence are ok)
 						for (let i = idx + 1; i < node.children.length; i++) {
 							if (!is_global(node.children[i])) {
-								error(
-									TSRX_CSS_GLOBAL_MIDDLE_PLACEMENT_ERROR,
-									null,
-									/** @type {AST.Node} */ (/** @type {unknown} */ (global)),
-									undefined,
-									undefined,
-									DIAGNOSTIC_CODES.CSS_GLOBAL_PLACEMENT,
-								);
+								report(TSRX_CSS_GLOBAL_MIDDLE_PLACEMENT_ERROR, first);
+								break;
 							}
 						}
 					}

--- a/packages/tsrx/src/parse/style.js
+++ b/packages/tsrx/src/parse/style.js
@@ -113,7 +113,15 @@ class Parser {
 /**
  * @template {string} T
  * @param {string} content
- * @param {{ filename: NonEmptyString<T>, line: number, column: number }} location position of the `<style>` tag in the source file
+ * @param {{
+ *   filename: NonEmptyString<T>,
+ *   line: number,
+ *   column: number,
+ *   body?: { start: number, line: number, column: number },
+ * }} location position of the `<style>` tag in the source file, and optionally
+ * `body`, the file offset and 1-based line / 0-based column of the style body's
+ * first character. With `body`, the sheet records `sourceStart` and a
+ * file-relative `loc`, and diagnostics on its nodes carry file positions.
  * @param {{ loose?: boolean }} options
  * @returns {AST.CSS.StyleSheet}
  */
@@ -126,14 +134,82 @@ export function parse_style(content, location, options) {
 	// pre-image-resistant hash to avoid leaking file structure into the bundle.
 	const hash_source = `${location.filename}:${location.line}:${location.column}:${content}`;
 
-	return {
+	/** @type {AST.CSS.StyleSheet} */
+	const sheet = {
 		source: content,
 		hash: `tsrx-${strong_hash(hash_source)}`,
 		type: 'StyleSheet',
 		children: read_body(parser),
 		start: 0,
 		end: content.length,
+		filename: location.filename,
 	};
+
+	if (location.body) {
+		sheet.sourceStart = location.body.start;
+		sheet.loc = {
+			start: { line: location.body.line, column: location.body.column },
+			end: css_position(sheet, content.length, location.body),
+		};
+	}
+
+	return sheet;
+}
+
+/**
+ * Map a style-body offset to a file line / column, given the file position of
+ * the body's first character.
+ *
+ * @param {AST.CSS.StyleSheet} sheet
+ * @param {number} offset
+ * @param {{ line: number, column: number }} origin
+ * @returns {{ line: number, column: number }}
+ */
+function css_position(sheet, offset, origin) {
+	const source = sheet.source;
+	let line = origin.line;
+	let line_start = -1;
+	for (let i = 0; i < offset; i++) {
+		const ch = source.charCodeAt(i);
+		if (ch === 13 && source.charCodeAt(i + 1) === 10) {
+			i++;
+		} else if (ch !== 10 && ch !== 13 && ch !== 0x2028 && ch !== 0x2029) {
+			continue;
+		}
+		line++;
+		line_start = i;
+	}
+	return {
+		line,
+		column: line_start === -1 ? origin.column + offset : offset - line_start - 1,
+	};
+}
+
+/**
+ * The file-relative `start` / `end` / `loc` of a CSS node in a sheet parsed
+ * with a `body` origin; the node itself when the sheet has none. CSS node
+ * offsets are relative to the style body, so this is what a diagnostic on a
+ * CSS node has to be anchored on.
+ *
+ * @param {AST.CSS.StyleSheet | null | undefined} sheet
+ * @param {AST.CSS.Node} node
+ * @returns {AST.Node | AST.NodeWithLocation}
+ */
+export function css_node_source_position(sheet, node) {
+	if (sheet?.sourceStart === undefined || !sheet.loc) {
+		return /** @type {AST.Node} */ (/** @type {unknown} */ (node));
+	}
+	const origin = sheet.loc.start;
+	return /** @type {AST.NodeWithLocation} */ (
+		/** @type {unknown} */ ({
+			start: node.start + sheet.sourceStart,
+			end: node.end + sheet.sourceStart,
+			loc: {
+				start: css_position(sheet, node.start, origin),
+				end: css_position(sheet, node.end, origin),
+			},
+		})
+	);
 }
 
 /** @param {Parser} parser */

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -2408,12 +2408,14 @@ export function TSRXPlugin(config) {
 					);
 				}
 				const content = this.#parseRawTextElement(open, node, 'style', contextDepth);
+				const bodyLoc = get_line_info(this, open.end);
 				const parsedCss = parse_style(
 					content,
 					{
 						filename,
 						line: open.loc.start.line,
 						column: open.loc.start.column,
+						body: { start: open.end, line: bodyLoc.line, column: bodyLoc.column },
 					},
 					{ loose: this.#loose },
 				);

--- a/packages/tsrx/tests/analyze/styles.test.js
+++ b/packages/tsrx/tests/analyze/styles.test.js
@@ -2,7 +2,13 @@
 /** @import { CompileError, TSRXAnalysisOptions } from '../../types/index' */
 
 import { describe, expect, it } from 'vitest';
-import { analyzeCss, analyzeTsrx, DIAGNOSTIC_CODES, parseModule } from '../../src/index.js';
+import {
+	analyzeCss,
+	analyzeTsrx,
+	DIAGNOSTIC_CODES,
+	parseModule,
+	parseStyle,
+} from '../../src/index.js';
 import {
 	TSRX_CSS_GLOBAL_MIDDLE_PLACEMENT_ERROR,
 	TSRX_CSS_GLOBAL_NESTED_IN_PSEUDOCLASS_ERROR,
@@ -691,12 +697,62 @@ describe('scoped style analysis', () => {
 	});
 
 	describe(':global placement', () => {
-		/** @param {string} css */
-		function parse_stylesheet(css) {
-			const ast = parseModule(`const t = <style>${css}</style>;`, filename);
+		/**
+		 * @param {string} source
+		 * @returns {AST.CSS.StyleSheet}
+		 */
+		function first_stylesheet(source) {
+			const ast = parseModule(source, filename);
 			const declaration = /** @type {AST.VariableDeclaration} */ (ast.body[0]);
 			const style = /** @type {AST.JSXStyleElement} */ (declaration.declarations[0].init);
 			return style.children[0];
+		}
+
+		/** @param {string} css */
+		function parse_stylesheet(css) {
+			return first_stylesheet(`const t = <style>${css}</style>;`);
+		}
+
+		/**
+		 * @param {string} source
+		 * @param {number} offset
+		 */
+		function loc_at(source, offset) {
+			const before = source.slice(0, offset);
+			return { line: before.split('\n').length, column: offset - (before.lastIndexOf('\n') + 1) };
+		}
+
+		/**
+		 * @param {AST.CSS.Node} sheet
+		 * @param {Parameters<typeof analyzeCss>[1]} [options]
+		 */
+		function analyze_thrown(sheet, options) {
+			try {
+				analyzeCss(sheet, options);
+			} catch (error) {
+				return /** @type {CompileError} */ (error);
+			}
+			return null;
+		}
+
+		/**
+		 * The error's `pos` / `end` are file offsets covering `:global...` in
+		 * `source`, and `loc` is the matching file-relative line / column.
+		 *
+		 * @param {CompileError | null} thrown
+		 * @param {string} source
+		 * @param {string} selector
+		 */
+		function expect_anchored_on(thrown, source, selector) {
+			const pos = source.indexOf(selector);
+			expect(pos, selector).not.toBe(-1);
+			expect(thrown?.fileName, source).toBe(filename);
+			expect(thrown?.pos, source).toBe(pos);
+			expect(thrown?.end, source).toBe(pos + selector.length);
+			expect(thrown?.loc, source).toEqual({
+				start: loc_at(source, pos),
+				end: loc_at(source, pos + selector.length),
+			});
 		}
 
 		it('reports misplaced :global with a coded error', () => {
@@ -705,16 +761,106 @@ describe('scoped style analysis', () => {
 				[':not(:global) { color: red; }', TSRX_CSS_GLOBAL_NESTED_IN_PSEUDOCLASS_ERROR],
 				[':is(:global .a) { color: red; }', TSRX_CSS_GLOBAL_NESTED_IN_PSEUDOCLASS_ERROR],
 			]) {
-				let thrown = /** @type {CompileError | null} */ (null);
-				try {
-					analyzeCss(parse_stylesheet(css));
-				} catch (error) {
-					thrown = /** @type {CompileError} */ (error);
-				}
+				const thrown = analyze_thrown(parse_stylesheet(css));
 
 				expect(thrown?.code, css).toBe(DIAGNOSTIC_CODES.CSS_GLOBAL_PLACEMENT);
 				expect(thrown?.message, css).toBe(message);
 			}
+		});
+
+		it('anchors the error on :global with file-relative offsets and loc', () => {
+			for (const [css, selector] of [
+				['.a :global(.b) .c { color: red; }', ':global(.b)'],
+				[':not(:global) { color: red; }', ':global'],
+				[':is(:global .a) { color: red; }', ':global'],
+			]) {
+				const source = `const t = <style>${css}</style>;`;
+				expect_anchored_on(analyze_thrown(first_stylesheet(source)), source, selector);
+			}
+		});
+
+		it('maps positions across lines and past leading whitespace', () => {
+			const source = `const theme = <style>
+	.x { color: blue; }
+	.a
+		:global(.b) .c { color: red; }
+</style>;`;
+			const thrown = analyze_thrown(first_stylesheet(source));
+
+			expect_anchored_on(thrown, source, ':global(.b)');
+			expect(thrown?.loc?.start).toEqual({ line: 4, column: 2 });
+		});
+
+		it('collects into errors and defaults fileName from the sheet', () => {
+			/** @type {CompileError[]} */
+			const errors = [];
+			const source = `const t = <style>
+	.a :global(.b) .c { color: red; }
+	.d :global(.e) .f { color: red; }
+</style>;`;
+
+			expect(() => analyzeCss(first_stylesheet(source), { errors })).not.toThrow();
+			expect(errors.map((error) => error.code)).toEqual([
+				DIAGNOSTIC_CODES.CSS_GLOBAL_PLACEMENT,
+				DIAGNOSTIC_CODES.CSS_GLOBAL_PLACEMENT,
+			]);
+			expect(errors.map((error) => error.type)).toEqual(['usage', 'usage']);
+			expect_anchored_on(errors[0], source, ':global(.b)');
+			expect_anchored_on(errors[1], source, ':global(.e)');
+		});
+
+		it('takes the filename from options over the sheet', () => {
+			const thrown = analyze_thrown(parse_stylesheet('.a :global(.b) .c {}'), {
+				filename: 'Other.tsrx',
+			});
+
+			expect(thrown?.fileName).toBe('Other.tsrx');
+		});
+
+		it('reports one middle-placement error per selector', () => {
+			/** @type {CompileError[]} */
+			const errors = [];
+
+			analyzeCss(parse_stylesheet('.a :global(.b) .c .d .e { color: red; }'), { errors });
+
+			expect(errors).toHaveLength(1);
+		});
+
+		it('positions a sheet parsed directly with a body origin', () => {
+			const prefix = 'const t = <style>';
+			const css = '.a :global(.b) .c { color: red; }';
+			const source = `${prefix}${css}</style>;`;
+			const sheet = parseStyle(
+				css,
+				{
+					filename,
+					line: 1,
+					column: 'const t = '.length,
+					body: { start: prefix.length, line: 1, column: prefix.length },
+				},
+				{},
+			);
+
+			expect(sheet.start).toBe(0);
+			expect(sheet.end).toBe(css.length);
+			expect(sheet.sourceStart).toBe(prefix.length);
+			expect(sheet.loc).toEqual({
+				start: { line: 1, column: prefix.length },
+				end: { line: 1, column: prefix.length + css.length },
+			});
+			expect_anchored_on(analyze_thrown(sheet), source, ':global(.b)');
+		});
+
+		it('keeps body-relative positions on a sheet parsed without an origin', () => {
+			const css = '.a :global(.b) .c { color: red; }';
+			const sheet = parseStyle(css, { filename, line: 1, column: 0 }, {});
+			const thrown = analyze_thrown(sheet);
+
+			expect(sheet.sourceStart).toBeUndefined();
+			expect(sheet.loc).toBeUndefined();
+			expect(thrown?.fileName).toBe(filename);
+			expect(thrown?.pos).toBe(css.indexOf(':global'));
+			expect(thrown?.loc).toBeUndefined();
 		});
 
 		it('accepts :global(...) at the start or end of a selector', () => {

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -780,6 +780,7 @@ declare module 'estree' {
 
 	export namespace CSS {
 		export interface BaseNode extends AST.NodeWithMaybeComments {
+			/** Offset into the style body (`StyleSheet.source`), not the file. */
 			start: number;
 			end: number;
 			loc?: AST.SourceLocation;
@@ -790,6 +791,14 @@ declare module 'estree' {
 			children: Array<Atrule | Rule>;
 			source: string;
 			hash: string;
+			/** The file the `<style>` body was parsed from. */
+			filename?: string;
+			/**
+			 * File offset of `source[0]`, set when the sheet was parsed with a body
+			 * origin (every sheet `parseModule` produces). `start` / `end` stay
+			 * body-relative; `loc` is then the body's file-relative location.
+			 */
+			sourceStart?: number;
 		}
 
 		export interface Atrule extends BaseNode {


### PR DESCRIPTION
Fixes #45. Supersedes #65, which carries the same intent on top of a stale merge of `main`.

## Problem

CSS nodes only carry offsets relative to the `<style>` body, so a consumer calling `analyzeCss(sheet)` directly (Octane does) got a coded `CompileError` whose `pos`/`end` were body-relative and whose `loc` was `undefined`. Only the JSX transform's re-anchoring on the `<style>` element gave `compile` users a position.

## Approach

- `parseStyle` takes an optional `body` origin (`{ start, line, column }` of the body's first character) and records it on the sheet as `sourceStart` plus a file-relative `loc`. Node `start`/`end` stay body-relative, so `renderStylesheets` keeps indexing `source` unchanged and hashes are untouched.
- The parser plugin passes the origin for every `<style>` body, so every sheet `parseModule` produces carries it.
- `analyzeCss` maps the offending `:global` pseudo-class through that origin **at report time** rather than attaching `loc` to every CSS node on every parse (the approach in #65), defaults `fileName` from the sheet, accepts `{ filename, errors, comments }` to collect instead of throw, and reports a middle-placement selector once instead of once per trailing selector.
- The error is anchored on the `:global(...)` pseudo-class itself rather than the enclosing relative selector, which would include the leading combinator whitespace.

The transform still re-anchors the diagnostic on the `<style>` element for `compile` / `compile_to_volar_mappings`: the type-only output has no tokens inside a CSS body, so that block is the only range the language server can map back to the document. A new language-server test pins that behaviour down.

## Tests

- `packages/tsrx/tests/analyze/styles.test.js` (`:global placement`): file-relative `pos`/`end`/`loc` for direct `analyzeCss` callers, multi-line bodies, the `errors` option, filename precedence, one error per selector, a sheet parsed directly with `parseStyle` and a `body` origin, and body-relative positions when parsed without one.
- `packages/language-server/tests/compileErrorDiagnosticPlugin.test.js`: the editor diagnostic lands on the `<style>` block.

Ran `pnpm typecheck` and the `tsrx-utils`, `tsrx-analyze`, target compiler, `language-server`, and `typescript-plugin` vitest projects locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted diagnostic and parse-metadata changes for CSS analysis; behavior is well covered by new tests and does not alter rendering or selector semantics.
> 
> **Overview**
> **`analyzeCss`** now emits `:global` placement diagnostics with **file-relative** `pos`, `end`, and `loc` on the misplaced `:global` pseudo-class (not the whole selector), defaults `fileName` from the parsed sheet, and accepts **`{ filename, errors, comments }`** so callers can collect issues instead of throwing. Middle-placement violations report **once per selector** instead of once per trailing segment.
> 
> **`parseStyle`** accepts an optional **`body`** origin (offset and line/column of the style body’s first character). Sheets from **`parseModule`** store **`sourceStart`** and file-relative **`loc`** while CSS node **`start`/`end` stay body-relative**; **`css_node_source_position`** maps nodes at report time. The parser plugin passes that origin when parsing `<style>` bodies.
> 
> Docs and types document the model. Tests cover direct `analyzeCss`/`parseStyle` positioning, the `errors` option, and a language-server case where compile still highlights the **whole `<style>` block** because type-only output has no in-body CSS tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7308c9dde9bcf2cc8e2b896644eb49f50543c011. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->