### PR TITLE
fix(tsrx): keep sibling-combinator rules at the top of a style scope

### DIFF
--- a/.changeset/prune-sibling-container.md
+++ b/.changeset/prune-sibling-container.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Keep sibling-combinator rules (`.a + .b`, `.a ~ .c`) whose elements sit at the top of a style scope or of a control-flow branch fragment. Pruning looked for siblings only under the nearest ancestor *element*, so items of a scope's root list — which has no element parent by design — and items of a branch fragment had no siblings and their rules were commented out as unused. `prune_css` now reads the element's actual children list (element or fragment), and the scope pre-pass seeds each scope's paths with a root fragment (`createScopeRoot`, exported for consumer compilers) that ancestor combinators still never match.

--- a/packages/tsrx/src/analyze/prune.js
+++ b/packages/tsrx/src/analyze/prune.js
@@ -422,17 +422,13 @@ function can_render_dynamic_content(element, check_classes = false) {
 function get_possible_element_siblings(node, direction, adjacent_only) {
 	/** @type {Map<AST.TSRXJSXElement, boolean>} */
 	const siblings = new Map();
-	const parent = get_element_parent(node);
+	const container = get_sibling_container(node);
 
-	if (!parent) {
+	if (container === null) {
 		return siblings;
 	}
 
-	// Get the container that holds the siblings
-	const container = node_children(parent);
 	const node_index = container.indexOf(node);
-
-	if (node_index === -1) return siblings;
 
 	// Determine which siblings to check based on direction
 	let start, end, step;
@@ -532,9 +528,8 @@ function apply_combinator(relative_selector, rest_selectors, rule, node, directi
 								sibling_matched = true;
 							} else {
 								// Check if there are any elements after this component that could match the remaining selectors
-								const parent = get_element_parent(node);
-								if (parent) {
-									const container = node_children(parent);
+								const container = get_sibling_container(node);
+								if (container !== null) {
 									const component_index = container.indexOf(possible_sibling);
 
 									// For adjacent combinator, only check immediate next element
@@ -578,6 +573,38 @@ function apply_combinator(relative_selector, rest_selectors, rule, node, directi
 			return true;
 	}
 }
+/**
+ * The children list an element sits in — that of the nearest ancestor on its
+ * path whose children include it, which is its parent element, a fragment
+ * (an authored `<>…</>`, a control-flow branch's output, or the synthetic
+ * root of a style scope), or `null` when the element has no container.
+ *
+ * Sibling combinators (`+`, `~`) read this list. Ancestor combinators keep
+ * using {@link get_element_parent}: a fragment is not an element, and a
+ * scope's root fragment stands for the container that a scoped block never
+ * styles.
+ *
+ * @param {AST.TSRXElementNode} node
+ * @returns {AST.Node[] | null}
+ */
+function get_sibling_container(node) {
+	const path = node.metadata?.path;
+	if (!path || !path.length) {
+		return null;
+	}
+
+	let i = path.length;
+
+	while (i--) {
+		const children = node_children(path[i]);
+		if (children.includes(node)) {
+			return children;
+		}
+	}
+
+	return null;
+}
+
 /**
  * @param {AST.TSRXElementNode} node
  * @returns {AST.TSRXJSXElement | null}

--- a/packages/tsrx/src/index.js
+++ b/packages/tsrx/src/index.js
@@ -252,6 +252,7 @@ export {
 // Analyze
 export { analyze_css as analyzeCss } from './analyze/css-analyze.js';
 export { prune_css as pruneCss } from './analyze/prune.js';
+export { create_scope_root as createScopeRoot } from './transform/jsx/style-scopes.js';
 export {
 	TSRX_DO_WHILE_STATEMENT_ERROR,
 	TSRX_FORGOTTEN_STATEMENT_CONTAINER_ERROR,

--- a/packages/tsrx/src/transform/jsx/style-scopes.js
+++ b/packages/tsrx/src/transform/jsx/style-scopes.js
@@ -446,7 +446,9 @@ function prepare_scope(own, render_items, holder, state) {
 	}
 	const hash = sheets.length > 0 ? sheets[0][1].hash : null;
 	const refs = collect_style_ref_attributes(own);
-	const elements = collect_css_prunable_elements(render_items, [], ctx);
+	const elements = collect_css_prunable_elements(render_items, [], ctx, [
+		create_scope_root(render_items),
+	]);
 
 	/** @type {AST.CSS.StyleSheet | null} */
 	let first_sheet = null;
@@ -567,11 +569,33 @@ export function apply_css_definition_metadata(
 }
 
 /**
+ * The root of a scope's ancestor paths: a fragment holding the list's items,
+ * so `prune_css` can find the siblings of a top-level item for `+` and `~`
+ * combinators. It is not an element, so ancestor combinators never match it —
+ * the container of a scope is exactly what a scoped block does not style.
+ *
+ * @param {AST.Node[]} items
+ * @returns {AST.Node}
+ */
+export function create_scope_root(items) {
+	return /** @type {AST.Node} */ (
+		/** @type {unknown} */ ({
+			type: 'JSXFragment',
+			openingFragment: { type: 'JSXOpeningFragment' },
+			closingFragment: { type: 'JSXClosingFragment' },
+			children: items,
+			metadata: { path: [] },
+		})
+	);
+}
+
+/**
  * Pruning runs before the walker stamps paths onto template nodes, so each
  * collected element gets its ancestor chain (`metadata.path`) here —
  * descendant/sibling selector matching in `prune_css` reads it. The scope's
  * own elements and those of nested scopes are collected; a component
- * boundary stops the walk.
+ * boundary stops the walk. Callers that collect a scope's items themselves
+ * should seed `path` with {@link create_scope_root} for the same reason.
  *
  * @param {AST.Node | AST.Node[]} value
  * @param {AST.TSRXJSXElement[]} [elements]

--- a/packages/tsrx/tests/fixtures/scoped-styles/sibling-combinators.expected.json
+++ b/packages/tsrx/tests/fixtures/scoped-styles/sibling-combinators.expected.json
@@ -1,0 +1,16 @@
+{
+  "elements": {
+    "a scope": ["scope"],
+    "b": ["scope"],
+    "c": ["scope"],
+    "wrap": ["scope"],
+    "x": ["scope"],
+    "y": ["scope"],
+    "d": ["scope"],
+    "e": ["scope"],
+    "g": ["scope"]
+  },
+  "cssOrder": ["scope"],
+  "pruned": [".f + .g"],
+  "classMaps": {}
+}

--- a/packages/tsrx/tests/fixtures/scoped-styles/sibling-combinators.tsrx
+++ b/packages/tsrx/tests/fixtures/scoped-styles/sibling-combinators.tsrx
@@ -1,0 +1,42 @@
+// Sibling combinators between the items of one scope, and between the items
+// of a branch fragment: both siblings carry the scope hash, so the rules are
+// kept. Only the descendant chain through `.wrap` had a parent element to find
+// siblings in before; the others sit at the top of their list.
+export function SiblingCombinators({ open }: { open: boolean }) @{
+	<>
+		<style>
+			.scope {
+				--label: scope;
+			}
+			.a + .b {
+				color: red;
+			}
+			.a ~ .c {
+				color: blue;
+			}
+			.wrap .x + .y {
+				color: green;
+			}
+			.d + .e {
+				color: black;
+			}
+			.f + .g {
+				color: gray;
+			}
+		</style>
+		<div class="a scope">{'a'}</div>
+		<div class="b">{'b'}</div>
+		<div class="c">{'c'}</div>
+		<div class="wrap">
+			<span class="x">{'x'}</span>
+			<span class="y">{'y'}</span>
+		</div>
+		@if (open) {
+			<>
+				<i class="d">{'d'}</i>
+				<i class="e">{'e'}</i>
+			</>
+		}
+		<i class="g">{'g'}</i>
+	</>
+}


### PR DESCRIPTION
`.a + .b` and `.a ~ .c` between the items of a style scope (or of a control-flow branch fragment) were pruned as unused by every target, although both elements carry the scope hash and the rule matches at runtime.

**Cause.** `prune_css` looked up siblings through `get_element_parent`, the nearest ancestor *element* on the path. The RFC #1 pre-pass prunes each scope against its items with an empty root path (the container must stay invisible to ancestor combinators), so top-level items had no element parent and no siblings. Items of a `<>…</>` inside a branch had the same problem, since the fragment was skipped too.

**Fix.**
- `prune_css` reads the element's actual children list (element or fragment) for `+` / `~`, via a new `get_sibling_container`. Ancestor combinators keep using `get_element_parent`, so a scope's container is still never matched.
- The style pre-pass seeds each scope's paths with a synthetic root fragment holding the list's items. `createScopeRoot` is exported so consumer compilers with their own collectors (Ripple, Octane) can seed the same root.
- New conformance fixture `sibling-combinators` (kept rules at the scope root, inside `.wrap`, and inside an `@if` fragment; `.f + .g` with no `.f` sibling still pruned), run by every JSX target.

Before, for the fixture: `/* (unused) .a + .b … */`. After: `.a.tsrx-… + .b:where(.tsrx-…)`.

Follow-ups once released: Ripple-TS/ripple#1441 seeds the root in its own collector; Octane's `collectPrunableElements` needs the same one-line seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CSS prune matching for `+`/`~` and scope path seeding; behavior is localized but affects all scoped-style targets and downstream compilers that collect prunable elements.
> 
> **Overview**
> **Fixes incorrect pruning** of `.a + .b` and `.a ~ .c` when both sides are top-level items in a scoped template or siblings inside a control-flow fragment. Those rules were marked unused because sibling lookup used the nearest ancestor **element**’s children, so scope-root and fragment children had no discoverable siblings.
> 
> `prune_css` now resolves siblings via **`get_sibling_container`**, walking `metadata.path` to the list that actually contains the node (parent element, authored fragment, or synthetic scope root). Ancestor combinators still use **`get_element_parent`**, so scope containers stay invisible to descendant selectors.
> 
> The style-scope pre-pass seeds each scope’s element paths with **`createScopeRoot`** (exported from `@tsrx/core` for other compilers). A new **`sibling-combinators`** fixture asserts kept rules at scope root, under `.wrap`, and in an `@if` fragment, while `.f + .g` stays pruned when `.f` is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 434db4c0ae166473df658149c420d7535b23a27a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->