### PR TITLE
fix(core): share generic-arrow and typed-default editor fixes

### DIFF
--- a/.changeset/shared-typescript-editor-diagnostics.md
+++ b/.changeset/shared-typescript-editor-diagnostics.md
@@ -1,0 +1,10 @@
+---
+"@tsrx/core": patch
+---
+
+Fix shared editor diagnostics for React, Preact, Solid, Vue, and other consumers
+of the core tooling pipeline. Generic arrows with a constrained or defaulted
+type parameter no longer produce a false trailing-comma error. Typed
+destructuring defaults retain their full diagnostic mapping, including when a
+multiline default ends in an array type assertion, instead of crashing source
+mapping generation.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -2886,8 +2886,14 @@ export function TSRXPlugin(config) {
 			 * @param {AST.TSTypeParameterDeclaration} node
 			 */
 			reportReservedArrowTypeParam(node) {
-				// Allow <T>() => {} syntax without requiring trailing comma
-				if (this.#collect && node.params.length === 1 && node.extra?.trailingComma === undefined) {
+				// Constraints and defaults already disambiguate a generic arrow from JSX.
+				if (
+					this.#collect &&
+					node.params.length === 1 &&
+					node.extra?.trailingComma === undefined &&
+					!node.params[0].constraint &&
+					!node.params[0].default
+				) {
 					error(
 						'This syntax is reserved in files with the .mts or .cts extension. Add a trailing comma, as in `<T,>() => ...`.',
 						this.#filename,

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -309,6 +309,9 @@ const TOOLING_LOCATION_WRAPPED_NODE_TYPES = new Set([
 	'ExportDefaultDeclaration',
 	'ExportAllDeclaration',
 	'TSPropertySignature',
+	// Whole defaults own diagnostics that can extend beyond the last mapped
+	// token of a type assertion, such as `items = EMPTY_ARRAY as string[]`.
+	'AssignmentPattern',
 ]);
 
 // Be careful when adding visitors that are already defined in `wrappers`.

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 import { builders as b, identifier_to_jsx_name, parseModule } from '@tsrx/core';
 import { assert_type } from './node-types.js';
 import {
@@ -21,6 +21,57 @@ export function runSharedSourceMappingTests({
 	name,
 	rejectsComponentAwait,
 }) {
+	describe(`[${name}] shared TypeScript editor diagnostics`, () => {
+		it.each(['Value extends { id: string }', 'Value = string', 'Value,'])(
+			'accepts an unambiguous generic arrow (%s)',
+			(parameter) => {
+				const source = `export const identity = <${parameter}>(value: Value) => value;`;
+				const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+				expect(result.errors).toEqual([]);
+			},
+		);
+
+		it('retains the trailing-comma diagnostic for an ambiguous generic arrow', () => {
+			const result = compile_to_volar_mappings(
+				'export const identity = <Value>(value: Value) => value;',
+				'App.tsrx',
+				{ loose: true },
+			);
+			expect(result.errors.map((error) => error.message)).toEqual([
+				expect.stringContaining('trailing comma'),
+			]);
+		});
+
+		it.each([' ', '\n\t'])(
+			'maps the whole typed destructuring default with whitespace %j',
+			(whitespace) => {
+				const source = `const EMPTY_ARRAY: readonly unknown[] = [];
+export function List({ items =${whitespace}EMPTY_ARRAY as string[] }: { items?: string[] }) {
+	return <span>{items.join(',')}</span>;
+}`;
+				const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+				expect(result.errors).toEqual([]);
+				const start = source.indexOf('items =');
+				const end = source.indexOf('[]', start) + 2;
+				const mapping = result.mappings.find((mapping) =>
+					mapping.sourceOffsets.some(
+						(offset, index) => offset === start && mapping.lengths[index] === end - start,
+					),
+				);
+				assert(mapping, 'The whole typed default must retain its diagnostic mapping');
+				expect(mapping.data.verification).toBe(true);
+				const index = mapping.sourceOffsets.indexOf(start);
+				const generated_start = mapping.generatedOffsets[index];
+				const generated_length = mapping.generatedLengths?.[index] ?? mapping.lengths[index];
+				expect(
+					result.code
+						.slice(generated_start, generated_start + generated_length)
+						.replace(/\s+/g, ' '),
+				).toBe(source.slice(start, end).replace(/\s+/g, ' '));
+			},
+		);
+	});
+
 	describe(`[${name}] source mappings do not crash for`, () => {
 		/**
 		 * @param {string} source


### PR DESCRIPTION
## Summary

Move the two shared editor fixes currently carried in Octane’s `@tsrx/core` patch into their owning core package. Both failures reproduce through the React, Preact, Solid, and Vue tooling entry points on current main.

- Valid generic arrows such as `<Value extends { id: string }>` and `<Value = string>` no longer report a false trailing-comma diagnostic. A bare `<Value>` still receives the existing diagnostic, and `<Value,>` remains accepted.
- Destructuring defaults ending in a type assertion, such as `items = EMPTY_ARRAY as string[]`, retain the full diagnostic mapping. This fixes `No source map entry` failures, including multiline defaults.

The mapping change only adds boundary locations to the tooling printer. Add an `@tsrx/core` patch changeset and reusable regression coverage in the existing shared source-mapping harness, which runs against all four target compilers. Octane can drop its local patch after consuming the resulting release; its compiler integration checks can remain downstream.

## Validation

- Before the fixes: 16 new cases fail across all four targets; 8 control cases pass.
- After the fixes: all 24 new cases pass across React, Preact, Solid, and Vue.
- Full `pnpm test`: 92 files passed; 4,021 tests passed, 33 skipped.
- Production JavaScript and source maps are identical before/after for 12 cases across all four targets.
- `pnpm typecheck`
- Prettier check on all changed JavaScript files.
- `pnpm changeset:check`, `pnpm rules:check`, and `git diff --check`.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted parser and source-map printer tweaks with regression tests; no auth, data, or runtime behavior changes beyond editor diagnostics.
> 
> **Overview**
> Fixes two **shared `@tsrx/core` editor diagnostics** that affect React, Preact, Solid, Vue, and other consumers of the Volar mapping pipeline.
> 
> **Generic arrow functions:** `reportReservedArrowTypeParam` now only suggests a trailing comma when a single type parameter is **ambiguous** (no `extends` constraint, no default, no trailing comma). Forms like `<Value extends { id: string }>`, `<Value = string>`, and `<Value,>` compile without a false trailing-comma error; bare `<Value>` still gets the existing diagnostic.
> 
> **Typed destructuring defaults:** The JSX tooling printer wraps **`AssignmentPattern`** nodes with location markers (alongside exports and property signatures), so defaults such as `items = EMPTY_ARRAY as string[]` keep a single diagnostic span through the type assertion instead of losing mapping or crashing with “No source map entry”.
> 
> Adds an **`@tsrx/core` patch changeset** and **shared harness tests** in `source-mappings.js` that run across all target compilers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba61e65be298859213a6bb194da104fbdfa59373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->