### PR TITLE
fix(prettier-plugin): keep the parentheses of an object destructuring assignment statement

### DIFF
--- a/.changeset/keep-object-pattern-assignment-parens.md
+++ b/.changeset/keep-object-pattern-assignment-parens.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/prettier-plugin': patch
+---
+
+Keep the parentheses of an object destructuring assignment used as a statement (`({ a } = obj);`), which the formatter dropped, turning the statement into a block.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -496,6 +496,11 @@ function assignmentExpressionNeedsParens(node, parent) {
 		return true;
 	}
 
+	// `({ a } = obj);` — without the parentheses the statement starts with a block.
+	if (parent.type === 'ExpressionStatement') {
+		return node.left.type === 'ObjectPattern';
+	}
+
 	if (parent.type === 'ConditionalExpression') {
 		return parent.test === node;
 	}

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -1610,6 +1610,34 @@ async function load() {
 			expect(result).toBeWithNewline(expected);
 		});
 
+		it('keeps the parentheses of an object destructuring assignment statement', async () => {
+			const input = `function swap() {
+  ({ other } = { other: 'y' });
+  [label] = ['b'];
+  ({ other } = source).other;
+}
+export function Pair() @{
+  const swap = () => {
+    ({ other } = { other: 'y' });
+  };
+  <span onClick={swap}>{other}</span>
+}`;
+			const expected = `function swap() {
+  ({ other } = { other: 'y' });
+  [label] = ['b'];
+  ({ other } = source).other;
+}
+export function Pair() @{
+  const swap = () => {
+    ({ other } = { other: 'y' });
+  };
+  <span onClick={swap}>{other}</span>
+}`;
+
+			const result = await format(input, { singleQuote: true });
+			expect(result).toBeWithNewline(expected);
+		});
+
 		it('should not change formatting for function object properties and properties in square brackets', async () => {
 			const expected = `export function App() {
   const SYMBOL_PROP = Symbol();


### PR DESCRIPTION
## Summary

- preserve required parentheses around object destructuring assignment statements
- cover regular functions and TSRX component callbacks while leaving array assignments and member access unchanged
- add a patch changeset for `@tsrx/prettier-plugin`

`({ a } = obj);` lost its parentheses because an ExpressionStatement parent
was not among the cases that preserve a parenthesized assignment, which
turned the statement into a block.

## Testing

- `pnpm test --project prettier-plugin` (477 tests passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted change to parenthesis preservation in the formatter with tests; no runtime or auth/data impact.
> 
> **Overview**
> Fixes a **syntax-breaking formatting bug** where the TSRX Prettier plugin stripped required parentheses from standalone object destructuring assignments like `({ other } = { other: 'y' });`. Without those parens, the statement begins with `{` and is parsed as a block instead of an assignment.
> 
> The printer now treats parenthesized assignment expressions whose left side is an **object pattern** and whose parent is an **expression statement** as needing preserved outer parentheses (same idea as existing rules for binary/logical parents). **Array** destructuring assignments and assignments used for **member access** (e.g. `({ other } = source).other`) are unchanged.
> 
> Adds regression coverage for plain functions and TSRX `@{ … }` component bodies, plus a patch changeset for `@tsrx/prettier-plugin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6992cc8b47c14742a2b207d2be40f524486557de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->