### PR TITLE
docs: document global keyframes on the TSRX website

### DIFF
--- a/website-tsrx/public/llms.txt
+++ b/website-tsrx/public/llms.txt
@@ -1012,6 +1012,53 @@ function Article({ html }: { html: string }) @{
 }
 ```
 
+### Global Keyframes
+
+Keyframes are scoped by default: the compiler renames each local `@keyframes`
+declaration using the style block's hash and rewrites matching `animation` and
+`animation-name` references in that block. To share keyframes across components,
+prefix the declared name with `-global-`. The compiler removes the prefix and
+adds no hash; references use the name without the prefix.
+
+```tsrx
+function App() @{
+	<>
+		<div class="parent"><Child /></div>
+		<style>
+			/* Scoped: renamed along with its references in this block. */
+			@keyframes slideIn {
+				from { transform: translateX(-100%); }
+				to { transform: translateX(0); }
+			}
+
+			/* Global: emitted as fadeIn, without a hash. */
+			@keyframes -global-fadeIn {
+				from { opacity: 0; }
+				to { opacity: 1; }
+			}
+
+			.parent { animation: slideIn 1s; }
+		</style>
+	</>
+}
+
+function Child() @{
+	<>
+		<div class="child">Child content</div>
+		<style>
+			.child { animation: fadeIn 1s; }
+		</style>
+	</>
+}
+```
+
+Other style blocks can use `animation: fadeIn 1s` or `animation-name: fadeIn`
+once the defining stylesheet is loaded. Only the keyframe name is global;
+selectors such as `.child` remain sibling-scoped. Keyframes inside a
+`:global { ... }` block also retain unscoped names. These rules also apply to
+vendor-prefixed keyframe at-rules and animation properties. For React, use
+`className` instead of `class` on host elements.
+
 ### Assigning a block gives you a theme object
 
 Assigning a `<style>` expression to a variable produces an object instead of a

--- a/website-tsrx/src/pages/features.tsrx
+++ b/website-tsrx/src/pages/features.tsrx
@@ -522,6 +522,41 @@ function Article({ html }: { html: string }) @{
 }`,
 );
 
+const GLOBAL_KEYFRAMES_HTML = highlight_tsrx(
+	`function App() @{
+  <>
+    <div class="parent"><Child /></div>
+
+    <style>
+      /* Scoped: the compiler renames slideIn and its references here. */
+      @keyframes slideIn {
+        from { transform: translateX(-100%); }
+        to { transform: translateX(0); }
+      }
+
+      /* Global: emitted as fadeIn, usable from other components. */
+      @keyframes -global-fadeIn {
+        from { opacity: 0; }
+        to { opacity: 1; }
+      }
+
+      .parent { animation: slideIn 1s; }
+    </style>
+  </>
+}
+
+function Child() @{
+  <>
+    <div class="child">Child content</div>
+
+    <style>
+      /* Reference the global name without the -global- prefix. */
+      .child { animation: fadeIn 1s; }
+    </style>
+  </>
+}`,
+);
+
 const LAZY_PROPS_HTML = highlight_tsrx(
 	`function UserCard(&{ name, age }: { name: string; age: number }) {
   return <div>
@@ -1272,6 +1307,34 @@ export const FeaturesPage = () => @{
 									</tr>
 								</tbody>
 							</table>
+							<h3 class="subsection-heading" id="global-keyframes">Global Keyframes</h3>
+							<p class="section-body">
+								Keyframes are scoped by default: the compiler adds the style block's hash to each
+								animation name and rewrites matching
+								<code class="inline-code">animation</code>
+								and
+								<code class="inline-code">animation-name</code>
+								references in that block. To share keyframes across components, prefix the name in
+								the declaration with
+								<code class="inline-code">-global-</code>.
+							</p>
+							<pre class="code-block">
+								<code innerHTML={GLOBAL_KEYFRAMES_HTML} />
+							</pre>
+							<p class="section-body">
+								The compiler emits
+								<code class="inline-code">@keyframes -global-fadeIn</code>
+								as
+								<code class="inline-code">@keyframes fadeIn</code>, without a hash. Other style
+								blocks can use
+								<code class="inline-code">animation: fadeIn 1s</code>
+								or
+								<code class="inline-code">animation-name: fadeIn</code>
+								once the defining stylesheet is loaded. Only the keyframe name is global; selectors
+								such as
+								<code class="inline-code">.child</code>
+								remain sibling-scoped.
+							</p>
 							<p class="section-body muted">
 								React note: TSRX keeps authored attributes as written. Use
 								<code class="inline-code">className</code>

--- a/website-tsrx/src/pages/specification.tsrx
+++ b/website-tsrx/src/pages/specification.tsrx
@@ -991,6 +991,27 @@ export function SpecificationPage() @{
 								<code>{STYLE_GRAMMAR}</code>
 							</pre>
 							<p class="section-body">
+								Keyframe names in a scoped style block are scoped by default. The implementation
+								renames each local
+								<code class="inline-code">@keyframes</code>
+								declaration using the block's hash and rewrites matching names in
+								<code class="inline-code">animation</code>
+								and
+								<code class="inline-code">animation-name</code>
+								declarations within that block. A keyframe name beginning with
+								<code class="inline-code">-global-</code>
+								is emitted with that prefix removed and no hash added: for example,
+								<code class="inline-code">@keyframes -global-fadeIn</code>
+								becomes
+								<code class="inline-code">@keyframes fadeIn</code>. References use the unprefixed
+								name, including in other components or style blocks once the defining stylesheet is
+								loaded. Keyframes declared inside a
+								<code class="inline-code">{':global { ... }'}</code>
+								block also retain unscoped names. These rules apply to vendor-prefixed keyframe
+								at-rules and animation properties as well. Making a keyframe name global does not
+								change the scope of selectors that reference it.
+							</p>
+							<p class="section-body">
 								A style body is captured as raw CSS text. A self-closing style element has no body,
 								no stylesheet, and no hash class of its own; it exists to carry an
 								<code class="inline-code">apply</code>


### PR DESCRIPTION
The website omitted TSRX's existing global keyframe support. Add a Global Keyframes section to the features page showing scoped animations alongside `@keyframes -global-fadeIn`, which emits `fadeIn` for use across components.

Document keyframe renaming, animation references, global blocks, and vendor-prefixed forms in the specification, and keep `llms.txt` in sync. This is documentation-only, so no changeset is needed.

Validation:
- Website production build passed (`pnpm --filter tsrx-website build`).
- Compiled the documented example with React, Preact, Solid, and Vue; checked that `slideIn` is scoped and `fadeIn` remains global.
- Prettier reported both updated pages unchanged; `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only updates to llms.txt, features, and specification pages with no product code changes.
> 
> **Overview**
> Documents **global keyframes** for scoped `<style>` blocks—behavior that already exists in the compiler but was missing from the site.
> 
> **`llms.txt`** adds a **Global Keyframes** section under scoped styles: default hashed `@keyframes` names, the `-global-` prefix (e.g. `@keyframes -global-fadeIn` → `fadeIn`), cross-component references, `:global { ... }` keyframes, and vendor-prefixed forms.
> 
> **Features page** adds the same topic with a highlighted `App`/`Child` example (`GLOBAL_KEYFRAMES_HTML`) and prose on scoping vs sharing animations.
> 
> **Specification §4.6** adds normative text on keyframe renaming, `animation` / `animation-name` rewriting, `-global-`, and that global names do not widen selector scope.
> 
> Documentation-only; no compiler or runtime changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c61e952fe48097ff902c2a327af87feae8f1de76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->