### PR TITLE
perf(runtime): walk non-array iterables with for...of in map_iterable

### DIFF
--- a/.changeset/map-iterable-for-of.md
+++ b/.changeset/map-iterable-for-of.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/runtime': patch
+---
+
+Speed up `map_iterable` for `Set`, `Map`, and other non-array iterables by walking them with `for...of` one item behind, storing single-node results without a helper call, and preallocating the result from a real `Set` or `Map` size. The size is only a capacity hint, so `is_last` and callbacks that mutate the collection behave exactly as before. As a side effect of `for...of`, a generator source is now closed when the callback throws.

--- a/packages/tsrx-runtime/src/iterable.js
+++ b/packages/tsrx-runtime/src/iterable.js
@@ -12,35 +12,94 @@ export function map_iterable(iterable, fn, tail, empty) {
 		return map_array(iterable, fn, tail, empty);
 	}
 
-	/** @type {Iterator<T>} */
-	var iterator;
+	/** @type {Iterable<T>} */
+	var source;
 	var iterable_prop = /** @type {Iterable<T>} */ (iterable)[Symbol.iterator];
 
 	if (typeof iterable_prop === 'function') {
-		iterator = iterable_prop.call(iterable);
+		source = /** @type {Iterable<T>} */ (iterable);
 	} else if (typeof (/** @type {Iterator<T>} */ (iterable).next) === 'function') {
-		iterator = Iterator.from(iterable);
+		source = Iterator.from(/** @type {Iterator<T>} */ (iterable));
 	} else {
 		throw new TypeError('The loop target has to be an Iterable');
 	}
 
