### PR TITLE
fix(runtime): tolerate Set/Map mutation during map_iterable

### DIFF
--- a/.changeset/map-iterable-set-map-mutation.md
+++ b/.changeset/map-iterable-set-map-mutation.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/runtime': patch
+---
+
+Fix `map_iterable` passing `undefined` items, skipping added entries, and reporting `is_last` early when a callback mutates the `Set` or `Map` being iterated. `Set` and `Map` walk the peek-ahead iterator path again; arrays keep the preallocated fast path.

--- a/packages/tsrx-runtime/src/iterable.js
+++ b/packages/tsrx-runtime/src/iterable.js
@@ -12,10 +12,6 @@ export function map_iterable(iterable, fn, tail, empty) {
 		return map_array(iterable, fn, tail, empty);
 	}
 
-	if (is_sized_iterable(iterable)) {
-		return map_sized(/** @type {Set<T> | Map<unknown, unknown>} */ (iterable), fn, tail, empty);
-	}
-
 	/** @type {Iterator<T>} */
 	var iterator;
 	var iterable_prop = /** @type {Iterable<T>} */ (iterable)[Symbol.iterator];
@@ -43,66 +39,6 @@ export function map_iterable(iterable, fn, tail, empty) {
 			break;
 		}
 		current = next;
-	}
-	return finish_tail(result, tail);
-}
-
-/**
- * True for Set and Map instances whose iterator is the default sized walk.
- * Custom iterators that happen to have `size` still take the peek-ahead path.
- *
- * @param {unknown} iterable
- * @returns {iterable is Set<unknown> | Map<unknown, unknown>}
- */
-function is_sized_iterable(iterable) {
-	if (iterable == null) {
-		return false;
-	}
-	var iterator = /** @type {Iterable<unknown>} */ (iterable)[Symbol.iterator];
-	return iterator === Set.prototype[Symbol.iterator] || iterator === Map.prototype[Symbol.iterator];
-}
-
-/**
- * @template T
- * @template U
- * @param {Set<T> | Map<unknown, unknown>} iterable
- * @param {(item: T, index: number, is_last: boolean) => U} fn
- * @param {(() => U | U[]) | null} [tail]
- * @param {() => U | U[]} [empty]
- * @returns {U[]}
- */
-function map_sized(iterable, fn, tail, empty) {
-	var length = iterable.size;
-	if (length === 0) {
-		return finish_empty(empty);
-	}
-
-	var iterator = iterable[Symbol.iterator]();
-	var first = fn(/** @type {T} */ (iterator.next().value), 0, length === 1);
-	if (Array.isArray(first)) {
-		/** @type {U[]} */
-		var flat = [];
-		push_mapped(flat, first);
-		for (var i = 1; i < length; i++) {
-			push_mapped(flat, fn(/** @type {T} */ (iterator.next().value), i, i === length - 1));
-		}
-		return finish_tail(flat, tail);
-	}
-
-	var result = new Array(length);
-	result[0] = first;
-	for (var i = 1; i < length; i++) {
-		var value = fn(/** @type {T} */ (iterator.next().value), i, i === length - 1);
-		if (Array.isArray(value)) {
-			result.length = i;
-			push_mapped(result, value);
-			i += 1;
-			for (; i < length; i++) {
-				push_mapped(result, fn(/** @type {T} */ (iterator.next().value), i, i === length - 1));
-			}
-			return finish_tail(result, tail);
-		}
-		result[i] = value;
 	}
 	return finish_tail(result, tail);
 }

--- a/packages/tsrx/tests/utils/iterable-runtime.test.js
+++ b/packages/tsrx/tests/utils/iterable-runtime.test.js
@@ -35,7 +35,7 @@ describe('map_iterable', function () {
 		).toEqual(['a:0', 'b', 'b', 'c:2!']);
 	});
 
