### PR TITLE
feat(runtime): export property_is_enumerable

### DIFF
--- a/.changeset/export-property-is-enumerable.md
+++ b/.changeset/export-property-is-enumerable.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/runtime': patch
+---
+
+Export `property_is_enumerable` from the language helpers module.

--- a/packages/tsrx-runtime/src/language-helpers.js
+++ b/packages/tsrx-runtime/src/language-helpers.js
@@ -26,6 +26,8 @@ export var object_prototype = Object.prototype;
 export var array_prototype = Array.prototype;
 /** @type {typeof Object.prototype.hasOwnProperty} */
 export var has_own_property = object_prototype.hasOwnProperty;
+/** @type {typeof Object.prototype.propertyIsEnumerable} */
+export var property_is_enumerable = object_prototype.propertyIsEnumerable;
 
 /**
  * @param {object} value

--- a/packages/tsrx-runtime/types/language-helpers.d.ts
+++ b/packages/tsrx-runtime/types/language-helpers.d.ts
@@ -12,6 +12,7 @@ export const structured_clone: typeof structuredClone;
 export const object_prototype: typeof Object.prototype;
 export const array_prototype: typeof Array.prototype;
 export const has_own_property: typeof Object.prototype.hasOwnProperty;
+export const property_is_enumerable: typeof Object.prototype.propertyIsEnumerable;
 
 export function has_prototype_accessor(value: object, key: PropertyKey): boolean;
 export function array_slice<T>(array_like: ArrayLike<T>, ...args: number[]): T[];


### PR DESCRIPTION
## Summary

- export the cached Object.prototype.propertyIsEnumerable method from the language helpers module
- expose the matching TypeScript declaration
- add a patch changeset for @tsrx/runtime

## Testing

- pnpm test --project tsrx-utils packages/tsrx/tests/utils/language-helpers-runtime.test.js packages/tsrx/tests/utils/language-helpers-types.test.js
- pnpm exec tsgo --noEmit -p packages/tsrx-runtime/tsconfig.json
- pnpm changeset:check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive patch export with no behavior changes to existing code paths.
> 
> **Overview**
> **Adds a public `property_is_enumerable` helper** on `@tsrx/runtime`, following the same cached-`Object.prototype` pattern as `has_own_property`.
> 
> The runtime module now exports `object_prototype.propertyIsEnumerable`, and the matching declaration is added in `language-helpers.d.ts`. A patch changeset records the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 847018e02de6e17f6e0ee8c285712c1461abb1a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->