-	var current = iterator.next();
-	if (current.done) {
+	// A real Set or Map preallocates the result from its size. The size is only a
+	// capacity hint: `is_last` still comes from the walk itself, so callbacks that
+	// add or remove entries keep the same semantics as any other iterable.
+	var capacity = 0;
+	if (
+		iterable_prop === Set.prototype[Symbol.iterator] ||
+		iterable_prop === Map.prototype[Symbol.iterator]
+	) {
+		var size = /** @type {Set<T> | Map<unknown, unknown>} */ (iterable).size;
+		if (typeof size === 'number' && size > 0) {
+			capacity = size;
+		}
+	}
+
+	/** @type {U[]} */
+	var result = capacity > 0 ? new Array(capacity) : [];
+	var count = 0;
+	var index = 0;
+	var has_previous = false;
+	/** @type {T | undefined} */
+	var previous;
+
+	// `for...of` lets engines skip the per-item iterator result object, and
+	// running one item behind keeps the peek-ahead contract: `fn` sees an item
+	// only after the next one has been pulled, so `is_last` is exact.
+	for (var item of source) {
+		if (has_previous) {
+			count = write_mapped(
+				result,
+				capacity,
+				count,
+				fn(/** @type {T} */ (previous), index++, false),
+			);
+		}
+		previous = item;
+		has_previous = true;
+	}
+
+	if (!has_previous) {
 		return finish_empty(empty);
 	}
 
-	var index = 0;
-	/** @type {U[]} */
-	var result = [];
-	while (true) {
-		var next = iterator.next();
-		push_mapped(result, fn(current.value, index++, !!next.done));
-		if (next.done) {
-			break;
-		}
-		current = next;
+	count = write_mapped(result, capacity, count, fn(/** @type {T} */ (previous), index, true));
+	if (count < capacity) {
+		result.length = count;
 	}
 	return finish_tail(result, tail);
+}
+
+/**
+ * Stores one mapped value. Slots below `capacity` are preallocated and written by
+ * index; anything past them is pushed. A fragment result truncates the unused
+ * slots and pushes, after which the returned count equals `capacity` so later
+ * values push as well.
+ *
+ * @template U
+ * @param {U[]} result
+ * @param {number} capacity
+ * @param {number} count
+ * @param {U | U[]} value
+ * @returns {number}
+ */
+function write_mapped(result, capacity, count, value) {
+	if (Array.isArray(value)) {
+		if (count < capacity) {
+			result.length = count;
+		}
+		push_mapped(result, value);
+		return capacity;
+	}
+	if (count < capacity) {
+		result[count] = value;
+		return count + 1;
+	}
+	result.push(value);
+	return count;
 }
 
 /**

--- a/packages/tsrx/tests/utils/iterable-runtime.test.js
+++ b/packages/tsrx/tests/utils/iterable-runtime.test.js
@@ -146,6 +146,103 @@ describe('map_iterable', function () {
 		).toEqual(['only:0!', 't', 'u']);
 	});
 
+	it('trims the preallocated result when a set or map shrinks mid-walk', function () {
+		var set = new Set([1, 2, 3, 4]);
+		var result = map_iterable(set, function (item) {
+			if (item === 1) {
+				set.delete(3);
+			}
+			return item;
+		});
+		expect(result).toStrictEqual([1, 2, 4]);
+		expect(result.length).toBe(3);
+		expect(Object.keys(result)).toStrictEqual(['0', '1', '2']);
+
+		var map = new Map([
+			[1, 'a'],
+			[2, 'b'],
+			[3, 'c'],
+		]);
+		var mapped = map_iterable(map, function (entry) {
+			map.clear();
+			return entry[1];
+		});
+		expect(mapped).toStrictEqual(['a', 'b']);
+		expect(mapped.length).toBe(2);
+	});
+
+	it('grows past the preallocated result when a set gains entries mid-walk', function () {
+		var set = new Set([1, 2]);
+		var result = map_iterable(set, function (item) {
+			if (item < 10) {
+				set.add(item + 10);
+			}
+			return item;
+		});
+		expect(result).toStrictEqual([1, 2, 11, 12]);
+		expect(result.length).toBe(4);
+	});
+
+	it('flattens fragments returned mid-walk over a preallocated set', function () {
+		expect(
+			map_iterable(new Set(['a', 'b', 'c', 'd']), function (item, index, is_last) {
+				if (index === 1) {
+					return [item, item];
+				}
+				return text_fn(item, index, is_last);
+			}),
+		).toStrictEqual(['a:0', 'b', 'b', 'c:2', 'd:3!']);
+
+		expect(
+			map_iterable(new Set(['a', 'b', 'c']), function (item, index, is_last) {
+				if (is_last) {
+					return [item, item];
+				}
+				return text_fn(item, index, is_last);
+			}),
+		).toStrictEqual(['a:0', 'b:1', 'c', 'c']);
+
+		expect(
+			map_iterable(new Set(['a', 'b', 'c']), function (item, index, is_last) {
+				if (index === 1) {
+					return [];
+				}
+				return text_fn(item, index, is_last);
+			}),
+		).toStrictEqual(['a:0', 'c:2!']);
+	});
+
+	it('preallocates for set subclasses and keeps undefined results', function () {
+		var Tagged = class extends Set {};
+		expect(map_iterable(new Tagged(['a', 'b']), text_fn)).toStrictEqual(['a:0', 'b:1!']);
+
+		var result = map_iterable(new Set([1, 2, 3]), function () {
+			return undefined;
+		});
+		expect(result.length).toBe(3);
+		expect(Object.keys(result)).toStrictEqual(['0', '1', '2']);
+	});
+
+	it('closes a generator when the callback throws', function () {
+		var closed = false;
+		var source = (function* () {
+			try {
+				yield 'a';
+				yield 'b';
+				yield 'c';
+			} finally {
+				closed = true;
+			}
+		})();
+
+		expect(function () {
+			map_iterable(source, function () {
+				throw new Error('boom');
+			});
+		}).toThrow('boom');
+		expect(closed).toBe(true);
+	});
+
 	it('still walks custom iterators that also have size', function () {
 		var dual = {
 			size: 2,


### PR DESCRIPTION
## Summary

Follow-up to #86, which restored correctness for `Set`/`Map` mutation during `map_iterable` at the cost of the #67 speed-up. This recovers most of that gain without reintroducing the bug.

Three changes to the non-array path in `packages/tsrx-runtime/src/iterable.js`:

- **`for...of` one item behind.** V8 has a fast path for `for...of` over native `Set`/`Map` iterators that skips the per-item result object; manual `iterator.next()` pays for it every time. Keeping the previous item in a local and calling `fn` for it once the next one has been pulled gives exactly the same callback ordering as the peek-ahead loop, so `is_last` and all mutation semantics are unchanged.
- **Inline scalar store.** Single-node results (the common `@for` body) are stored directly; only fragments go through the flatten helper.
- **Preallocate from `size` for real `Set`/`Map`.** The size is a capacity hint only. `is_last` still comes from the walk, a fragment truncates the unused slots and pushes, a shrinking collection trims the tail, and a growing one pushes past the hint.

The array path is untouched.

## Behaviour note

`for...of` calls `iterator.return()` when `fn` throws, so a generator source with a `finally` block is now closed instead of left suspended. Covered by a test and called out in the changeset.

## Performance

Same isolated harness as #86, Node 24, 100 entries, identity-style callbacks. Two interleaved runs each; second pair shown (the first pair was still warming up).

| Source | main (#86) | this PR |
| --- | ---: | ---: |
| Set 100, scalar | 585k ops/s | 1230k ops/s |
| Set 100, fragment | 308k | 295k |
| Map 100 | 264k | 308k |
| Set 10 | 2753k | 2745k |
| Generator 3 | 4241k | 4276k |
| Array 100 (unchanged path) | 2036k | 2323k |

For reference, the broken #67 sized path measured ~1700k on Set 100 in this harness. Map stays bounded by the spec-mandated `[key, value]` tuple per entry; keys-plus-lookup and `forEach` alternatives both measured slower.

## Tests

`iterable-runtime.test.js` adds: trimming after mid-walk deletes/clear (asserting length and no holes), growth past the preallocation, fragments at the middle, end, and empty positions of a preallocated set, `Set` subclasses, `undefined` results, and generator closing on throw. A scratch script also compared the new and old implementations on 22 scenarios for values, length, and holes with no differences.

## Validation

- `pnpm exec vitest run --project tsrx-utils` (23 files, 610 tests)
- `pnpm typecheck`
- `pnpm exec prettier --check` on touched files, `pnpm changeset:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core `@for` runtime path with subtle iteration semantics; behavior is intended to match prior fixes but generator cleanup on throw is a visible side effect.
> 
> **Overview**
> **`map_iterable`** on non-array sources is reworked in `@tsrx/runtime` to recover performance lost after a prior correctness fix, without changing `is_last` or mid-iteration `Set`/`Map` mutation behavior.
> 
> The manual `iterator.next()` loop is replaced by **`for...of` with a one-item lag**, so each callback still runs only after the next element is pulled (same peek-ahead as before). **Native `Set`/`Map`** paths **preallocate** the output from `.size` as a capacity hint only; **`write_mapped`** writes scalars by index and only uses flattening for array fragments, trimming or growing the result when the walk shrinks or grows the collection.
> 
> **Array** mapping is unchanged. **Generators** now run **`finally` / cleanup when the callback throws**, because `for...of` closes the iterator on error—new tests cover shrink/grow, fragments, subclasses, and that close behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7975b4013fd1957e7206ec236fc9edbd24545d4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->