-	it('maps sets and maps with size-based is_last', function () {
+	it('maps sets and maps with is_last on the final entry', function () {
 		expect(map_iterable(new Set(['a', 'b']), text_fn)).toEqual(['a:0', 'b:1!']);
 		expect(
 			map_iterable(
@@ -46,6 +46,104 @@ describe('map_iterable', function () {
 				text_fn,
 			),
 		).toEqual(['k,v:0', 'k2,v2:1!']);
+	});
+
+	it('tolerates clearing a set or map from a callback', function () {
+		var set = new Set([1, 2]);
+		expect(
+			map_iterable(set, function (item) {
+				set.clear();
+				return item;
+			}),
+		).toEqual([1, 2]);
+
+		var map = new Map([
+			[1, 'a'],
+			[2, 'b'],
+		]);
+		expect(
+			map_iterable(map, function (entry) {
+				map.clear();
+				return entry[0];
+			}),
+		).toEqual([1, 2]);
+	});
+
+	it('visits entries added to a set or map during iteration', function () {
+		var set = new Set([1, 2]);
+		expect(
+			map_iterable(set, function (item, index, is_last) {
+				set.add(3);
+				return [item, index, is_last];
+			}),
+		).toEqual([1, 0, false, 2, 1, false, 3, 2, true]);
+
+		var map = new Map([
+			[1, 'a'],
+			[2, 'b'],
+		]);
+		expect(
+			map_iterable(map, function (entry, index, is_last) {
+				map.set(3, 'c');
+				return [entry[0], index, is_last];
+			}),
+		).toEqual([1, 0, false, 2, 1, false, 3, 2, true]);
+	});
+
+	it('skips entries deleted from a set or map before they are visited', function () {
+		var set = new Set([1, 2, 3, 4]);
+		expect(
+			map_iterable(set, function (item, index, is_last) {
+				if (item === 1) {
+					set.delete(3);
+				}
+				return [item, index, is_last];
+			}),
+		).toEqual([1, 0, false, 2, 1, false, 4, 2, true]);
+
+		var map = new Map([
+			[1, 'a'],
+			[2, 'b'],
+			[3, 'c'],
+		]);
+		expect(
+			map_iterable(map, function (entry, index, is_last) {
+				if (entry[0] === 1) {
+					map.delete(3);
+				}
+				return [entry[0], index, is_last];
+			}),
+		).toEqual([1, 0, false, 2, 1, true]);
+	});
+
+	it('keeps tails after a mutated set and never calls fn for an emptied one', function () {
+		var set = new Set(['a', 'b']);
+		expect(
+			map_iterable(
+				set,
+				function (item, index, is_last) {
+					set.delete('b');
+					return text_fn(item, index, is_last);
+				},
+				function () {
+					return 'tail';
+				},
+			),
+		).toEqual(['a:0', 'b:1!', 'tail']);
+
+		var single = new Set(['only']);
+		expect(
+			map_iterable(
+				single,
+				function (item, index, is_last) {
+					single.clear();
+					return text_fn(item, index, is_last);
+				},
+				function () {
+					return ['t', 'u'];
+				},
+			),
+		).toEqual(['only:0!', 't', 'u']);
 	});
 
 	it('still walks custom iterators that also have size', function () {


### PR DESCRIPTION
## Summary

Fixes the `@tsrx/runtime` 0.1.5 regression reported downstream in octanejs/octane#977.

PR #67 added a `map_sized` fast path for `Set`/`Map` that cached `size` and read `iterator.next().value` without checking `done`. When a `@for` callback mutates the collection it is iterating, that path:

- passes `undefined` as the item once the collection shrinks (`Map` destructuring then throws)
- never visits entries added during iteration
- reports `is_last` on the wrong item

This restores the 0.1.2 behaviour by sending `Set` and `Map` through the existing peek-ahead iterator loop. The array preallocation path from #67 is unchanged.

## Tests

New cases in `iterable-runtime.test.js` cover clear, delete-before-visit, and add-during-iteration for both `Set` and `Map`, asserting values, indices, `is_last`, plus tail handling after mutation.

## Performance

Isolated microbenchmark, Node 24, `String(item)` body, 100 entries:

| Source | pre-#67 | #67 (broken) | this PR |
| --- | ---: | ---: | ---: |
| Set 100 | 364k ops/s | 750k ops/s | 370k ops/s |
| Map 100 | 39k ops/s | 42k ops/s | 35k ops/s |

A hybrid that keeps peek-ahead but preallocates the result from `size` measured ~505k ops/s on Set and no change on Map. It was left out to keep this a minimal correctness fix; it can be a follow-up if the Set number matters.

## Validation

- `pnpm exec vitest run --project tsrx-utils` (23 files, 605 tests)
- `pnpm typecheck`
- `pnpm exec prettier --check` on touched files, `pnpm changeset:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted runtime bugfix with broad new tests; behavior matches pre-#67 semantics aside from intentional Set/Map perf regression.
> 
> **Overview**
> Reverts the **Set**/**Map** `size`-based fast path in `map_iterable` (`is_sized_iterable` / `map_sized`) so those collections use the same **peek-ahead** iterator loop as other iterables. That fixes a **0.1.5** regression where mutating the collection inside the callback could yield **`undefined` items**, **skip newly added** entries, and set **`is_last` too early**.
> 
> **Arrays** still use the preallocated `map_array` path from #67; only default **Set**/**Map** iteration behavior changes (with a perf tradeoff on large sets).
> 
> Tests in `iterable-runtime.test.js` now cover **clear**, **add during iteration**, **delete before visit**, and **tail** handling for mutated sets/maps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6af980c5d70b58c6cf1999df7481b8c2392a33d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->