### PR TITLE
Add compile-time platform flags across TSRX builders

### DIFF
--- a/.changeset/tidy-platform-flags.md
+++ b/.changeset/tidy-platform-flags.md
@@ -22,4 +22,4 @@
 '@tsrx/vscode-plugin': patch
 ---
 
-Add validated web, iOS, and Android compile-time platform flags, early ordinary-if specialization for TSRX source and virtual TypeScript, and matching definitions across every in-repo Vite, Rspack, Turbopack, and Bun integration.
+Add validated web, iOS, and Android compile-time platform flags, early ordinary-if specialization for TSRX source and virtual TypeScript, automatic inherited-tsconfig resolution, and matching definitions across every in-repo Vite, Rspack, Turbopack, and Bun integration.

--- a/.changeset/tidy-platform-flags.md
+++ b/.changeset/tidy-platform-flags.md
@@ -1,0 +1,25 @@
+---
+'@tsrx/core': patch
+'@tsrx/react': patch
+'@tsrx/preact': patch
+'@tsrx/solid': patch
+'@tsrx/vue': patch
+'@tsrx/vite-plugin-react': patch
+'@tsrx/vite-plugin-preact': patch
+'@tsrx/vite-plugin-solid': patch
+'@tsrx/vite-plugin-vue': patch
+'@tsrx/rspack-plugin-react': patch
+'@tsrx/rspack-plugin-preact': patch
+'@tsrx/rspack-plugin-solid': patch
+'@tsrx/rspack-plugin-vue': patch
+'@tsrx/turbopack-plugin-react': patch
+'@tsrx/bun-plugin-react': patch
+'@tsrx/bun-plugin-preact': patch
+'@tsrx/bun-plugin-solid': patch
+'@tsrx/bun-plugin-vue': patch
+'@tsrx/typescript-plugin': patch
+'@tsrx/language-server': patch
+'@tsrx/vscode-plugin': patch
+---
+
+Add validated web, iOS, and Android compile-time platform flags, early ordinary-if specialization for TSRX source and virtual TypeScript, and matching definitions across every in-repo Vite, Rspack, Turbopack, and Bun integration.

--- a/.changeset/tidy-platform-flags.md
+++ b/.changeset/tidy-platform-flags.md
@@ -22,4 +22,4 @@
 '@tsrx/vscode-plugin': patch
 ---
 
-Add validated web, iOS, and Android compile-time platform flags, early ordinary-if specialization for TSRX source and virtual TypeScript, automatic inherited-tsconfig resolution, and matching definitions across every in-repo Vite, Rspack, Turbopack, and Bun integration, with conflict checks and chained source maps.
+Add validated web, iOS, and Android compile-time platform flags, early ordinary-if specialization for TSRX source and virtual TypeScript, automatic inherited/project-referenced tsconfig resolution, and matching definitions across every in-repo Vite, Rspack, Turbopack, and Bun integration, with conflict checks and chained source maps.

--- a/.changeset/tidy-platform-flags.md
+++ b/.changeset/tidy-platform-flags.md
@@ -22,4 +22,4 @@
 '@tsrx/vscode-plugin': patch
 ---
 
-Add validated web, iOS, and Android compile-time platform flags, early ordinary-if specialization for TSRX source and virtual TypeScript, automatic inherited-tsconfig resolution, and matching definitions across every in-repo Vite, Rspack, Turbopack, and Bun integration.
+Add validated web, iOS, and Android compile-time platform flags, early ordinary-if specialization for TSRX source and virtual TypeScript, automatic inherited-tsconfig resolution, and matching definitions across every in-repo Vite, Rspack, Turbopack, and Bun integration, with conflict checks and chained source maps.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ export function TodoList({ items }: { items: Todo[] }) @{
 
 - TypeScript-compatible `.tsrx` modules that interoperate with JavaScript,
   TypeScript, and TSX code.
+- Compile-time `import.meta.env.platform` guards for shared web, iOS, and Android
+  source.
 - JSX statement containers that keep setup and rendered output in one lexical
   scope.
 - Template-native `@if`, `@for`, `@switch`, and `@try` control flow.
@@ -114,6 +116,35 @@ Zed Extension Marketplace. The
 [TSRX plugin for JetBrains IDEs](https://plugins.jetbrains.com/plugin/33991-tsrx)
 has been submitted to JetBrains Marketplace and is under review. Integrations for
 Neovim and Sublime Text are also maintained here.
+
+## Platform-specific source
+
+Select `"web"`, `"ios"`, or `"android"` in the active TypeScript project and pass
+the same value to the target's build integration:
+
+```json
+{
+  "tsrx": {
+    "compiler": "@tsrx/react",
+    "platform": "ios"
+  }
+}
+```
+
+```ts
+tsrxReact({ platform: 'ios' });
+```
+
+All three exact flags are available: `import.meta.env.platform.web`, `.ios`, and
+`.android`. An ordinary `if` whose test is exactly one flag is selected before
+TSRX semantic analysis, CSS extraction, virtual TypeScript generation, and target
+lowering. This keeps inactive platform-only code, dynamic imports, and styles out
+of diagnostics and build output. Template `@if` remains runtime control flow; use
+an ordinary `if` when inactive content must be excluded early.
+
+There is no implicit web default. A recognized flag without a platform, or any
+platform value other than the three exact strings above, is an error. Keep the
+tsconfig and builder values identical.
 
 ## Learn and contribute
 

--- a/README.md
+++ b/README.md
@@ -119,8 +119,7 @@ Neovim and Sublime Text are also maintained here.
 
 ## Platform-specific source
 
-Select `"web"`, `"ios"`, or `"android"` in the active TypeScript project and pass
-the same value to the target's build integration:
+Select `"web"`, `"ios"`, or `"android"` in the active TypeScript project:
 
 ```json
 {
@@ -132,7 +131,7 @@ the same value to the target's build integration:
 ```
 
 ```ts
-tsrxReact({ platform: 'ios' });
+tsrxReact(); // reads tsrx.platform from the project tsconfig
 ```
 
 All three exact flags are available: `import.meta.env.platform.web`, `.ios`, and
@@ -143,8 +142,9 @@ of diagnostics and build output. Template `@if` remains runtime control flow; us
 an ordinary `if` when inactive content must be excluded early.
 
 There is no implicit web default. A recognized flag without a platform, or any
-platform value other than the three exact strings above, is an error. Keep the
-tsconfig and builder values identical.
+platform value other than the three exact strings above, is an error. An explicit
+builder `platform` option remains available as an override/fallback, but it must
+match tsconfig when both are present.
 
 ## Learn and contribute
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Select `"web"`, `"ios"`, or `"android"` in the active TypeScript project:
 ```
 
 ```ts
-tsrxReact(); // reads tsrx.platform from the project tsconfig
+tsrxReact(); // reads tsrx.platform through extends/project references
 ```
 
 All three exact flags are available: `import.meta.env.platform.web`, `.ios`, and

--- a/packages/bun-plugin-preact/README.md
+++ b/packages/bun-plugin-preact/README.md
@@ -17,7 +17,7 @@ await Bun.build({
   entrypoints: ['./src/App.tsrx'],
   outdir: './dist',
   target: 'browser',
-  plugins: [tsrxPreact({ platform: 'web' })],
+  plugins: [tsrxPreact()],
 });
 ```
 
@@ -39,9 +39,10 @@ Bun.plugin(tsrxPreact());
 - `suspenseSource`: module used by the compiler for Suspense imports.
 - `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
   standalone runtime imports).
-- `platform`: optional compile-time platform (`'web'`, `'ios'`, or `'android'`).
-  Set the same `tsrx.platform` value in the active tsconfig. For `Bun.build`, the
-  plugin defines all three exact flags and rejects conflicting definitions.
+- `platform`: optional override/fallback for the compile-time platform. Normally
+  the plugin reads `tsrx.platform` from Bun's selected/nearest tsconfig, including
+  `extends`. An override must match tsconfig. For `Bun.build`, all three exact
+  flags are defined and conflicting definitions are rejected.
 - `emitCss`: whether to emit virtual CSS imports (default: `true`).
 - `include`, `exclude`: regex filters for source files.
 

--- a/packages/bun-plugin-preact/README.md
+++ b/packages/bun-plugin-preact/README.md
@@ -17,7 +17,7 @@ await Bun.build({
   entrypoints: ['./src/App.tsrx'],
   outdir: './dist',
   target: 'browser',
-  plugins: [tsrxPreact()],
+  plugins: [tsrxPreact({ platform: 'web' })],
 });
 ```
 
@@ -39,6 +39,9 @@ Bun.plugin(tsrxPreact());
 - `suspenseSource`: module used by the compiler for Suspense imports.
 - `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
   standalone runtime imports).
+- `platform`: optional compile-time platform (`'web'`, `'ios'`, or `'android'`).
+  Set the same `tsrx.platform` value in the active tsconfig. For `Bun.build`, the
+  plugin defines all three exact flags and rejects conflicting definitions.
 - `emitCss`: whether to emit virtual CSS imports (default: `true`).
 - `include`, `exclude`: regex filters for source files.
 

--- a/packages/bun-plugin-preact/package.json
+++ b/packages/bun-plugin-preact/package.json
@@ -23,6 +23,7 @@
     "test": "pnpm -w test --project bun-plugin-preact"
   },
   "dependencies": {
+    "@tsrx/core": "workspace:*",
     "@tsrx/preact": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/bun-plugin-preact/src/index.js
+++ b/packages/bun-plugin-preact/src/index.js
@@ -1,8 +1,8 @@
 /** @import { BunPlugin, Target, Transpiler } from 'bun' */
-/** @import { RuntimeImportMode } from '@tsrx/preact' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/preact' */
 
 import { readFile } from 'node:fs/promises';
-import { compile } from '@tsrx/preact';
+import { compile, mergePlatformDefinitions, validatePlatform } from '@tsrx/preact';
 
 const DEFAULT_INCLUDE = /\.tsrx$/;
 const CSS_QUERY = '?tsrx-css&lang.css';
@@ -15,6 +15,7 @@ const CSS_QUERY_PATTERN = /\?tsrx-css&lang\.css$/;
  * 	jsxImportSource?: string,
  * 	suspenseSource?: string,
  * 	runtimeImports?: RuntimeImportMode,
+ * 	platform?: Platform,
  * 	emitCss?: boolean,
  * }} TsrxPreactBunPluginOptions
  */
@@ -91,11 +92,13 @@ function create_transpiler(jsx_import_source, target) {
  * @returns {BunPlugin}
  */
 export function tsrxPreact(options = {}) {
+	const platform = validatePlatform(options.platform);
 	const jsx_import_source = options.jsxImportSource ?? 'preact';
 	const emit_css = options.emitCss ?? true;
 	const compile_options = {
 		suspenseSource: options.suspenseSource,
 		runtimeImports: options.runtimeImports,
+		platform,
 	};
 
 	/** @type {Map<string, string>} */
@@ -108,6 +111,14 @@ export function tsrxPreact(options = {}) {
 			// build.config is only present for Bun.build(); runtime registration
 			// via Bun.plugin(), including bun:test preloads, does not provide it.
 			const build_config = build.config ?? {};
+			if (platform !== undefined && build.config) {
+				build.config.define = /** @type {Record<string, string>} */ (
+					mergePlatformDefinitions(build.config.define, platform, {
+						integration: 'Bun',
+						serialize: true,
+					})
+				);
+			}
 			const transpiler = create_transpiler(jsx_import_source, build_config.target);
 
 			build.onResolve({ filter: CSS_QUERY_PATTERN }, (args) => ({

--- a/packages/bun-plugin-preact/src/index.js
+++ b/packages/bun-plugin-preact/src/index.js
@@ -2,7 +2,9 @@
 /** @import { Platform, RuntimeImportMode } from '@tsrx/preact' */
 
 import { readFile } from 'node:fs/promises';
-import { compile, mergePlatformDefinitions, validatePlatform } from '@tsrx/preact';
+import { compile } from '@tsrx/preact';
+import { mergePlatformDefinitions, validatePlatform } from '@tsrx/core';
+import { resolveBuildPlatform } from '@tsrx/core/config';
 
 const DEFAULT_INCLUDE = /\.tsrx$/;
 const CSS_QUERY = '?tsrx-css&lang.css';
@@ -92,14 +94,9 @@ function create_transpiler(jsx_import_source, target) {
  * @returns {BunPlugin}
  */
 export function tsrxPreact(options = {}) {
-	const platform = validatePlatform(options.platform);
+	const explicit_platform = validatePlatform(options.platform);
 	const jsx_import_source = options.jsxImportSource ?? 'preact';
 	const emit_css = options.emitCss ?? true;
-	const compile_options = {
-		suspenseSource: options.suspenseSource,
-		runtimeImports: options.runtimeImports,
-		platform,
-	};
 
 	/** @type {Map<string, string>} */
 	const css_cache = new Map();
@@ -111,6 +108,17 @@ export function tsrxPreact(options = {}) {
 			// build.config is only present for Bun.build(); runtime registration
 			// via Bun.plugin(), including bun:test preloads, does not provide it.
 			const build_config = build.config ?? {};
+			const platform = resolveBuildPlatform({
+				root: build_config.root ?? process.cwd(),
+				tsconfig: typeof build_config.tsconfig === 'string' ? build_config.tsconfig : undefined,
+				platform: explicit_platform,
+				integration: '@tsrx/bun-plugin-preact',
+			});
+			const compile_options = {
+				suspenseSource: options.suspenseSource,
+				runtimeImports: options.runtimeImports,
+				platform,
+			};
 			if (platform !== undefined && build.config) {
 				build.config.define = /** @type {Record<string, string>} */ (
 					mergePlatformDefinitions(build.config.define, platform, {

--- a/packages/bun-plugin-preact/types/index.d.ts
+++ b/packages/bun-plugin-preact/types/index.d.ts
@@ -8,7 +8,7 @@ export interface TsrxPreactBunPluginOptions {
 	suspenseSource?: string;
 	/** Direct mode requires `@tsrx/preact-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
-	/** Must match `tsrx.platform` in the active tsconfig. */
+	/** Optional override; inferred from tsconfig by default and must agree when both exist. */
 	platform?: Platform;
 	emitCss?: boolean;
 }

--- a/packages/bun-plugin-preact/types/index.d.ts
+++ b/packages/bun-plugin-preact/types/index.d.ts
@@ -1,5 +1,5 @@
 import type { BunPlugin } from 'bun';
-import type { RuntimeImportMode } from '@tsrx/preact';
+import type { Platform, RuntimeImportMode } from '@tsrx/preact';
 
 export interface TsrxPreactBunPluginOptions {
 	include?: RegExp;
@@ -8,6 +8,8 @@ export interface TsrxPreactBunPluginOptions {
 	suspenseSource?: string;
 	/** Direct mode requires `@tsrx/preact-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
+	/** Must match `tsrx.platform` in the active tsconfig. */
+	platform?: Platform;
 	emitCss?: boolean;
 }
 

--- a/packages/bun-plugin-react/README.md
+++ b/packages/bun-plugin-react/README.md
@@ -17,7 +17,7 @@ await Bun.build({
   entrypoints: ['./src/App.tsrx'],
   outdir: './dist',
   target: 'browser',
-  plugins: [tsrxReact()],
+  plugins: [tsrxReact({ platform: 'web' })],
 });
 ```
 
@@ -38,6 +38,9 @@ Bun.plugin(tsrxReact());
 - `jsxImportSource`: automatic JSX runtime import source (default: `'react'`).
 - `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
   standalone runtime imports).
+- `platform`: optional compile-time platform (`'web'`, `'ios'`, or `'android'`).
+  Set the same `tsrx.platform` value in the active tsconfig. For `Bun.build`, the
+  plugin defines all three exact flags and rejects conflicting definitions.
 - `emitCss`: whether to emit virtual CSS imports (default: `true`).
 - `include`, `exclude`: regex filters for source files.
 

--- a/packages/bun-plugin-react/README.md
+++ b/packages/bun-plugin-react/README.md
@@ -17,7 +17,7 @@ await Bun.build({
   entrypoints: ['./src/App.tsrx'],
   outdir: './dist',
   target: 'browser',
-  plugins: [tsrxReact({ platform: 'web' })],
+  plugins: [tsrxReact()],
 });
 ```
 
@@ -38,9 +38,10 @@ Bun.plugin(tsrxReact());
 - `jsxImportSource`: automatic JSX runtime import source (default: `'react'`).
 - `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
   standalone runtime imports).
-- `platform`: optional compile-time platform (`'web'`, `'ios'`, or `'android'`).
-  Set the same `tsrx.platform` value in the active tsconfig. For `Bun.build`, the
-  plugin defines all three exact flags and rejects conflicting definitions.
+- `platform`: optional override/fallback for the compile-time platform. Normally
+  the plugin reads `tsrx.platform` from Bun's selected/nearest tsconfig, including
+  `extends`. An override must match tsconfig. For `Bun.build`, all three exact
+  flags are defined and conflicting definitions are rejected.
 - `emitCss`: whether to emit virtual CSS imports (default: `true`).
 - `include`, `exclude`: regex filters for source files.
 

--- a/packages/bun-plugin-react/package.json
+++ b/packages/bun-plugin-react/package.json
@@ -23,6 +23,7 @@
     "test": "pnpm -w test --project bun-plugin-react"
   },
   "dependencies": {
+    "@tsrx/core": "workspace:*",
     "@tsrx/react": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/bun-plugin-react/src/index.js
+++ b/packages/bun-plugin-react/src/index.js
@@ -2,7 +2,9 @@
 /** @import { Platform, RuntimeImportMode } from '@tsrx/react' */
 
 import { readFile } from 'node:fs/promises';
-import { compile, mergePlatformDefinitions, validatePlatform } from '@tsrx/react';
+import { compile } from '@tsrx/react';
+import { mergePlatformDefinitions, validatePlatform } from '@tsrx/core';
+import { resolveBuildPlatform } from '@tsrx/core/config';
 
 const DEFAULT_INCLUDE = /\.tsrx$/;
 const CSS_QUERY = '?tsrx-css&lang.css';
@@ -91,10 +93,9 @@ function create_transpiler(jsx_import_source, target) {
  * @returns {BunPlugin}
  */
 export function tsrxReact(options = {}) {
-	const platform = validatePlatform(options.platform);
+	const explicit_platform = validatePlatform(options.platform);
 	const jsx_import_source = options.jsxImportSource ?? 'react';
 	const emit_css = options.emitCss ?? true;
-	const compile_options = { runtimeImports: options.runtimeImports, platform };
 
 	/** @type {Map<string, string>} */
 	const css_cache = new Map();
@@ -106,6 +107,13 @@ export function tsrxReact(options = {}) {
 			// build.config is only present for Bun.build(); runtime registration
 			// via Bun.plugin(), including bun:test preloads, does not provide it.
 			const build_config = build.config ?? {};
+			const platform = resolveBuildPlatform({
+				root: build_config.root ?? process.cwd(),
+				tsconfig: typeof build_config.tsconfig === 'string' ? build_config.tsconfig : undefined,
+				platform: explicit_platform,
+				integration: '@tsrx/bun-plugin-react',
+			});
+			const compile_options = { runtimeImports: options.runtimeImports, platform };
 			if (platform !== undefined && build.config) {
 				build.config.define = /** @type {Record<string, string>} */ (
 					mergePlatformDefinitions(build.config.define, platform, {

--- a/packages/bun-plugin-react/src/index.js
+++ b/packages/bun-plugin-react/src/index.js
@@ -1,8 +1,8 @@
 /** @import { BunPlugin, Target, Transpiler } from 'bun' */
-/** @import { RuntimeImportMode } from '@tsrx/react' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/react' */
 
 import { readFile } from 'node:fs/promises';
-import { compile } from '@tsrx/react';
+import { compile, mergePlatformDefinitions, validatePlatform } from '@tsrx/react';
 
 const DEFAULT_INCLUDE = /\.tsrx$/;
 const CSS_QUERY = '?tsrx-css&lang.css';
@@ -15,6 +15,7 @@ const CSS_QUERY_PATTERN = /\?tsrx-css&lang\.css$/;
  * 	jsxImportSource?: string,
  * 	emitCss?: boolean,
  * 	runtimeImports?: RuntimeImportMode,
+ * 	platform?: Platform,
  * }} TsrxReactBunPluginOptions
  */
 
@@ -90,9 +91,10 @@ function create_transpiler(jsx_import_source, target) {
  * @returns {BunPlugin}
  */
 export function tsrxReact(options = {}) {
+	const platform = validatePlatform(options.platform);
 	const jsx_import_source = options.jsxImportSource ?? 'react';
 	const emit_css = options.emitCss ?? true;
-	const compile_options = { runtimeImports: options.runtimeImports };
+	const compile_options = { runtimeImports: options.runtimeImports, platform };
 
 	/** @type {Map<string, string>} */
 	const css_cache = new Map();
@@ -104,6 +106,14 @@ export function tsrxReact(options = {}) {
 			// build.config is only present for Bun.build(); runtime registration
 			// via Bun.plugin(), including bun:test preloads, does not provide it.
 			const build_config = build.config ?? {};
+			if (platform !== undefined && build.config) {
+				build.config.define = /** @type {Record<string, string>} */ (
+					mergePlatformDefinitions(build.config.define, platform, {
+						integration: 'Bun',
+						serialize: true,
+					})
+				);
+			}
 			const transpiler = create_transpiler(jsx_import_source, build_config.target);
 
 			build.onResolve({ filter: CSS_QUERY_PATTERN }, (args) => ({

--- a/packages/bun-plugin-react/types/index.d.ts
+++ b/packages/bun-plugin-react/types/index.d.ts
@@ -4,7 +4,7 @@ import type { Platform, RuntimeImportMode } from '@tsrx/react';
 export interface TsrxReactBunPluginOptions {
 	/** Direct mode requires `@tsrx/react-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
-	/** Must match `tsrx.platform` in the active tsconfig. */
+	/** Optional override; inferred from tsconfig by default and must agree when both exist. */
 	platform?: Platform;
 	include?: RegExp;
 	exclude?: RegExp | RegExp[];

--- a/packages/bun-plugin-react/types/index.d.ts
+++ b/packages/bun-plugin-react/types/index.d.ts
@@ -1,9 +1,11 @@
 import type { BunPlugin } from 'bun';
-import type { RuntimeImportMode } from '@tsrx/react';
+import type { Platform, RuntimeImportMode } from '@tsrx/react';
 
 export interface TsrxReactBunPluginOptions {
 	/** Direct mode requires `@tsrx/react-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
+	/** Must match `tsrx.platform` in the active tsconfig. */
+	platform?: Platform;
 	include?: RegExp;
 	exclude?: RegExp | RegExp[];
 	jsxImportSource?: string;

--- a/packages/bun-plugin-solid/README.md
+++ b/packages/bun-plugin-solid/README.md
@@ -18,7 +18,7 @@ await Bun.build({
   entrypoints: ['./src/App.tsrx'],
   outdir: './dist',
   target: 'browser',
-  plugins: [tsrxSolid()],
+  plugins: [tsrxSolid({ platform: 'web' })],
 });
 ```
 
@@ -39,6 +39,9 @@ Bun.plugin(tsrxSolid());
 - `solid`: options forwarded to `babel-preset-solid`.
 - `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
   standalone runtime imports).
+- `platform`: optional compile-time platform (`'web'`, `'ios'`, or `'android'`).
+  Set the same `tsrx.platform` value in the active tsconfig. For `Bun.build`, the
+  plugin defines all three exact flags and rejects conflicting definitions.
 - `emitCss`: whether to emit virtual CSS imports (default: `true`).
 - `include`, `exclude`: regex filters for source files.
 

--- a/packages/bun-plugin-solid/README.md
+++ b/packages/bun-plugin-solid/README.md
@@ -18,7 +18,7 @@ await Bun.build({
   entrypoints: ['./src/App.tsrx'],
   outdir: './dist',
   target: 'browser',
-  plugins: [tsrxSolid({ platform: 'web' })],
+  plugins: [tsrxSolid()],
 });
 ```
 
@@ -39,9 +39,10 @@ Bun.plugin(tsrxSolid());
 - `solid`: options forwarded to `babel-preset-solid`.
 - `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
   standalone runtime imports).
-- `platform`: optional compile-time platform (`'web'`, `'ios'`, or `'android'`).
-  Set the same `tsrx.platform` value in the active tsconfig. For `Bun.build`, the
-  plugin defines all three exact flags and rejects conflicting definitions.
+- `platform`: optional override/fallback for the compile-time platform. Normally
+  the plugin reads `tsrx.platform` from Bun's selected/nearest tsconfig, including
+  `extends`. An override must match tsconfig. For `Bun.build`, all three exact
+  flags are defined and conflicting definitions are rejected.
 - `emitCss`: whether to emit virtual CSS imports (default: `true`).
 - `include`, `exclude`: regex filters for source files.
 

--- a/packages/bun-plugin-solid/package.json
+++ b/packages/bun-plugin-solid/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@babel/core": "catalog:default",
     "@babel/preset-typescript": "catalog:default",
+    "@tsrx/core": "workspace:*",
     "@tsrx/solid": "workspace:*",
     "babel-preset-solid": "catalog:default"
   },

--- a/packages/bun-plugin-solid/src/index.js
+++ b/packages/bun-plugin-solid/src/index.js
@@ -1,9 +1,9 @@
 /** @import { BunPlugin } from 'bun' */
-/** @import { RuntimeImportMode } from '@tsrx/solid' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/solid' */
 
 import { readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { compile } from '@tsrx/solid';
+import { compile, mergePlatformDefinitions, validatePlatform } from '@tsrx/solid';
 
 const require = createRequire(import.meta.url);
 const { transformAsync } = require('@babel/core');
@@ -21,6 +21,7 @@ const CSS_QUERY_PATTERN = /\?tsrx-css&lang\.css$/;
  * 	emitCss?: boolean,
  * 	solid?: object,
  * 	runtimeImports?: RuntimeImportMode,
+ * 	platform?: Platform,
  * }} TsrxSolidBunPluginOptions
  */
 
@@ -100,8 +101,9 @@ async function transform_solid(source, file_path, solid_options) {
  * @returns {BunPlugin}
  */
 export function tsrxSolid(options = {}) {
+	const platform = validatePlatform(options.platform);
 	const emit_css = options.emitCss ?? true;
-	const compile_options = { runtimeImports: options.runtimeImports };
+	const compile_options = { runtimeImports: options.runtimeImports, platform };
 
 	/** @type {Map<string, string>} */
 	const css_cache = new Map();
@@ -110,6 +112,14 @@ export function tsrxSolid(options = {}) {
 		name: '@tsrx/bun-plugin-solid',
 
 		setup(build) {
+			if (platform !== undefined && build.config) {
+				build.config.define = /** @type {Record<string, string>} */ (
+					mergePlatformDefinitions(build.config.define, platform, {
+						integration: 'Bun',
+						serialize: true,
+					})
+				);
+			}
 			build.onResolve({ filter: CSS_QUERY_PATTERN }, (args) => ({
 				path: args.path,
 			}));

--- a/packages/bun-plugin-solid/src/index.js
+++ b/packages/bun-plugin-solid/src/index.js
@@ -3,7 +3,9 @@
 
 import { readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { compile, mergePlatformDefinitions, validatePlatform } from '@tsrx/solid';
+import { compile } from '@tsrx/solid';
+import { mergePlatformDefinitions, validatePlatform } from '@tsrx/core';
+import { resolveBuildPlatform } from '@tsrx/core/config';
 
 const require = createRequire(import.meta.url);
 const { transformAsync } = require('@babel/core');
@@ -101,9 +103,8 @@ async function transform_solid(source, file_path, solid_options) {
  * @returns {BunPlugin}
  */
 export function tsrxSolid(options = {}) {
-	const platform = validatePlatform(options.platform);
+	const explicit_platform = validatePlatform(options.platform);
 	const emit_css = options.emitCss ?? true;
-	const compile_options = { runtimeImports: options.runtimeImports, platform };
 
 	/** @type {Map<string, string>} */
 	const css_cache = new Map();
@@ -112,6 +113,14 @@ export function tsrxSolid(options = {}) {
 		name: '@tsrx/bun-plugin-solid',
 
 		setup(build) {
+			const build_config = build.config ?? {};
+			const platform = resolveBuildPlatform({
+				root: build_config.root ?? process.cwd(),
+				tsconfig: typeof build_config.tsconfig === 'string' ? build_config.tsconfig : undefined,
+				platform: explicit_platform,
+				integration: '@tsrx/bun-plugin-solid',
+			});
+			const compile_options = { runtimeImports: options.runtimeImports, platform };
 			if (platform !== undefined && build.config) {
 				build.config.define = /** @type {Record<string, string>} */ (
 					mergePlatformDefinitions(build.config.define, platform, {

--- a/packages/bun-plugin-solid/types/index.d.ts
+++ b/packages/bun-plugin-solid/types/index.d.ts
@@ -4,7 +4,7 @@ import type { Platform, RuntimeImportMode } from '@tsrx/solid';
 export interface TsrxSolidBunPluginOptions {
 	/** Direct mode requires `@tsrx/solid-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
-	/** Must match `tsrx.platform` in the active tsconfig. */
+	/** Optional override; inferred from tsconfig by default and must agree when both exist. */
 	platform?: Platform;
 	include?: RegExp;
 	exclude?: RegExp | RegExp[];

--- a/packages/bun-plugin-solid/types/index.d.ts
+++ b/packages/bun-plugin-solid/types/index.d.ts
@@ -1,9 +1,11 @@
 import type { BunPlugin } from 'bun';
-import type { RuntimeImportMode } from '@tsrx/solid';
+import type { Platform, RuntimeImportMode } from '@tsrx/solid';
 
 export interface TsrxSolidBunPluginOptions {
 	/** Direct mode requires `@tsrx/solid-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
+	/** Must match `tsrx.platform` in the active tsconfig. */
+	platform?: Platform;
 	include?: RegExp;
 	exclude?: RegExp | RegExp[];
 	emitCss?: boolean;

--- a/packages/bun-plugin-vue/README.md
+++ b/packages/bun-plugin-vue/README.md
@@ -17,7 +17,7 @@ await Bun.build({
   entrypoints: ['./src/App.tsrx'],
   outdir: './dist',
   target: 'browser',
-  plugins: [tsrxVue()],
+  plugins: [tsrxVue({ platform: 'web' })],
 });
 ```
 
@@ -39,6 +39,9 @@ Bun.plugin(tsrxVue());
 - `vapor`: options forwarded to `vue-jsx-vapor`.
 - `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
   standalone runtime imports).
+- `platform`: optional compile-time platform (`'web'`, `'ios'`, or `'android'`).
+  Set the same `tsrx.platform` value in the active tsconfig. For `Bun.build`, the
+  plugin defines all three exact flags and rejects conflicting definitions.
 - `emitCss`: whether to emit virtual CSS imports (default: `true`).
 - `include`, `exclude`: regex filters for source files.
 

--- a/packages/bun-plugin-vue/README.md
+++ b/packages/bun-plugin-vue/README.md
@@ -17,7 +17,7 @@ await Bun.build({
   entrypoints: ['./src/App.tsrx'],
   outdir: './dist',
   target: 'browser',
-  plugins: [tsrxVue({ platform: 'web' })],
+  plugins: [tsrxVue()],
 });
 ```
 
@@ -39,9 +39,10 @@ Bun.plugin(tsrxVue());
 - `vapor`: options forwarded to `vue-jsx-vapor`.
 - `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
   standalone runtime imports).
-- `platform`: optional compile-time platform (`'web'`, `'ios'`, or `'android'`).
-  Set the same `tsrx.platform` value in the active tsconfig. For `Bun.build`, the
-  plugin defines all three exact flags and rejects conflicting definitions.
+- `platform`: optional override/fallback for the compile-time platform. Normally
+  the plugin reads `tsrx.platform` from Bun's selected/nearest tsconfig, including
+  `extends`. An override must match tsconfig. For `Bun.build`, all three exact
+  flags are defined and conflicting definitions are rejected.
 - `emitCss`: whether to emit virtual CSS imports (default: `true`).
 - `include`, `exclude`: regex filters for source files.
 

--- a/packages/bun-plugin-vue/package.json
+++ b/packages/bun-plugin-vue/package.json
@@ -23,6 +23,7 @@
     "test": "pnpm -w test --project bun-plugin-vue"
   },
   "dependencies": {
+    "@tsrx/core": "workspace:*",
     "@tsrx/vue": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/bun-plugin-vue/src/index.js
+++ b/packages/bun-plugin-vue/src/index.js
@@ -3,7 +3,9 @@
 
 import { readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { compile, mergePlatformDefinitions, validatePlatform } from '@tsrx/vue';
+import { compile } from '@tsrx/vue';
+import { mergePlatformDefinitions, validatePlatform } from '@tsrx/core';
+import { resolveBuildPlatform } from '@tsrx/core/config';
 import { addVaporInteropToCreateVaporApp } from '@tsrx/vue/interop';
 
 const require = createRequire(import.meta.url);
@@ -129,10 +131,9 @@ function resolve_vapor_options(options) {
  * @returns {BunPlugin}
  */
 export function tsrxVue(options = {}) {
-	const platform = validatePlatform(options.platform);
+	const explicit_platform = validatePlatform(options.platform);
 	const emit_css = options.emitCss ?? true;
 	const vapor_options = resolve_vapor_options(options.vapor);
-	const compile_options = { runtimeImports: options.runtimeImports, platform };
 
 	/** @type {Map<string, string>} */
 	const css_cache = new Map();
@@ -144,6 +145,13 @@ export function tsrxVue(options = {}) {
 			// build.config is only present for Bun.build(); runtime registration
 			// via Bun.plugin(), including bun:test preloads, does not provide it.
 			const build_config = build.config ?? {};
+			const platform = resolveBuildPlatform({
+				root: build_config.root ?? process.cwd(),
+				tsconfig: typeof build_config.tsconfig === 'string' ? build_config.tsconfig : undefined,
+				platform: explicit_platform,
+				integration: '@tsrx/bun-plugin-vue',
+			});
+			const compile_options = { runtimeImports: options.runtimeImports, platform };
 			if (platform !== undefined && build.config) {
 				build.config.define = /** @type {Record<string, string>} */ (
 					mergePlatformDefinitions(build.config.define, platform, {

--- a/packages/bun-plugin-vue/src/index.js
+++ b/packages/bun-plugin-vue/src/index.js
@@ -1,9 +1,9 @@
 /** @import { BunPlugin, Target, Transpiler } from 'bun' */
-/** @import { RuntimeImportMode } from '@tsrx/vue' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/vue' */
 
 import { readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { compile } from '@tsrx/vue';
+import { compile, mergePlatformDefinitions, validatePlatform } from '@tsrx/vue';
 import { addVaporInteropToCreateVaporApp } from '@tsrx/vue/interop';
 
 const require = createRequire(import.meta.url);
@@ -27,6 +27,7 @@ const DEFAULT_VAPOR_OPTIONS = {
  * 	exclude?: RegExp | RegExp[],
  * 	emitCss?: boolean,
  * 	runtimeImports?: RuntimeImportMode,
+ * 	platform?: Platform,
  * 	vapor?: {
  * 		macros?: boolean | object,
  * 		compiler?: { runtimeModuleName?: string },
@@ -128,9 +129,10 @@ function resolve_vapor_options(options) {
  * @returns {BunPlugin}
  */
 export function tsrxVue(options = {}) {
+	const platform = validatePlatform(options.platform);
 	const emit_css = options.emitCss ?? true;
 	const vapor_options = resolve_vapor_options(options.vapor);
-	const compile_options = { runtimeImports: options.runtimeImports };
+	const compile_options = { runtimeImports: options.runtimeImports, platform };
 
 	/** @type {Map<string, string>} */
 	const css_cache = new Map();
@@ -142,6 +144,14 @@ export function tsrxVue(options = {}) {
 			// build.config is only present for Bun.build(); runtime registration
 			// via Bun.plugin(), including bun:test preloads, does not provide it.
 			const build_config = build.config ?? {};
+			if (platform !== undefined && build.config) {
+				build.config.define = /** @type {Record<string, string>} */ (
+					mergePlatformDefinitions(build.config.define, platform, {
+						integration: 'Bun',
+						serialize: true,
+					})
+				);
+			}
 			const transpiler = create_transpiler(build_config.target);
 
 			build.onResolve({ filter: CSS_QUERY_PATTERN }, (args) => ({

--- a/packages/bun-plugin-vue/types/index.d.ts
+++ b/packages/bun-plugin-vue/types/index.d.ts
@@ -11,7 +11,7 @@ export interface TsrxVueBunPluginVaporOptions {
 export interface TsrxVueBunPluginOptions {
 	/** Direct mode requires `@tsrx/vue-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
-	/** Must match `tsrx.platform` in the active tsconfig. */
+	/** Optional override; inferred from tsconfig by default and must agree when both exist. */
 	platform?: Platform;
 	include?: RegExp;
 	exclude?: RegExp | RegExp[];

--- a/packages/bun-plugin-vue/types/index.d.ts
+++ b/packages/bun-plugin-vue/types/index.d.ts
@@ -1,5 +1,5 @@
 import type { BunPlugin } from 'bun';
-import type { RuntimeImportMode } from '@tsrx/vue';
+import type { Platform, RuntimeImportMode } from '@tsrx/vue';
 
 export interface TsrxVueBunPluginVaporOptions {
 	macros?: boolean | object;
@@ -11,6 +11,8 @@ export interface TsrxVueBunPluginVaporOptions {
 export interface TsrxVueBunPluginOptions {
 	/** Direct mode requires `@tsrx/vue-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
+	/** Must match `tsrx.platform` in the active tsconfig. */
+	platform?: Platform;
 	include?: RegExp;
 	exclude?: RegExp | RegExp[];
 	emitCss?: boolean;

--- a/packages/rspack-plugin-preact/README.md
+++ b/packages/rspack-plugin-preact/README.md
@@ -14,7 +14,7 @@ pnpm add -D @tsrx/rspack-plugin-preact
 import { TsrxPreactRspackPlugin } from '@tsrx/rspack-plugin-preact';
 
 export default {
-  plugins: [new TsrxPreactRspackPlugin({ platform: 'web' })],
+  plugins: [new TsrxPreactRspackPlugin()],
 };
 ```
 
@@ -33,9 +33,10 @@ when unset.
   `'preact/compat'`).
 - `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
   standalone runtime imports).
-- `platform`: optional compile-time platform (`'web'`, `'ios'`, or `'android'`).
-  Set the same `tsrx.platform` value in the active tsconfig. The plugin defines
-  all three exact flags and rejects conflicting Rspack definitions.
+- `platform`: optional override/fallback for the compile-time platform. Normally
+  the plugin reads `tsrx.platform` from the project tsconfig (including
+  `resolve.tsConfig` and `extends`). An override must match tsconfig. The plugin
+  defines all three exact flags and rejects conflicting Rspack definitions.
 
 When using `runtimeImports: 'direct'`, install the runtime as a direct production
 dependency of the package that owns the compiled modules:

--- a/packages/rspack-plugin-preact/README.md
+++ b/packages/rspack-plugin-preact/README.md
@@ -14,7 +14,7 @@ pnpm add -D @tsrx/rspack-plugin-preact
 import { TsrxPreactRspackPlugin } from '@tsrx/rspack-plugin-preact';
 
 export default {
-  plugins: [new TsrxPreactRspackPlugin()],
+  plugins: [new TsrxPreactRspackPlugin({ platform: 'web' })],
 };
 ```
 
@@ -33,6 +33,9 @@ when unset.
   `'preact/compat'`).
 - `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
   standalone runtime imports).
+- `platform`: optional compile-time platform (`'web'`, `'ios'`, or `'android'`).
+  Set the same `tsrx.platform` value in the active tsconfig. The plugin defines
+  all three exact flags and rejects conflicting Rspack definitions.
 
 When using `runtimeImports: 'direct'`, install the runtime as a direct production
 dependency of the package that owns the compiled modules:

--- a/packages/rspack-plugin-preact/package.json
+++ b/packages/rspack-plugin-preact/package.json
@@ -20,6 +20,7 @@
     }
   },
   "dependencies": {
+    "@tsrx/core": "workspace:*",
     "@tsrx/preact": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/rspack-plugin-preact/src/css-loader.js
+++ b/packages/rspack-plugin-preact/src/css-loader.js
@@ -1,6 +1,6 @@
 /** @import { LoaderContext } from '@rspack/core' */
 
-/** @import { RuntimeImportMode } from '@tsrx/preact' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/preact' */
 
 import { compile } from '@tsrx/preact';
 
@@ -9,7 +9,7 @@ import { compile } from '@tsrx/preact';
  * the scoped CSS emitted by its `<style>` block. Invoked when rspack resolves
  * the sibling `?tsrx-css&lang.css` import emitted by the JS loader.
  *
- * @this {LoaderContext<{ suspenseSource?: string, runtimeImports?: RuntimeImportMode }>}
+ * @this {LoaderContext<{ suspenseSource?: string, runtimeImports?: RuntimeImportMode, platform?: Platform }>}
  * @param {string} source
  * @returns {void}
  */

--- a/packages/rspack-plugin-preact/src/index.js
+++ b/packages/rspack-plugin-preact/src/index.js
@@ -1,8 +1,13 @@
 /** @import { Compiler, RspackPluginInstance } from '@rspack/core' */
-/** @import { RuntimeImportMode } from '@tsrx/preact' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/preact' */
 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+	createPlatformDefinitions,
+	mergePlatformDefinitions,
+	validatePlatform,
+} from '@tsrx/preact';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -12,6 +17,24 @@ const CSS_LOADER = path.join(__dirname, 'css-loader.js');
 
 const TSRX_EXTENSION_PATTERN = /\.tsrx$/;
 const CSS_QUERY_PATTERN = /tsrx-css/;
+
+/** @param {Compiler} compiler @param {Platform | undefined} platform */
+function apply_platform_definitions(compiler, platform) {
+	if (platform === undefined) return;
+	const compiler_with_definitions = /** @type {any} */ (compiler);
+	for (const plugin of compiler_with_definitions.options.plugins ?? []) {
+		if (plugin?.name !== 'DefinePlugin' || !Array.isArray(plugin._args)) continue;
+		const definitions = plugin._args[0];
+		if (definitions && typeof definitions === 'object') {
+			mergePlatformDefinitions(definitions, platform, { integration: 'Rspack' });
+		}
+	}
+	const DefinePlugin = compiler_with_definitions.webpack?.DefinePlugin;
+	if (typeof DefinePlugin !== 'function') {
+		throw new Error('Rspack compiler does not expose DefinePlugin for TSRX platform flags.');
+	}
+	new DefinePlugin(createPlatformDefinitions(platform)).apply(compiler);
+}
 
 /**
  * Rspack plugin for `.tsrx` files that compiles them via `@tsrx/preact` and
@@ -24,13 +47,14 @@ const CSS_QUERY_PATTERN = /tsrx-css/;
  */
 export class TsrxPreactRspackPlugin {
 	/**
-	 * @param {{ jsxImportSource?: string, suspenseSource?: string, runtimeImports?: RuntimeImportMode }} [options]
+	 * @param {{ jsxImportSource?: string, suspenseSource?: string, runtimeImports?: RuntimeImportMode, platform?: Platform }} [options]
 	 */
 	constructor(options = {}) {
 		this.options = {
 			jsxImportSource: options.jsxImportSource ?? 'preact',
 			suspenseSource: options.suspenseSource,
 			runtimeImports: options.runtimeImports ?? 'compiler',
+			platform: validatePlatform(options.platform),
 		};
 	}
 
@@ -40,6 +64,7 @@ export class TsrxPreactRspackPlugin {
 	 */
 	apply(compiler) {
 		const { jsxImportSource } = this.options;
+		apply_platform_definitions(compiler, this.options.platform);
 
 		const resolve = compiler.options.resolve;
 		if (resolve.extensions && !resolve.extensions.includes('.tsrx')) {
@@ -88,6 +113,7 @@ export class TsrxPreactRspackPlugin {
 						options: {
 							suspenseSource: this.options.suspenseSource,
 							runtimeImports: this.options.runtimeImports,
+							platform: this.options.platform,
 						},
 					},
 				],
@@ -102,6 +128,7 @@ export class TsrxPreactRspackPlugin {
 						options: {
 							suspenseSource: this.options.suspenseSource,
 							runtimeImports: this.options.runtimeImports,
+							platform: this.options.platform,
 						},
 					},
 				],

--- a/packages/rspack-plugin-preact/src/index.js
+++ b/packages/rspack-plugin-preact/src/index.js
@@ -15,14 +15,27 @@ const CSS_LOADER = path.join(__dirname, 'css-loader.js');
 const TSRX_EXTENSION_PATTERN = /\.tsrx$/;
 const CSS_QUERY_PATTERN = /tsrx-css/;
 
+/** @param {any} plugin @returns {Record<string, unknown> | undefined} */
+function get_define_plugin_definitions(plugin) {
+	if (plugin == null || typeof plugin !== 'object') return undefined;
+	if ((plugin.name ?? plugin.constructor?.name) !== 'DefinePlugin') return undefined;
+	if (plugin.definitions && typeof plugin.definitions === 'object') return plugin.definitions;
+	if (Array.isArray(plugin._args) && plugin._args[0] && typeof plugin._args[0] === 'object') {
+		return plugin._args[0];
+	}
+	if (plugin.options && typeof plugin.options === 'object' && !Array.isArray(plugin.options)) {
+		return plugin.options;
+	}
+	return undefined;
+}
+
 /** @param {Compiler} compiler @param {Platform | undefined} platform */
 function apply_platform_definitions(compiler, platform) {
 	if (platform === undefined) return;
 	const compiler_with_definitions = /** @type {any} */ (compiler);
 	for (const plugin of compiler_with_definitions.options.plugins ?? []) {
-		if (plugin?.name !== 'DefinePlugin' || !Array.isArray(plugin._args)) continue;
-		const definitions = plugin._args[0];
-		if (definitions && typeof definitions === 'object') {
+		const definitions = get_define_plugin_definitions(plugin);
+		if (definitions) {
 			mergePlatformDefinitions(definitions, platform, { integration: 'Rspack' });
 		}
 	}

--- a/packages/rspack-plugin-preact/src/index.js
+++ b/packages/rspack-plugin-preact/src/index.js
@@ -3,11 +3,8 @@
 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import {
-	createPlatformDefinitions,
-	mergePlatformDefinitions,
-	validatePlatform,
-} from '@tsrx/preact';
+import { createPlatformDefinitions, mergePlatformDefinitions, validatePlatform } from '@tsrx/core';
+import { resolveBuildPlatform } from '@tsrx/core/config';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -50,11 +47,12 @@ export class TsrxPreactRspackPlugin {
 	 * @param {{ jsxImportSource?: string, suspenseSource?: string, runtimeImports?: RuntimeImportMode, platform?: Platform }} [options]
 	 */
 	constructor(options = {}) {
+		this.explicit_platform = validatePlatform(options.platform);
 		this.options = {
 			jsxImportSource: options.jsxImportSource ?? 'preact',
 			suspenseSource: options.suspenseSource,
 			runtimeImports: options.runtimeImports ?? 'compiler',
-			platform: validatePlatform(options.platform),
+			platform: this.explicit_platform,
 		};
 	}
 
@@ -63,6 +61,15 @@ export class TsrxPreactRspackPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
+		const compiler_options = /** @type {any} */ (compiler).options;
+		const resolve_tsconfig = compiler_options.resolve?.tsConfig;
+		this.options.platform = resolveBuildPlatform({
+			root: /** @type {any} */ (compiler).context ?? process.cwd(),
+			tsconfig:
+				typeof resolve_tsconfig === 'string' ? resolve_tsconfig : resolve_tsconfig?.configFile,
+			platform: this.explicit_platform,
+			integration: '@tsrx/rspack-plugin-preact',
+		});
 		const { jsxImportSource } = this.options;
 		apply_platform_definitions(compiler, this.options.platform);
 

--- a/packages/rspack-plugin-preact/src/js-loader.js
+++ b/packages/rspack-plugin-preact/src/js-loader.js
@@ -1,6 +1,6 @@
 /** @import { LoaderContext } from '@rspack/core' */
 
-/** @import { RuntimeImportMode } from '@tsrx/preact' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/preact' */
 
 import { compile } from '@tsrx/preact';
 
@@ -9,7 +9,7 @@ import { compile } from '@tsrx/preact';
  * appends an `import` of the sibling virtual CSS module so rspack can
  * include the styles in the asset graph.
  *
- * @this {LoaderContext<{ suspenseSource?: string, runtimeImports?: RuntimeImportMode }>}
+ * @this {LoaderContext<{ suspenseSource?: string, runtimeImports?: RuntimeImportMode, platform?: Platform }>}
  * @param {string} source
  * @returns {void}
  */

--- a/packages/rspack-plugin-preact/types/index.d.ts
+++ b/packages/rspack-plugin-preact/types/index.d.ts
@@ -1,17 +1,19 @@
 import type { Compiler, RspackPluginInstance } from '@rspack/core';
-import type { RuntimeImportMode } from '@tsrx/preact';
+import type { Platform, RuntimeImportMode } from '@tsrx/preact';
 
 export interface TsrxPreactRspackPluginOptions {
 	jsxImportSource?: string;
 	suspenseSource?: string;
 	/** Direct mode requires `@tsrx/preact-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
+	/** Must match `tsrx.platform` in the active tsconfig. */
+	platform?: Platform;
 }
 
 export declare class TsrxPreactRspackPlugin implements RspackPluginInstance {
 	constructor(options?: TsrxPreactRspackPluginOptions);
 	options: Required<Pick<TsrxPreactRspackPluginOptions, 'jsxImportSource'>> &
-		Pick<TsrxPreactRspackPluginOptions, 'suspenseSource'> &
+		Pick<TsrxPreactRspackPluginOptions, 'suspenseSource' | 'platform'> &
 		Required<Pick<TsrxPreactRspackPluginOptions, 'runtimeImports'>>;
 	apply(compiler: Compiler): void;
 }

--- a/packages/rspack-plugin-preact/types/index.d.ts
+++ b/packages/rspack-plugin-preact/types/index.d.ts
@@ -6,7 +6,7 @@ export interface TsrxPreactRspackPluginOptions {
 	suspenseSource?: string;
 	/** Direct mode requires `@tsrx/preact-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
-	/** Must match `tsrx.platform` in the active tsconfig. */
+	/** Optional override; inferred from tsconfig by default and must agree when both exist. */
 	platform?: Platform;
 }
 

--- a/packages/rspack-plugin-react/README.md
+++ b/packages/rspack-plugin-react/README.md
@@ -14,7 +14,7 @@ pnpm add -D @tsrx/rspack-plugin-react
 import { TsrxReactRspackPlugin } from '@tsrx/rspack-plugin-react';
 
 export default {
-  plugins: [new TsrxReactRspackPlugin({ platform: 'web' })],
+  plugins: [new TsrxReactRspackPlugin()],
 };
 ```
 
@@ -31,10 +31,10 @@ when unset.
 - `jsxImportSource`: automatic JSX runtime import source (default: `'react'`).
 - `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
   standalone runtime imports).
-- `platform`: optional compile-time platform (`'web'`, `'ios'`, or `'android'`).
-  Set the same `tsrx.platform` value in the active tsconfig. The plugin defines
-  all three exact `import.meta.env.platform.*` flags and rejects conflicting
-  Rspack definitions.
+- `platform`: optional override/fallback for the compile-time platform. Normally
+  the plugin reads `tsrx.platform` from the project tsconfig (including
+  `resolve.tsConfig` and `extends`). An override must match tsconfig. The plugin
+  defines all three exact flags and rejects conflicting Rspack definitions.
 
 When using `runtimeImports: 'direct'`, install the runtime as a direct production
 dependency of the package that owns the compiled modules:

--- a/packages/rspack-plugin-react/README.md
+++ b/packages/rspack-plugin-react/README.md
@@ -14,7 +14,7 @@ pnpm add -D @tsrx/rspack-plugin-react
 import { TsrxReactRspackPlugin } from '@tsrx/rspack-plugin-react';
 
 export default {
-  plugins: [new TsrxReactRspackPlugin()],
+  plugins: [new TsrxReactRspackPlugin({ platform: 'web' })],
 };
 ```
 
@@ -31,6 +31,10 @@ when unset.
 - `jsxImportSource`: automatic JSX runtime import source (default: `'react'`).
 - `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
   standalone runtime imports).
+- `platform`: optional compile-time platform (`'web'`, `'ios'`, or `'android'`).
+  Set the same `tsrx.platform` value in the active tsconfig. The plugin defines
+  all three exact `import.meta.env.platform.*` flags and rejects conflicting
+  Rspack definitions.
 
 When using `runtimeImports: 'direct'`, install the runtime as a direct production
 dependency of the package that owns the compiled modules:

--- a/packages/rspack-plugin-react/package.json
+++ b/packages/rspack-plugin-react/package.json
@@ -20,6 +20,7 @@
     }
   },
   "dependencies": {
+    "@tsrx/core": "workspace:*",
     "@tsrx/react": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/rspack-plugin-react/src/css-loader.js
+++ b/packages/rspack-plugin-react/src/css-loader.js
@@ -1,6 +1,6 @@
 /** @import { LoaderContext } from '@rspack/core' */
 
-/** @import { RuntimeImportMode } from '@tsrx/react' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/react' */
 
 import { compile } from '@tsrx/react';
 
@@ -9,7 +9,7 @@ import { compile } from '@tsrx/react';
  * the scoped CSS emitted by its `<style>` block. Invoked when rspack resolves
  * the sibling `?tsrx-css&lang.css` import emitted by the JS loader.
  *
- * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode }>}
+ * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode, platform?: Platform }>}
  * @param {string} source
  * @returns {void}
  */

--- a/packages/rspack-plugin-react/src/index.js
+++ b/packages/rspack-plugin-react/src/index.js
@@ -15,15 +15,28 @@ const CSS_LOADER = path.join(__dirname, 'css-loader.js');
 const TSRX_EXTENSION_PATTERN = /\.tsrx$/;
 const CSS_QUERY_PATTERN = /tsrx-css/;
 
+/** @param {any} plugin @returns {Record<string, unknown> | undefined} */
+function get_define_plugin_definitions(plugin) {
+	if (plugin == null || typeof plugin !== 'object') return undefined;
+	if ((plugin.name ?? plugin.constructor?.name) !== 'DefinePlugin') return undefined;
+	if (plugin.definitions && typeof plugin.definitions === 'object') return plugin.definitions;
+	if (Array.isArray(plugin._args) && plugin._args[0] && typeof plugin._args[0] === 'object') {
+		return plugin._args[0];
+	}
+	if (plugin.options && typeof plugin.options === 'object' && !Array.isArray(plugin.options)) {
+		return plugin.options;
+	}
+	return undefined;
+}
+
 /** @param {Compiler} compiler @param {Platform | undefined} platform */
 function apply_platform_definitions(compiler, platform) {
 	if (platform === undefined) return;
 
 	const compiler_with_definitions = /** @type {any} */ (compiler);
 	for (const plugin of compiler_with_definitions.options.plugins ?? []) {
-		if (plugin?.name !== 'DefinePlugin' || !Array.isArray(plugin._args)) continue;
-		const definitions = plugin._args[0];
-		if (definitions && typeof definitions === 'object') {
+		const definitions = get_define_plugin_definitions(plugin);
+		if (definitions) {
 			mergePlatformDefinitions(definitions, platform, { integration: 'Rspack' });
 		}
 	}

--- a/packages/rspack-plugin-react/src/index.js
+++ b/packages/rspack-plugin-react/src/index.js
@@ -3,7 +3,8 @@
 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createPlatformDefinitions, mergePlatformDefinitions, validatePlatform } from '@tsrx/react';
+import { createPlatformDefinitions, mergePlatformDefinitions, validatePlatform } from '@tsrx/core';
+import { resolveBuildPlatform } from '@tsrx/core/config';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -48,10 +49,11 @@ export class TsrxReactRspackPlugin {
 	 * @param {{ jsxImportSource?: string, runtimeImports?: RuntimeImportMode, platform?: Platform }} [options]
 	 */
 	constructor(options = {}) {
+		this.explicit_platform = validatePlatform(options.platform);
 		this.options = {
 			jsxImportSource: options.jsxImportSource ?? 'react',
 			runtimeImports: options.runtimeImports ?? 'compiler',
-			platform: validatePlatform(options.platform),
+			platform: this.explicit_platform,
 		};
 	}
 
@@ -60,6 +62,15 @@ export class TsrxReactRspackPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
+		const compiler_options = /** @type {any} */ (compiler).options;
+		const resolve_tsconfig = compiler_options.resolve?.tsConfig;
+		this.options.platform = resolveBuildPlatform({
+			root: /** @type {any} */ (compiler).context ?? process.cwd(),
+			tsconfig:
+				typeof resolve_tsconfig === 'string' ? resolve_tsconfig : resolve_tsconfig?.configFile,
+			platform: this.explicit_platform,
+			integration: '@tsrx/rspack-plugin-react',
+		});
 		const { jsxImportSource } = this.options;
 		apply_platform_definitions(compiler, this.options.platform);
 

--- a/packages/rspack-plugin-react/src/index.js
+++ b/packages/rspack-plugin-react/src/index.js
@@ -1,8 +1,9 @@
 /** @import { Compiler, RspackPluginInstance } from '@rspack/core' */
-/** @import { RuntimeImportMode } from '@tsrx/react' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/react' */
 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createPlatformDefinitions, mergePlatformDefinitions, validatePlatform } from '@tsrx/react';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -12,6 +13,26 @@ const CSS_LOADER = path.join(__dirname, 'css-loader.js');
 
 const TSRX_EXTENSION_PATTERN = /\.tsrx$/;
 const CSS_QUERY_PATTERN = /tsrx-css/;
+
+/** @param {Compiler} compiler @param {Platform | undefined} platform */
+function apply_platform_definitions(compiler, platform) {
+	if (platform === undefined) return;
+
+	const compiler_with_definitions = /** @type {any} */ (compiler);
+	for (const plugin of compiler_with_definitions.options.plugins ?? []) {
+		if (plugin?.name !== 'DefinePlugin' || !Array.isArray(plugin._args)) continue;
+		const definitions = plugin._args[0];
+		if (definitions && typeof definitions === 'object') {
+			mergePlatformDefinitions(definitions, platform, { integration: 'Rspack' });
+		}
+	}
+
+	const DefinePlugin = compiler_with_definitions.webpack?.DefinePlugin;
+	if (typeof DefinePlugin !== 'function') {
+		throw new Error('Rspack compiler does not expose DefinePlugin for TSRX platform flags.');
+	}
+	new DefinePlugin(createPlatformDefinitions(platform)).apply(compiler);
+}
 
 /**
  * Rspack plugin for `.tsrx` files that compiles them via `@tsrx/react` and
@@ -24,12 +45,13 @@ const CSS_QUERY_PATTERN = /tsrx-css/;
  */
 export class TsrxReactRspackPlugin {
 	/**
-	 * @param {{ jsxImportSource?: string, runtimeImports?: RuntimeImportMode }} [options]
+	 * @param {{ jsxImportSource?: string, runtimeImports?: RuntimeImportMode, platform?: Platform }} [options]
 	 */
 	constructor(options = {}) {
 		this.options = {
 			jsxImportSource: options.jsxImportSource ?? 'react',
 			runtimeImports: options.runtimeImports ?? 'compiler',
+			platform: validatePlatform(options.platform),
 		};
 	}
 
@@ -39,6 +61,7 @@ export class TsrxReactRspackPlugin {
 	 */
 	apply(compiler) {
 		const { jsxImportSource } = this.options;
+		apply_platform_definitions(compiler, this.options.platform);
 
 		const resolve = compiler.options.resolve;
 		if (resolve.extensions && !resolve.extensions.includes('.tsrx')) {
@@ -86,6 +109,7 @@ export class TsrxReactRspackPlugin {
 						loader: JS_LOADER,
 						options: {
 							runtimeImports: this.options.runtimeImports,
+							platform: this.options.platform,
 						},
 					},
 				],
@@ -99,6 +123,7 @@ export class TsrxReactRspackPlugin {
 						loader: CSS_LOADER,
 						options: {
 							runtimeImports: this.options.runtimeImports,
+							platform: this.options.platform,
 						},
 					},
 				],

--- a/packages/rspack-plugin-react/src/js-loader.js
+++ b/packages/rspack-plugin-react/src/js-loader.js
@@ -1,6 +1,6 @@
 /** @import { LoaderContext } from '@rspack/core' */
 
-/** @import { RuntimeImportMode } from '@tsrx/react' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/react' */
 
 import { compile } from '@tsrx/react';
 
@@ -9,7 +9,7 @@ import { compile } from '@tsrx/react';
  * appends an `import` of the sibling virtual CSS module so rspack can
  * include the styles in the asset graph.
  *
- * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode }>}
+ * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode, platform?: Platform }>}
  * @param {string} source
  * @returns {void}
  */

--- a/packages/rspack-plugin-react/types/index.d.ts
+++ b/packages/rspack-plugin-react/types/index.d.ts
@@ -1,15 +1,18 @@
 import type { Compiler, RspackPluginInstance } from '@rspack/core';
-import type { RuntimeImportMode } from '@tsrx/react';
+import type { Platform, RuntimeImportMode } from '@tsrx/react';
 
 export interface TsrxReactRspackPluginOptions {
 	jsxImportSource?: string;
 	/** Direct mode requires `@tsrx/react-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
+	/** Must match `tsrx.platform` in the active tsconfig. */
+	platform?: Platform;
 }
 
 export declare class TsrxReactRspackPlugin implements RspackPluginInstance {
 	constructor(options?: TsrxReactRspackPluginOptions);
-	options: Required<TsrxReactRspackPluginOptions>;
+	options: Required<Pick<TsrxReactRspackPluginOptions, 'jsxImportSource' | 'runtimeImports'>> &
+		Pick<TsrxReactRspackPluginOptions, 'platform'>;
 	apply(compiler: Compiler): void;
 }
 

--- a/packages/rspack-plugin-react/types/index.d.ts
+++ b/packages/rspack-plugin-react/types/index.d.ts
@@ -5,7 +5,7 @@ export interface TsrxReactRspackPluginOptions {
 	jsxImportSource?: string;
 	/** Direct mode requires `@tsrx/react-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
-	/** Must match `tsrx.platform` in the active tsconfig. */
+	/** Optional override; inferred from tsconfig by default and must agree when both exist. */
 	platform?: Platform;
 }
 

--- a/packages/rspack-plugin-solid/README.md
+++ b/packages/rspack-plugin-solid/README.md
@@ -15,7 +15,7 @@ pnpm add -D @tsrx/rspack-plugin-solid
 import { TsrxSolidRspackPlugin } from '@tsrx/rspack-plugin-solid';
 
 export default {
-  plugins: [new TsrxSolidRspackPlugin()],
+  plugins: [new TsrxSolidRspackPlugin({ platform: 'web' })],
 };
 ```
 
@@ -34,6 +34,9 @@ when unset. In development mode it adds `solid-refresh/babel` unless you pass
   `true` unless Rspack is running in production mode.
 - `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
   standalone runtime imports).
+- `platform`: optional compile-time platform (`'web'`, `'ios'`, or `'android'`).
+  Set the same `tsrx.platform` value in the active tsconfig. The plugin defines
+  all three exact flags and rejects conflicting Rspack definitions.
 
 When using `runtimeImports: 'direct'`, install the runtime as a direct production
 dependency of the package that owns the compiled modules:

--- a/packages/rspack-plugin-solid/README.md
+++ b/packages/rspack-plugin-solid/README.md
@@ -15,7 +15,7 @@ pnpm add -D @tsrx/rspack-plugin-solid
 import { TsrxSolidRspackPlugin } from '@tsrx/rspack-plugin-solid';
 
 export default {
-  plugins: [new TsrxSolidRspackPlugin({ platform: 'web' })],
+  plugins: [new TsrxSolidRspackPlugin()],
 };
 ```
 
@@ -34,9 +34,10 @@ when unset. In development mode it adds `solid-refresh/babel` unless you pass
   `true` unless Rspack is running in production mode.
 - `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
   standalone runtime imports).
-- `platform`: optional compile-time platform (`'web'`, `'ios'`, or `'android'`).
-  Set the same `tsrx.platform` value in the active tsconfig. The plugin defines
-  all three exact flags and rejects conflicting Rspack definitions.
+- `platform`: optional override/fallback for the compile-time platform. Normally
+  the plugin reads `tsrx.platform` from the project tsconfig (including
+  `resolve.tsConfig` and `extends`). An override must match tsconfig. The plugin
+  defines all three exact flags and rejects conflicting Rspack definitions.
 
 When using `runtimeImports: 'direct'`, install the runtime as a direct production
 dependency of the package that owns the compiled modules:

--- a/packages/rspack-plugin-solid/package.json
+++ b/packages/rspack-plugin-solid/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@babel/core": "^7.29.0",
     "@babel/preset-typescript": "^7.28.5",
+    "@tsrx/core": "workspace:*",
     "@tsrx/solid": "workspace:*",
     "babel-loader": "^10.1.1",
     "babel-preset-solid": "catalog:default",

--- a/packages/rspack-plugin-solid/src/css-loader.js
+++ b/packages/rspack-plugin-solid/src/css-loader.js
@@ -1,6 +1,6 @@
 /** @import { LoaderContext } from '@rspack/core' */
 
-/** @import { RuntimeImportMode } from '@tsrx/solid' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/solid' */
 
 import { compile } from '@tsrx/solid';
 
@@ -9,7 +9,7 @@ import { compile } from '@tsrx/solid';
  * the scoped CSS emitted by its `<style>` block. Invoked when rspack resolves
  * the sibling `?tsrx-css&lang.css` import emitted by the JS loader.
  *
- * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode }>}
+ * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode, platform?: Platform }>}
  * @param {string} source
  * @returns {void}
  */

--- a/packages/rspack-plugin-solid/src/index.js
+++ b/packages/rspack-plugin-solid/src/index.js
@@ -4,7 +4,8 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createPlatformDefinitions, mergePlatformDefinitions, validatePlatform } from '@tsrx/solid';
+import { createPlatformDefinitions, mergePlatformDefinitions, validatePlatform } from '@tsrx/core';
+import { resolveBuildPlatform } from '@tsrx/core/config';
 
 const require = createRequire(import.meta.url);
 
@@ -52,10 +53,11 @@ export class TsrxSolidRspackPlugin {
 	 * @param {{ hot?: boolean, runtimeImports?: RuntimeImportMode, platform?: Platform }} [options]
 	 */
 	constructor(options = {}) {
+		this.explicit_platform = validatePlatform(options.platform);
 		this.options = {
 			hot: options.hot,
 			runtimeImports: options.runtimeImports ?? 'compiler',
-			platform: validatePlatform(options.platform),
+			platform: this.explicit_platform,
 		};
 	}
 
@@ -64,6 +66,15 @@ export class TsrxSolidRspackPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
+		const compiler_options = /** @type {any} */ (compiler).options;
+		const resolve_tsconfig = compiler_options.resolve?.tsConfig;
+		this.options.platform = resolveBuildPlatform({
+			root: /** @type {any} */ (compiler).context ?? process.cwd(),
+			tsconfig:
+				typeof resolve_tsconfig === 'string' ? resolve_tsconfig : resolve_tsconfig?.configFile,
+			platform: this.explicit_platform,
+			integration: '@tsrx/rspack-plugin-solid',
+		});
 		const hot = this.options.hot ?? compiler.options.mode !== 'production';
 		apply_platform_definitions(compiler, this.options.platform);
 

--- a/packages/rspack-plugin-solid/src/index.js
+++ b/packages/rspack-plugin-solid/src/index.js
@@ -22,14 +22,27 @@ const SOLID_REFRESH_BABEL = require.resolve('solid-refresh/babel');
 const TSRX_EXTENSION_PATTERN = /\.tsrx$/;
 const CSS_QUERY_PATTERN = /tsrx-css/;
 
+/** @param {any} plugin @returns {Record<string, unknown> | undefined} */
+function get_define_plugin_definitions(plugin) {
+	if (plugin == null || typeof plugin !== 'object') return undefined;
+	if ((plugin.name ?? plugin.constructor?.name) !== 'DefinePlugin') return undefined;
+	if (plugin.definitions && typeof plugin.definitions === 'object') return plugin.definitions;
+	if (Array.isArray(plugin._args) && plugin._args[0] && typeof plugin._args[0] === 'object') {
+		return plugin._args[0];
+	}
+	if (plugin.options && typeof plugin.options === 'object' && !Array.isArray(plugin.options)) {
+		return plugin.options;
+	}
+	return undefined;
+}
+
 /** @param {Compiler} compiler @param {Platform | undefined} platform */
 function apply_platform_definitions(compiler, platform) {
 	if (platform === undefined) return;
 	const compiler_with_definitions = /** @type {any} */ (compiler);
 	for (const plugin of compiler_with_definitions.options.plugins ?? []) {
-		if (plugin?.name !== 'DefinePlugin' || !Array.isArray(plugin._args)) continue;
-		const definitions = plugin._args[0];
-		if (definitions && typeof definitions === 'object') {
+		const definitions = get_define_plugin_definitions(plugin);
+		if (definitions) {
 			mergePlatformDefinitions(definitions, platform, { integration: 'Rspack' });
 		}
 	}

--- a/packages/rspack-plugin-solid/src/index.js
+++ b/packages/rspack-plugin-solid/src/index.js
@@ -1,9 +1,10 @@
 /** @import { Compiler, RspackPluginInstance } from '@rspack/core' */
-/** @import { RuntimeImportMode } from '@tsrx/solid' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/solid' */
 
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createPlatformDefinitions, mergePlatformDefinitions, validatePlatform } from '@tsrx/solid';
 
 const require = createRequire(import.meta.url);
 
@@ -20,6 +21,24 @@ const SOLID_REFRESH_BABEL = require.resolve('solid-refresh/babel');
 const TSRX_EXTENSION_PATTERN = /\.tsrx$/;
 const CSS_QUERY_PATTERN = /tsrx-css/;
 
+/** @param {Compiler} compiler @param {Platform | undefined} platform */
+function apply_platform_definitions(compiler, platform) {
+	if (platform === undefined) return;
+	const compiler_with_definitions = /** @type {any} */ (compiler);
+	for (const plugin of compiler_with_definitions.options.plugins ?? []) {
+		if (plugin?.name !== 'DefinePlugin' || !Array.isArray(plugin._args)) continue;
+		const definitions = plugin._args[0];
+		if (definitions && typeof definitions === 'object') {
+			mergePlatformDefinitions(definitions, platform, { integration: 'Rspack' });
+		}
+	}
+	const DefinePlugin = compiler_with_definitions.webpack?.DefinePlugin;
+	if (typeof DefinePlugin !== 'function') {
+		throw new Error('Rspack compiler does not expose DefinePlugin for TSRX platform flags.');
+	}
+	new DefinePlugin(createPlatformDefinitions(platform)).apply(compiler);
+}
+
 /**
  * Rspack plugin for `.tsrx` files that compiles them via `@tsrx/solid` and
  * then delegates the final TSX + JSX transform to `babel-loader` with Solid's
@@ -30,12 +49,13 @@ const CSS_QUERY_PATTERN = /tsrx-css/;
  */
 export class TsrxSolidRspackPlugin {
 	/**
-	 * @param {{ hot?: boolean, runtimeImports?: RuntimeImportMode }} [options]
+	 * @param {{ hot?: boolean, runtimeImports?: RuntimeImportMode, platform?: Platform }} [options]
 	 */
 	constructor(options = {}) {
 		this.options = {
 			hot: options.hot,
 			runtimeImports: options.runtimeImports ?? 'compiler',
+			platform: validatePlatform(options.platform),
 		};
 	}
 
@@ -45,6 +65,7 @@ export class TsrxSolidRspackPlugin {
 	 */
 	apply(compiler) {
 		const hot = this.options.hot ?? compiler.options.mode !== 'production';
+		apply_platform_definitions(compiler, this.options.platform);
 
 		const resolve = compiler.options.resolve;
 		if (resolve.extensions && !resolve.extensions.includes('.tsrx')) {
@@ -96,6 +117,7 @@ export class TsrxSolidRspackPlugin {
 						loader: JS_LOADER,
 						options: {
 							runtimeImports: this.options.runtimeImports,
+							platform: this.options.platform,
 						},
 					},
 				],
@@ -109,6 +131,7 @@ export class TsrxSolidRspackPlugin {
 						loader: CSS_LOADER,
 						options: {
 							runtimeImports: this.options.runtimeImports,
+							platform: this.options.platform,
 						},
 					},
 				],

--- a/packages/rspack-plugin-solid/src/js-loader.js
+++ b/packages/rspack-plugin-solid/src/js-loader.js
@@ -1,6 +1,6 @@
 /** @import { LoaderContext } from '@rspack/core' */
 
-/** @import { RuntimeImportMode } from '@tsrx/solid' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/solid' */
 
 import { compile } from '@tsrx/solid';
 
@@ -9,7 +9,7 @@ import { compile } from '@tsrx/solid';
  * appends an `import` of the sibling virtual CSS module so rspack can
  * include the styles in the asset graph.
  *
- * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode }>}
+ * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode, platform?: Platform }>}
  * @param {string} source
  * @returns {void}
  */

--- a/packages/rspack-plugin-solid/types/index.d.ts
+++ b/packages/rspack-plugin-solid/types/index.d.ts
@@ -1,15 +1,17 @@
 import type { Compiler, RspackPluginInstance } from '@rspack/core';
-import type { RuntimeImportMode } from '@tsrx/solid';
+import type { Platform, RuntimeImportMode } from '@tsrx/solid';
 
 export interface TsrxSolidRspackPluginOptions {
 	hot?: boolean;
 	/** Direct mode requires `@tsrx/solid-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
+	/** Must match `tsrx.platform` in the active tsconfig. */
+	platform?: Platform;
 }
 
 export declare class TsrxSolidRspackPlugin implements RspackPluginInstance {
 	constructor(options?: TsrxSolidRspackPluginOptions);
-	options: Pick<TsrxSolidRspackPluginOptions, 'hot'> &
+	options: Pick<TsrxSolidRspackPluginOptions, 'hot' | 'platform'> &
 		Required<Pick<TsrxSolidRspackPluginOptions, 'runtimeImports'>>;
 	apply(compiler: Compiler): void;
 }

--- a/packages/rspack-plugin-solid/types/index.d.ts
+++ b/packages/rspack-plugin-solid/types/index.d.ts
@@ -5,7 +5,7 @@ export interface TsrxSolidRspackPluginOptions {
 	hot?: boolean;
 	/** Direct mode requires `@tsrx/solid-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
-	/** Must match `tsrx.platform` in the active tsconfig. */
+	/** Optional override; inferred from tsconfig by default and must agree when both exist. */
 	platform?: Platform;
 }
 

--- a/packages/rspack-plugin-vue/README.md
+++ b/packages/rspack-plugin-vue/README.md
@@ -15,7 +15,7 @@ pnpm add -D @tsrx/rspack-plugin-vue
 import { TsrxVueRspackPlugin } from '@tsrx/rspack-plugin-vue';
 
 export default {
-  plugins: [new TsrxVueRspackPlugin()],
+  plugins: [new TsrxVueRspackPlugin({ platform: 'web' })],
 };
 ```
 
@@ -33,6 +33,9 @@ when unset. Editor typechecking should set `jsxImportSource: 'vue-jsx-vapor'`.
   macros and uses `runtimeModuleName: 'vue-jsx-vapor'`.
 - `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
   standalone runtime imports).
+- `platform`: optional compile-time platform (`'web'`, `'ios'`, or `'android'`).
+  Set the same `tsrx.platform` value in the active tsconfig. The plugin defines
+  all three exact flags and rejects conflicting Rspack definitions.
 
 When using `runtimeImports: 'direct'`, install the runtime as a direct production
 dependency of the package that owns the compiled modules:

--- a/packages/rspack-plugin-vue/README.md
+++ b/packages/rspack-plugin-vue/README.md
@@ -15,7 +15,7 @@ pnpm add -D @tsrx/rspack-plugin-vue
 import { TsrxVueRspackPlugin } from '@tsrx/rspack-plugin-vue';
 
 export default {
-  plugins: [new TsrxVueRspackPlugin({ platform: 'web' })],
+  plugins: [new TsrxVueRspackPlugin()],
 };
 ```
 
@@ -33,9 +33,10 @@ when unset. Editor typechecking should set `jsxImportSource: 'vue-jsx-vapor'`.
   macros and uses `runtimeModuleName: 'vue-jsx-vapor'`.
 - `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
   standalone runtime imports).
-- `platform`: optional compile-time platform (`'web'`, `'ios'`, or `'android'`).
-  Set the same `tsrx.platform` value in the active tsconfig. The plugin defines
-  all three exact flags and rejects conflicting Rspack definitions.
+- `platform`: optional override/fallback for the compile-time platform. Normally
+  the plugin reads `tsrx.platform` from the project tsconfig (including
+  `resolve.tsConfig` and `extends`). An override must match tsconfig. The plugin
+  defines all three exact flags and rejects conflicting Rspack definitions.
 
 When using `runtimeImports: 'direct'`, install the runtime as a direct production
 dependency of the package that owns the compiled modules:

--- a/packages/rspack-plugin-vue/package.json
+++ b/packages/rspack-plugin-vue/package.json
@@ -20,6 +20,7 @@
     }
   },
   "dependencies": {
+    "@tsrx/core": "workspace:*",
     "@tsrx/vue": "workspace:*",
     "source-map": "catalog:default"
   },

--- a/packages/rspack-plugin-vue/src/css-loader.js
+++ b/packages/rspack-plugin-vue/src/css-loader.js
@@ -1,6 +1,6 @@
 /** @import { LoaderContext } from '@rspack/core' */
 
-/** @import { RuntimeImportMode } from '@tsrx/vue' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/vue' */
 
 import { compile } from '@tsrx/vue';
 
@@ -9,7 +9,7 @@ import { compile } from '@tsrx/vue';
  * scoped CSS emitted by its `<style>` block. Invoked when rspack resolves the
  * sibling `?tsrx-css&lang.css` import emitted by the JS loader.
  *
- * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode }>}
+ * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode, platform?: Platform }>}
  * @param {string} source
  * @returns {void}
  */

--- a/packages/rspack-plugin-vue/src/index.js
+++ b/packages/rspack-plugin-vue/src/index.js
@@ -3,7 +3,8 @@
 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createPlatformDefinitions, mergePlatformDefinitions, validatePlatform } from '@tsrx/vue';
+import { createPlatformDefinitions, mergePlatformDefinitions, validatePlatform } from '@tsrx/core';
+import { resolveBuildPlatform } from '@tsrx/core/config';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -49,10 +50,11 @@ export class TsrxVueRspackPlugin {
 	 * @param {{ vapor?: { macros?: boolean | object, compiler?: { runtimeModuleName?: string } }, runtimeImports?: RuntimeImportMode, platform?: Platform }} [options]
 	 */
 	constructor(options = {}) {
+		this.explicit_platform = validatePlatform(options.platform);
 		this.options = {
 			vapor: options.vapor,
 			runtimeImports: options.runtimeImports ?? 'compiler',
-			platform: validatePlatform(options.platform),
+			platform: this.explicit_platform,
 		};
 	}
 
@@ -61,6 +63,15 @@ export class TsrxVueRspackPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
+		const compiler_options = /** @type {any} */ (compiler).options;
+		const resolve_tsconfig = compiler_options.resolve?.tsConfig;
+		this.options.platform = resolveBuildPlatform({
+			root: /** @type {any} */ (compiler).context ?? process.cwd(),
+			tsconfig:
+				typeof resolve_tsconfig === 'string' ? resolve_tsconfig : resolve_tsconfig?.configFile,
+			platform: this.explicit_platform,
+			integration: '@tsrx/rspack-plugin-vue',
+		});
 		apply_platform_definitions(compiler, this.options.platform);
 		const resolve = compiler.options.resolve;
 		if (resolve.extensions && !resolve.extensions.includes('.tsrx')) {

--- a/packages/rspack-plugin-vue/src/index.js
+++ b/packages/rspack-plugin-vue/src/index.js
@@ -1,8 +1,9 @@
 /** @import { Compiler, RspackPluginInstance } from '@rspack/core' */
-/** @import { RuntimeImportMode } from '@tsrx/vue' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/vue' */
 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createPlatformDefinitions, mergePlatformDefinitions, validatePlatform } from '@tsrx/vue';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -16,6 +17,24 @@ const TSRX_EXTENSION_PATTERN = /\.tsrx$/;
 const CSS_QUERY_PATTERN = /tsrx-css/;
 const SOURCE_EXTENSION_PATTERN = /\.[cm]?[jt]sx?$/;
 
+/** @param {Compiler} compiler @param {Platform | undefined} platform */
+function apply_platform_definitions(compiler, platform) {
+	if (platform === undefined) return;
+	const compiler_with_definitions = /** @type {any} */ (compiler);
+	for (const plugin of compiler_with_definitions.options.plugins ?? []) {
+		if (plugin?.name !== 'DefinePlugin' || !Array.isArray(plugin._args)) continue;
+		const definitions = plugin._args[0];
+		if (definitions && typeof definitions === 'object') {
+			mergePlatformDefinitions(definitions, platform, { integration: 'Rspack' });
+		}
+	}
+	const DefinePlugin = compiler_with_definitions.webpack?.DefinePlugin;
+	if (typeof DefinePlugin !== 'function') {
+		throw new Error('Rspack compiler does not expose DefinePlugin for TSRX platform flags.');
+	}
+	new DefinePlugin(createPlatformDefinitions(platform)).apply(compiler);
+}
+
 /**
  * Rspack plugin for `.tsrx` files that compiles them via `@tsrx/vue`, runs the
  * result through `vue-jsx-vapor`, and finally strips the remaining TypeScript
@@ -27,12 +46,13 @@ const SOURCE_EXTENSION_PATTERN = /\.[cm]?[jt]sx?$/;
  */
 export class TsrxVueRspackPlugin {
 	/**
-	 * @param {{ vapor?: { macros?: boolean | object, compiler?: { runtimeModuleName?: string } }, runtimeImports?: RuntimeImportMode }} [options]
+	 * @param {{ vapor?: { macros?: boolean | object, compiler?: { runtimeModuleName?: string } }, runtimeImports?: RuntimeImportMode, platform?: Platform }} [options]
 	 */
 	constructor(options = {}) {
 		this.options = {
 			vapor: options.vapor,
 			runtimeImports: options.runtimeImports ?? 'compiler',
+			platform: validatePlatform(options.platform),
 		};
 	}
 
@@ -41,6 +61,7 @@ export class TsrxVueRspackPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
+		apply_platform_definitions(compiler, this.options.platform);
 		const resolve = compiler.options.resolve;
 		if (resolve.extensions && !resolve.extensions.includes('.tsrx')) {
 			resolve.extensions.push('.tsrx');
@@ -96,6 +117,7 @@ export class TsrxVueRspackPlugin {
 						loader: JS_LOADER,
 						options: {
 							runtimeImports: this.options.runtimeImports,
+							platform: this.options.platform,
 						},
 					},
 				],
@@ -109,6 +131,7 @@ export class TsrxVueRspackPlugin {
 						loader: CSS_LOADER,
 						options: {
 							runtimeImports: this.options.runtimeImports,
+							platform: this.options.platform,
 						},
 					},
 				],

--- a/packages/rspack-plugin-vue/src/index.js
+++ b/packages/rspack-plugin-vue/src/index.js
@@ -18,14 +18,27 @@ const TSRX_EXTENSION_PATTERN = /\.tsrx$/;
 const CSS_QUERY_PATTERN = /tsrx-css/;
 const SOURCE_EXTENSION_PATTERN = /\.[cm]?[jt]sx?$/;
 
+/** @param {any} plugin @returns {Record<string, unknown> | undefined} */
+function get_define_plugin_definitions(plugin) {
+	if (plugin == null || typeof plugin !== 'object') return undefined;
+	if ((plugin.name ?? plugin.constructor?.name) !== 'DefinePlugin') return undefined;
+	if (plugin.definitions && typeof plugin.definitions === 'object') return plugin.definitions;
+	if (Array.isArray(plugin._args) && plugin._args[0] && typeof plugin._args[0] === 'object') {
+		return plugin._args[0];
+	}
+	if (plugin.options && typeof plugin.options === 'object' && !Array.isArray(plugin.options)) {
+		return plugin.options;
+	}
+	return undefined;
+}
+
 /** @param {Compiler} compiler @param {Platform | undefined} platform */
 function apply_platform_definitions(compiler, platform) {
 	if (platform === undefined) return;
 	const compiler_with_definitions = /** @type {any} */ (compiler);
 	for (const plugin of compiler_with_definitions.options.plugins ?? []) {
-		if (plugin?.name !== 'DefinePlugin' || !Array.isArray(plugin._args)) continue;
-		const definitions = plugin._args[0];
-		if (definitions && typeof definitions === 'object') {
+		const definitions = get_define_plugin_definitions(plugin);
+		if (definitions) {
 			mergePlatformDefinitions(definitions, platform, { integration: 'Rspack' });
 		}
 	}

--- a/packages/rspack-plugin-vue/src/js-loader.js
+++ b/packages/rspack-plugin-vue/src/js-loader.js
@@ -1,6 +1,6 @@
 /** @import { LoaderContext } from '@rspack/core' */
 
-/** @import { RuntimeImportMode } from '@tsrx/vue' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/vue' */
 
 import { compile } from '@tsrx/vue';
 
@@ -9,7 +9,7 @@ import { compile } from '@tsrx/vue';
  * present, appends an `import` of the sibling virtual CSS module so rspack can
  * include the styles in the asset graph.
  *
- * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode }>}
+ * @this {LoaderContext<{ runtimeImports?: RuntimeImportMode, platform?: Platform }>}
  * @param {string} source
  * @returns {void}
  */

--- a/packages/rspack-plugin-vue/types/index.d.ts
+++ b/packages/rspack-plugin-vue/types/index.d.ts
@@ -1,5 +1,5 @@
 import type { Compiler, RspackPluginInstance } from '@rspack/core';
-import type { RuntimeImportMode } from '@tsrx/vue';
+import type { Platform, RuntimeImportMode } from '@tsrx/vue';
 
 export interface TsrxVueRspackVaporOptions {
 	macros?: boolean | object;
@@ -12,11 +12,13 @@ export interface TsrxVueRspackPluginOptions {
 	vapor?: TsrxVueRspackVaporOptions;
 	/** Direct mode requires `@tsrx/vue-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
+	/** Must match `tsrx.platform` in the active tsconfig. */
+	platform?: Platform;
 }
 
 export declare class TsrxVueRspackPlugin implements RspackPluginInstance {
 	constructor(options?: TsrxVueRspackPluginOptions);
-	options: Pick<TsrxVueRspackPluginOptions, 'vapor'> &
+	options: Pick<TsrxVueRspackPluginOptions, 'vapor' | 'platform'> &
 		Required<Pick<TsrxVueRspackPluginOptions, 'runtimeImports'>>;
 	apply(compiler: Compiler): void;
 }

--- a/packages/rspack-plugin-vue/types/index.d.ts
+++ b/packages/rspack-plugin-vue/types/index.d.ts
@@ -12,7 +12,7 @@ export interface TsrxVueRspackPluginOptions {
 	vapor?: TsrxVueRspackVaporOptions;
 	/** Direct mode requires `@tsrx/vue-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
-	/** Must match `tsrx.platform` in the active tsconfig. */
+	/** Optional override; inferred from tsconfig by default and must agree when both exist. */
 	platform?: Platform;
 }
 

--- a/packages/tsrx-preact/src/index.js
+++ b/packages/tsrx-preact/src/index.js
@@ -16,12 +16,6 @@ import { DEFAULT_SUSPENSE_SOURCE, transform } from './transform.js';
 
 export { DEFAULT_SUSPENSE_SOURCE };
 export { isRefProp } from './ref.js';
-export {
-	createPlatformDefinitions,
-	mergePlatformDefinitions,
-	replacePlatformFlags,
-	validatePlatform,
-} from '@tsrx/core';
 
 /**
  * Parse tsrx-preact source code to an ESTree AST.

--- a/packages/tsrx-preact/src/index.js
+++ b/packages/tsrx-preact/src/index.js
@@ -3,11 +3,25 @@
 /** @import { NonEmptyString } from '@tsrx/core/types/helpers' */
 /** @import { CompileOptions } from '../types/index' */
 
-import { analyzeTsrx, createVolarMappingsResult, dedupeMappings, parseModule } from '@tsrx/core';
+import {
+	analyzeTsrx,
+	createVolarMappingsResult,
+	dedupeMappings,
+	hasPlatformNamespace,
+	parseModule,
+	specializePlatform,
+	withPlatformTypes,
+} from '@tsrx/core';
 import { DEFAULT_SUSPENSE_SOURCE, transform } from './transform.js';
 
 export { DEFAULT_SUSPENSE_SOURCE };
 export { isRefProp } from './ref.js';
+export {
+	createPlatformDefinitions,
+	mergePlatformDefinitions,
+	replacePlatformFlags,
+	validatePlatform,
+} from '@tsrx/core';
 
 /**
  * Parse tsrx-preact source code to an ESTree AST.
@@ -35,10 +49,16 @@ export function compile(source, filename, compile_options) {
 	const errors = /** @type {CompileError[]} */ ([]);
 	const comments = /** @type {AST.CommentWithLocation[]} */ ([]);
 	const collect = !!(compile_options?.collect || compile_options?.loose);
-	const ast = parseModule(
+	let ast = parseModule(
 		source,
 		filename,
 		collect ? { collect: true, loose: !!compile_options?.loose, errors, comments } : undefined,
+	);
+	ast = specializePlatform(
+		ast,
+		compile_options?.platform,
+		filename,
+		collect ? { errors, comments } : undefined,
 	);
 	analyzeTsrx(
 		ast,
@@ -75,7 +95,7 @@ export function compile(source, filename, compile_options) {
 export function compile_to_volar_mappings(source, filename, options) {
 	const errors = /** @type {CompileError[]} */ ([]);
 	const comments = /** @type {AST.CommentWithLocation[]} */ ([]);
-	const ast = parseModule(source, filename, {
+	let ast = parseModule(source, filename, {
 		...options,
 		collect: true,
 		loose: !!options?.loose,
@@ -84,6 +104,8 @@ export function compile_to_volar_mappings(source, filename, options) {
 		errors,
 		comments,
 	});
+	const uses_platform_flags = hasPlatformNamespace(ast);
+	ast = specializePlatform(ast, options?.platform, filename, { errors, comments });
 	analyzeTsrx(ast, filename, {
 		collect: true,
 		loose: !!options?.loose,
@@ -108,8 +130,9 @@ export function compile_to_volar_mappings(source, filename, options) {
 		errors,
 	});
 
-	return {
+	const deduped = {
 		...result,
 		mappings: dedupeMappings(result.mappings),
 	};
+	return uses_platform_flags ? withPlatformTypes(deduped, options?.platform) : deduped;
 }

--- a/packages/tsrx-preact/types/index.d.ts
+++ b/packages/tsrx-preact/types/index.d.ts
@@ -2,12 +2,6 @@ import type { Program } from 'estree';
 import type { BaseCompileOptions, CompileFn, ParseOptions, VolarCompileFn } from '@tsrx/core/types';
 
 export type { Platform, RuntimeImportMode, TsrxPlatformFlags } from '@tsrx/core/types';
-export {
-	createPlatformDefinitions,
-	mergePlatformDefinitions,
-	replacePlatformFlags,
-	validatePlatform,
-} from '@tsrx/core/types';
 
 /**
  * Per-call compile options for tsrx-preact. Exposed publicly so the Vite

--- a/packages/tsrx-preact/types/index.d.ts
+++ b/packages/tsrx-preact/types/index.d.ts
@@ -1,7 +1,13 @@
 import type { Program } from 'estree';
 import type { BaseCompileOptions, CompileFn, ParseOptions, VolarCompileFn } from '@tsrx/core/types';
 
-export type { RuntimeImportMode } from '@tsrx/core/types';
+export type { Platform, RuntimeImportMode, TsrxPlatformFlags } from '@tsrx/core/types';
+export {
+	createPlatformDefinitions,
+	mergePlatformDefinitions,
+	replacePlatformFlags,
+	validatePlatform,
+} from '@tsrx/core/types';
 
 /**
  * Per-call compile options for tsrx-preact. Exposed publicly so the Vite

--- a/packages/tsrx-react/src/index.js
+++ b/packages/tsrx-react/src/index.js
@@ -2,10 +2,24 @@
 /** @import { BaseCompileOptions, CompileError, CompileResult, ParseOptions, VolarMappingsResult } from '@tsrx/core/types' */
 /** @import { NonEmptyString } from '@tsrx/core/types/helpers' */
 
-import { analyzeTsrx, createVolarMappingsResult, dedupeMappings, parseModule } from '@tsrx/core';
+import {
+	analyzeTsrx,
+	createVolarMappingsResult,
+	dedupeMappings,
+	hasPlatformNamespace,
+	parseModule,
+	specializePlatform,
+	withPlatformTypes,
+} from '@tsrx/core';
 import { transform } from './transform.js';
 
 export { isRefProp } from './ref.js';
+export {
+	createPlatformDefinitions,
+	mergePlatformDefinitions,
+	replacePlatformFlags,
+	validatePlatform,
+} from '@tsrx/core';
 
 /**
  * Parse tsrx-react source code to an ESTree AST.
@@ -33,10 +47,16 @@ export function compile(source, filename, options) {
 	const errors = /** @type {CompileError[]} */ ([]);
 	const comments = /** @type {AST.CommentWithLocation[]} */ ([]);
 	const collect = !!(options?.collect || options?.loose);
-	const ast = parseModule(
+	let ast = parseModule(
 		source,
 		filename,
 		collect ? { collect: true, loose: !!options?.loose, errors, comments } : undefined,
+	);
+	ast = specializePlatform(
+		ast,
+		options?.platform,
+		filename,
+		collect ? { errors, comments } : undefined,
 	);
 	analyzeTsrx(
 		ast,
@@ -64,7 +84,7 @@ export function compile(source, filename, options) {
 export function compile_to_volar_mappings(source, filename, options) {
 	const errors = /** @type {CompileError[]} */ ([]);
 	const comments = /** @type {AST.CommentWithLocation[]} */ ([]);
-	const ast = parseModule(source, filename, {
+	let ast = parseModule(source, filename, {
 		...options,
 		collect: true,
 		loose: !!options?.loose,
@@ -73,6 +93,8 @@ export function compile_to_volar_mappings(source, filename, options) {
 		errors,
 		comments,
 	});
+	const uses_platform_flags = hasPlatformNamespace(ast);
+	ast = specializePlatform(ast, options?.platform, filename, { errors, comments });
 	analyzeTsrx(ast, filename, {
 		collect: true,
 		loose: !!options?.loose,
@@ -97,8 +119,9 @@ export function compile_to_volar_mappings(source, filename, options) {
 		errors,
 	});
 
-	return {
+	const deduped = {
 		...result,
 		mappings: dedupeMappings(result.mappings),
 	};
+	return uses_platform_flags ? withPlatformTypes(deduped, options?.platform) : deduped;
 }

--- a/packages/tsrx-react/src/index.js
+++ b/packages/tsrx-react/src/index.js
@@ -14,12 +14,6 @@ import {
 import { transform } from './transform.js';
 
 export { isRefProp } from './ref.js';
-export {
-	createPlatformDefinitions,
-	mergePlatformDefinitions,
-	replacePlatformFlags,
-	validatePlatform,
-} from '@tsrx/core';
 
 /**
  * Parse tsrx-react source code to an ESTree AST.

--- a/packages/tsrx-react/types/index.d.ts
+++ b/packages/tsrx-react/types/index.d.ts
@@ -1,7 +1,13 @@
 import type { Program } from 'estree';
 import type { BaseCompileOptions, CompileFn, ParseOptions, VolarCompileFn } from '@tsrx/core/types';
 
-export type { RuntimeImportMode } from '@tsrx/core/types';
+export type { Platform, RuntimeImportMode, TsrxPlatformFlags } from '@tsrx/core/types';
+export {
+	createPlatformDefinitions,
+	mergePlatformDefinitions,
+	replacePlatformFlags,
+	validatePlatform,
+} from '@tsrx/core/types';
 
 export function parse(source: string, filename?: string, options?: ParseOptions): Program;
 

--- a/packages/tsrx-react/types/index.d.ts
+++ b/packages/tsrx-react/types/index.d.ts
@@ -2,12 +2,6 @@ import type { Program } from 'estree';
 import type { BaseCompileOptions, CompileFn, ParseOptions, VolarCompileFn } from '@tsrx/core/types';
 
 export type { Platform, RuntimeImportMode, TsrxPlatformFlags } from '@tsrx/core/types';
-export {
-	createPlatformDefinitions,
-	mergePlatformDefinitions,
-	replacePlatformFlags,
-	validatePlatform,
-} from '@tsrx/core/types';
 
 export function parse(source: string, filename?: string, options?: ParseOptions): Program;
 

--- a/packages/tsrx-solid/src/index.js
+++ b/packages/tsrx-solid/src/index.js
@@ -2,10 +2,24 @@
 /** @import { BaseCompileOptions, CompileError, CompileResult, ParseOptions, VolarMappingsResult } from '@tsrx/core/types' */
 /** @import { NonEmptyString } from '@tsrx/core/types/helpers' */
 
-import { analyzeTsrx, createVolarMappingsResult, dedupeMappings, parseModule } from '@tsrx/core';
+import {
+	analyzeTsrx,
+	createVolarMappingsResult,
+	dedupeMappings,
+	hasPlatformNamespace,
+	parseModule,
+	specializePlatform,
+	withPlatformTypes,
+} from '@tsrx/core';
 import { transform } from './transform.js';
 
 export { isRefProp } from './ref.js';
+export {
+	createPlatformDefinitions,
+	mergePlatformDefinitions,
+	replacePlatformFlags,
+	validatePlatform,
+} from '@tsrx/core';
 
 /**
  * Parse tsrx-solid source code to an ESTree AST.
@@ -33,10 +47,16 @@ export function compile(source, filename, options) {
 	const errors = /** @type {CompileError[]} */ ([]);
 	const comments = /** @type {AST.CommentWithLocation[]} */ ([]);
 	const collect = !!(options?.collect || options?.loose);
-	const ast = parseModule(
+	let ast = parseModule(
 		source,
 		filename,
 		collect ? { collect: true, loose: !!options?.loose, errors, comments } : undefined,
+	);
+	ast = specializePlatform(
+		ast,
+		options?.platform,
+		filename,
+		collect ? { errors, comments } : undefined,
 	);
 	analyzeTsrx(
 		ast,
@@ -64,7 +84,7 @@ export function compile(source, filename, options) {
 export function compile_to_volar_mappings(source, filename, options) {
 	const errors = /** @type {CompileError[]} */ ([]);
 	const comments = /** @type {AST.CommentWithLocation[]} */ ([]);
-	const ast = parseModule(source, filename, {
+	let ast = parseModule(source, filename, {
 		...options,
 		collect: true,
 		loose: !!options?.loose,
@@ -73,6 +93,8 @@ export function compile_to_volar_mappings(source, filename, options) {
 		errors,
 		comments,
 	});
+	const uses_platform_flags = hasPlatformNamespace(ast);
+	ast = specializePlatform(ast, options?.platform, filename, { errors, comments });
 	analyzeTsrx(ast, filename, {
 		collect: true,
 		loose: !!options?.loose,
@@ -98,8 +120,9 @@ export function compile_to_volar_mappings(source, filename, options) {
 		errors,
 	});
 
-	return {
+	const deduped = {
 		...result,
 		mappings: dedupeMappings(result.mappings),
 	};
+	return uses_platform_flags ? withPlatformTypes(deduped, options?.platform) : deduped;
 }

--- a/packages/tsrx-solid/src/index.js
+++ b/packages/tsrx-solid/src/index.js
@@ -14,12 +14,6 @@ import {
 import { transform } from './transform.js';
 
 export { isRefProp } from './ref.js';
-export {
-	createPlatformDefinitions,
-	mergePlatformDefinitions,
-	replacePlatformFlags,
-	validatePlatform,
-} from '@tsrx/core';
 
 /**
  * Parse tsrx-solid source code to an ESTree AST.

--- a/packages/tsrx-solid/types/index.d.ts
+++ b/packages/tsrx-solid/types/index.d.ts
@@ -1,7 +1,13 @@
 import type { Program } from 'estree';
 import type { BaseCompileOptions, CompileFn, ParseOptions, VolarCompileFn } from '@tsrx/core/types';
 
-export type { RuntimeImportMode } from '@tsrx/core/types';
+export type { Platform, RuntimeImportMode, TsrxPlatformFlags } from '@tsrx/core/types';
+export {
+	createPlatformDefinitions,
+	mergePlatformDefinitions,
+	replacePlatformFlags,
+	validatePlatform,
+} from '@tsrx/core/types';
 
 export function parse(source: string, filename?: string, options?: ParseOptions): Program;
 

--- a/packages/tsrx-solid/types/index.d.ts
+++ b/packages/tsrx-solid/types/index.d.ts
@@ -2,12 +2,6 @@ import type { Program } from 'estree';
 import type { BaseCompileOptions, CompileFn, ParseOptions, VolarCompileFn } from '@tsrx/core/types';
 
 export type { Platform, RuntimeImportMode, TsrxPlatformFlags } from '@tsrx/core/types';
-export {
-	createPlatformDefinitions,
-	mergePlatformDefinitions,
-	replacePlatformFlags,
-	validatePlatform,
-} from '@tsrx/core/types';
 
 export function parse(source: string, filename?: string, options?: ParseOptions): Program;
 

--- a/packages/tsrx-vue/src/index.js
+++ b/packages/tsrx-vue/src/index.js
@@ -14,12 +14,6 @@ import {
 import { transform } from './transform.js';
 
 export { isRefProp } from './ref.js';
-export {
-	createPlatformDefinitions,
-	mergePlatformDefinitions,
-	replacePlatformFlags,
-	validatePlatform,
-} from '@tsrx/core';
 
 /**
  * Parse tsrx-vue source code to an ESTree AST.

--- a/packages/tsrx-vue/src/index.js
+++ b/packages/tsrx-vue/src/index.js
@@ -2,10 +2,24 @@
 /** @import { BaseCompileOptions, CompileError, CompileResult, ParseOptions, VolarMappingsResult } from '@tsrx/core/types' */
 /** @import { NonEmptyString } from '@tsrx/core/types/helpers' */
 
-import { analyzeTsrx, createVolarMappingsResult, dedupeMappings, parseModule } from '@tsrx/core';
+import {
+	analyzeTsrx,
+	createVolarMappingsResult,
+	dedupeMappings,
+	hasPlatformNamespace,
+	parseModule,
+	specializePlatform,
+	withPlatformTypes,
+} from '@tsrx/core';
 import { transform } from './transform.js';
 
 export { isRefProp } from './ref.js';
+export {
+	createPlatformDefinitions,
+	mergePlatformDefinitions,
+	replacePlatformFlags,
+	validatePlatform,
+} from '@tsrx/core';
 
 /**
  * Parse tsrx-vue source code to an ESTree AST.
@@ -33,10 +47,16 @@ export function compile(source, filename, options) {
 	const errors = /** @type {CompileError[]} */ ([]);
 	const comments = /** @type {AST.CommentWithLocation[]} */ ([]);
 	const collect = !!(options?.collect || options?.loose);
-	const ast = parseModule(
+	let ast = parseModule(
 		source,
 		filename,
 		collect ? { collect: true, loose: !!options?.loose, errors, comments } : undefined,
+	);
+	ast = specializePlatform(
+		ast,
+		options?.platform,
+		filename,
+		collect ? { errors, comments } : undefined,
 	);
 	analyzeTsrx(
 		ast,
@@ -64,7 +84,7 @@ export function compile(source, filename, options) {
 export function compile_to_volar_mappings(source, filename, options) {
 	const errors = /** @type {CompileError[]} */ ([]);
 	const comments = /** @type {AST.CommentWithLocation[]} */ ([]);
-	const ast = parseModule(source, filename, {
+	let ast = parseModule(source, filename, {
 		...options,
 		collect: true,
 		loose: !!options?.loose,
@@ -73,6 +93,8 @@ export function compile_to_volar_mappings(source, filename, options) {
 		errors,
 		comments,
 	});
+	const uses_platform_flags = hasPlatformNamespace(ast);
+	ast = specializePlatform(ast, options?.platform, filename, { errors, comments });
 	analyzeTsrx(ast, filename, {
 		collect: true,
 		loose: !!options?.loose,
@@ -98,8 +120,9 @@ export function compile_to_volar_mappings(source, filename, options) {
 		errors,
 	});
 
-	return {
+	const deduped = {
 		...result,
 		mappings: dedupeMappings(result.mappings),
 	};
+	return uses_platform_flags ? withPlatformTypes(deduped, options?.platform) : deduped;
 }

--- a/packages/tsrx-vue/types/index.d.ts
+++ b/packages/tsrx-vue/types/index.d.ts
@@ -1,7 +1,13 @@
 import type { Program } from 'estree';
 import type { BaseCompileOptions, CompileFn, ParseOptions, VolarCompileFn } from '@tsrx/core/types';
 
-export type { RuntimeImportMode } from '@tsrx/core/types';
+export type { Platform, RuntimeImportMode, TsrxPlatformFlags } from '@tsrx/core/types';
+export {
+	createPlatformDefinitions,
+	mergePlatformDefinitions,
+	replacePlatformFlags,
+	validatePlatform,
+} from '@tsrx/core/types';
 
 export function parse(source: string, filename?: string, options?: ParseOptions): Program;
 

--- a/packages/tsrx-vue/types/index.d.ts
+++ b/packages/tsrx-vue/types/index.d.ts
@@ -2,12 +2,6 @@ import type { Program } from 'estree';
 import type { BaseCompileOptions, CompileFn, ParseOptions, VolarCompileFn } from '@tsrx/core/types';
 
 export type { Platform, RuntimeImportMode, TsrxPlatformFlags } from '@tsrx/core/types';
-export {
-	createPlatformDefinitions,
-	mergePlatformDefinitions,
-	replacePlatformFlags,
-	validatePlatform,
-} from '@tsrx/core/types';
 
 export function parse(source: string, filename?: string, options?: ParseOptions): Program;
 

--- a/packages/tsrx/package.json
+++ b/packages/tsrx/package.json
@@ -37,6 +37,10 @@
       "types": "./src/vite/dep-scan.js",
       "default": "./src/vite/dep-scan.js"
     },
+    "./config": {
+      "types": "./types/config.d.ts",
+      "default": "./src/config.js"
+    },
     "./runtime/ref": {
       "types": "./types/runtime/ref.d.ts",
       "default": "./src/runtime/ref.js"
@@ -79,6 +83,7 @@
     "@types/estree": "catalog:default",
     "acorn": "catalog:default",
     "esrap": "catalog:default",
+    "get-tsconfig": "catalog:default",
     "magic-string": "catalog:default",
     "zimmerframe": "catalog:default"
   },

--- a/packages/tsrx/src/config.js
+++ b/packages/tsrx/src/config.js
@@ -1,6 +1,7 @@
 /** @import { Platform } from '../types/index' */
 
 import path from 'node:path';
+import { existsSync, statSync } from 'node:fs';
 import { findTsconfig, getExtendsChain } from 'get-tsconfig';
 import { validate_platform } from './transform/platform.js';
 
@@ -52,6 +53,96 @@ function read_layer_platform(layer) {
 }
 
 /**
+ * @param {string} config_path
+ * @param {unknown} reference
+ * @returns {string}
+ */
+function resolve_reference_path(config_path, reference) {
+	if (
+		!reference ||
+		typeof reference !== 'object' ||
+		Array.isArray(reference) ||
+		typeof (/** @type {Record<string, unknown>} */ (reference).path) !== 'string'
+	) {
+		throw new TypeError(
+			`Invalid TypeScript project reference ${render_value(reference)} in ${config_path}. Expected an object with a string path.`,
+		);
+	}
+
+	const declared_path = /** @type {{ path: string }} */ (reference).path;
+	const candidate = path.resolve(path.dirname(config_path), declared_path);
+	const candidates = [candidate];
+	if (path.extname(candidate) === '') candidates.push(`${candidate}.json`);
+	if (existsSync(candidate) && statSync(candidate).isDirectory()) {
+		candidates.unshift(path.join(candidate, 'tsconfig.json'));
+	}
+
+	for (const file_name of candidates) {
+		if (existsSync(file_name) && statSync(file_name).isFile()) return file_name;
+	}
+
+	throw new Error(
+		`Unable to resolve TypeScript project reference ${JSON.stringify(declared_path)} from ${config_path}.`,
+	);
+}
+
+/**
+ * Resolve the effective platform of one config. If it does not declare or
+ * inherit one, collect selections from its referenced projects recursively.
+ * This covers solution-style Vite configs whose active app settings live in
+ * `tsconfig.app.json`.
+ *
+ * @param {string} config_path
+ * @param {string} integration
+ * @param {Set<string>} visited
+ * @returns {Set<Platform>}
+ */
+function collect_config_platforms(config_path, integration, visited) {
+	const normalized_path = path.resolve(config_path);
+	if (visited.has(normalized_path)) return new Set();
+	visited.add(normalized_path);
+
+	let layers;
+	try {
+		// get-tsconfig returns the root first, followed by extended configs in
+		// precedence order. The first own platform declaration is therefore the
+		// effective value, while a sibling `tsrx.compiler` key can still inherit.
+		layers = getExtendsChain(normalized_path, { cache: new Map() });
+	} catch (error) {
+		throw new Error(
+			`Unable to resolve TSRX platform from ${normalized_path} for ${integration}: ${error instanceof Error ? error.message : String(error)}`,
+			{ cause: error },
+		);
+	}
+
+	for (const layer of layers) {
+		const declared = read_layer_platform(layer);
+		if (declared !== undefined) return new Set([declared]);
+	}
+
+	const root_config = layers[0]?.config;
+	if (!root_config || typeof root_config !== 'object' || Array.isArray(root_config)) {
+		return new Set();
+	}
+	const references = /** @type {Record<string, unknown>} */ (root_config).references;
+	if (references === undefined) return new Set();
+	if (!Array.isArray(references)) {
+		throw new TypeError(
+			`Invalid TypeScript project references ${render_value(references)} in ${normalized_path}. Expected an array.`,
+		);
+	}
+
+	const platforms = new Set();
+	for (const reference of references) {
+		const reference_path = resolve_reference_path(normalized_path, reference);
+		for (const platform of collect_config_platforms(reference_path, integration, visited)) {
+			platforms.add(platform);
+		}
+	}
+	return platforms;
+}
+
+/**
  * Resolve `tsrx.platform` for a builder from the same nearest/configured
  * tsconfig and explicit `extends` graph used by the project. An explicit
  * builder option is retained as an escape hatch, but it must agree with a
@@ -70,28 +161,13 @@ export function resolveBuildPlatform(options = {}) {
 
 	if (!config_path) return explicit_platform;
 
-	let layers;
-	try {
-		// get-tsconfig returns the root first, followed by extended configs in
-		// precedence order. The first own platform declaration is therefore the
-		// effective value, while a sibling `tsrx.compiler` key can still inherit.
-		layers = getExtendsChain(config_path, { cache: new Map() });
-	} catch (error) {
+	const configured_platforms = collect_config_platforms(config_path, integration, new Set());
+	if (configured_platforms.size > 1) {
 		throw new Error(
-			`Unable to resolve TSRX platform from ${config_path} for ${integration}: ${error instanceof Error ? error.message : String(error)}`,
-			{ cause: error },
+			`Referenced TypeScript projects select multiple TSRX platforms for ${integration}: ${[...configured_platforms].map((platform) => JSON.stringify(platform)).join(', ')}. Select one project tsconfig explicitly or declare tsrx.platform in ${config_path}.`,
 		);
 	}
-
-	/** @type {Platform | undefined} */
-	let configured_platform;
-	for (const layer of layers) {
-		const declared = read_layer_platform(layer);
-		if (declared !== undefined) {
-			configured_platform = declared;
-			break;
-		}
-	}
+	const configured_platform = configured_platforms.values().next().value;
 
 	if (
 		explicit_platform !== undefined &&

--- a/packages/tsrx/src/config.js
+++ b/packages/tsrx/src/config.js
@@ -1,0 +1,107 @@
+/** @import { Platform } from '../types/index' */
+
+import path from 'node:path';
+import { findTsconfig, getExtendsChain } from 'get-tsconfig';
+import { validate_platform } from './transform/platform.js';
+
+/**
+ * @typedef {object} BuildPlatformResolutionOptions
+ * @property {string} [root]
+ * @property {string} [tsconfig]
+ * @property {unknown} [platform]
+ * @property {string} [integration]
+ */
+
+/** @param {unknown} value @returns {string} */
+function render_value(value) {
+	try {
+		return JSON.stringify(value) ?? String(value);
+	} catch {
+		return String(value);
+	}
+}
+
+/**
+ * Read one layer's own `tsrx.platform` declaration. `undefined` means this
+ * layer does not declare the key, while every other invalid value throws.
+ *
+ * @param {{ path: string, config: unknown }} layer
+ * @returns {Platform | undefined}
+ */
+function read_layer_platform(layer) {
+	const config = layer.config;
+	if (!config || typeof config !== 'object' || Array.isArray(config)) return undefined;
+	if (!Object.prototype.hasOwnProperty.call(config, 'tsrx')) return undefined;
+
+	const tsrx = /** @type {Record<string, unknown>} */ (config).tsrx;
+	if (!tsrx || typeof tsrx !== 'object' || Array.isArray(tsrx)) {
+		throw new TypeError(
+			`Invalid TSRX declaration ${render_value(tsrx)} in ${layer.path}. Expected an object.`,
+		);
+	}
+	if (!Object.prototype.hasOwnProperty.call(tsrx, 'platform')) return undefined;
+
+	try {
+		return validate_platform(/** @type {Record<string, unknown>} */ (tsrx).platform);
+	} catch (error) {
+		throw new TypeError(
+			`${error instanceof Error ? error.message : String(error)} Declared in ${layer.path}.`,
+			{ cause: error },
+		);
+	}
+}
+
+/**
+ * Resolve `tsrx.platform` for a builder from the same nearest/configured
+ * tsconfig and explicit `extends` graph used by the project. An explicit
+ * builder option is retained as an escape hatch, but it must agree with a
+ * tsconfig declaration when both exist.
+ *
+ * @param {BuildPlatformResolutionOptions} [options]
+ * @returns {Platform | undefined}
+ */
+export function resolveBuildPlatform(options = {}) {
+	const integration = options.integration ?? 'build integration';
+	const explicit_platform = validate_platform(options.platform, `${integration} platform option`);
+	const root = path.resolve(options.root ?? process.cwd());
+	const config_path = options.tsconfig
+		? path.resolve(root, options.tsconfig)
+		: findTsconfig(root, { cache: new Map() });
+
+	if (!config_path) return explicit_platform;
+
+	let layers;
+	try {
+		// get-tsconfig returns the root first, followed by extended configs in
+		// precedence order. The first own platform declaration is therefore the
+		// effective value, while a sibling `tsrx.compiler` key can still inherit.
+		layers = getExtendsChain(config_path, { cache: new Map() });
+	} catch (error) {
+		throw new Error(
+			`Unable to resolve TSRX platform from ${config_path} for ${integration}: ${error instanceof Error ? error.message : String(error)}`,
+			{ cause: error },
+		);
+	}
+
+	/** @type {Platform | undefined} */
+	let configured_platform;
+	for (const layer of layers) {
+		const declared = read_layer_platform(layer);
+		if (declared !== undefined) {
+			configured_platform = declared;
+			break;
+		}
+	}
+
+	if (
+		explicit_platform !== undefined &&
+		configured_platform !== undefined &&
+		explicit_platform !== configured_platform
+	) {
+		throw new Error(
+			`TSRX platform mismatch for ${integration}: tsconfig selects ${JSON.stringify(configured_platform)}, but the integration option selects ${JSON.stringify(explicit_platform)}. Remove the integration option or make the values match.`,
+		);
+	}
+
+	return configured_platform ?? explicit_platform;
+}

--- a/packages/tsrx/src/diagnostics.js
+++ b/packages/tsrx/src/diagnostics.js
@@ -1,4 +1,6 @@
 export const DIAGNOSTIC_CODES = {
+	/** A recognized `import.meta.env.platform.*` flag is used without a selected platform. */
+	PLATFORM_REQUIRED: 'tsrx-platform-required',
 	JSX_EXPRESSION_VALUE: 'tsrx-jsx-expression-value',
 	UNCLOSED_TAG: 'tsrx-unclosed-tag',
 	MISMATCHED_CLOSING_TAG: 'tsrx-mismatched-closing-tag',

--- a/packages/tsrx/src/index.js
+++ b/packages/tsrx/src/index.js
@@ -150,6 +150,18 @@ export { normalize_css_property_name as normalizeCssPropertyName } from './utils
 export { escape, escape_script as escapeScript } from './utils/escaping.js';
 
 // Transform
+export {
+	PLATFORMS,
+	create_platform_definitions as createPlatformDefinitions,
+	get_platform_flag as getPlatformFlag,
+	has_platform_flag as hasPlatformFlag,
+	has_platform_namespace as hasPlatformNamespace,
+	merge_platform_definitions as mergePlatformDefinitions,
+	replace_platform_flags as replacePlatformFlags,
+	specialize_platform as specializePlatform,
+	validate_platform as validatePlatform,
+	with_platform_types as withPlatformTypes,
+} from './transform/platform.js';
 export { with_deferred_imports as withDeferredImports } from './transform/imports.js';
 export {
 	add_jsx_setup_declaration as addJsxSetupDeclaration,

--- a/packages/tsrx/src/transform/platform.js
+++ b/packages/tsrx/src/transform/platform.js
@@ -1,0 +1,365 @@
+/** @import * as AST from 'estree' */
+/** @import { CompileError, Platform, PlatformSpecializationOptions } from '../../types/index' */
+
+import MagicString from 'magic-string';
+import { DIAGNOSTIC_CODES } from '../diagnostics.js';
+import { error } from '../errors.js';
+import { parse_module } from '../parse/parse-module.js';
+import { child_nodes, is_ast_node } from '../utils/ast.js';
+
+export const PLATFORMS = /** @type {const} */ (['web', 'ios', 'android']);
+
+const platform_set = new Set(PLATFORMS);
+
+/** @param {unknown} value @returns {string} */
+function render_value(value) {
+	try {
+		return JSON.stringify(value) ?? String(value);
+	} catch {
+		return String(value);
+	}
+}
+
+/**
+ * Validate a public compiler/build integration platform option without
+ * coercion. `undefined` represents an unconfigured project and remains valid.
+ *
+ * @param {unknown} platform
+ * @param {string} [option_name]
+ * @returns {Platform | undefined}
+ */
+export function validate_platform(platform, option_name = 'platform') {
+	if (platform === undefined || platform_set.has(/** @type {Platform} */ (platform))) {
+		return /** @type {Platform | undefined} */ (platform);
+	}
+
+	const rendered = render_value(platform);
+	throw new TypeError(
+		`Invalid TSRX ${option_name} ${rendered}. Expected "web", "ios", or "android".`,
+	);
+}
+
+/**
+ * Return the selected platform name for one of the three exact supported
+ * property paths, or `null` for every other expression.
+ *
+ * Parentheses do not change whether an if-test is exact. Other wrappers and
+ * operators intentionally do: `!flag`, `flag === true`, optional access, and
+ * computed access remain ordinary runtime expressions.
+ *
+ * @param {AST.Node | null | undefined} node
+ * @returns {Platform | null}
+ */
+export function get_platform_flag(node) {
+	while (node?.type === 'ParenthesizedExpression') {
+		node = node.expression;
+	}
+
+	if (
+		node?.type !== 'MemberExpression' ||
+		node.computed ||
+		node.optional ||
+		node.property.type !== 'Identifier' ||
+		!platform_set.has(/** @type {Platform} */ (node.property.name))
+	) {
+		return null;
+	}
+
+	const platform = node.object;
+	if (!is_platform_namespace(platform)) return null;
+
+	return /** @type {Platform} */ (node.property.name);
+}
+
+/** @param {AST.Node | null | undefined} node @returns {boolean} */
+function is_platform_namespace(node) {
+	if (
+		node?.type !== 'MemberExpression' ||
+		node.computed ||
+		node.optional ||
+		node.property.type !== 'Identifier' ||
+		node.property.name !== 'platform'
+	) {
+		return false;
+	}
+
+	const env = node.object;
+	if (
+		env.type !== 'MemberExpression' ||
+		env.computed ||
+		env.optional ||
+		env.property.type !== 'Identifier' ||
+		env.property.name !== 'env'
+	) {
+		return false;
+	}
+
+	const import_meta = env.object;
+	if (
+		import_meta.type !== 'MetaProperty' ||
+		import_meta.meta.type !== 'Identifier' ||
+		import_meta.meta.name !== 'import' ||
+		import_meta.property.type !== 'Identifier' ||
+		import_meta.property.name !== 'meta'
+	) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Find the first exact platform flag anywhere in a parsed source tree.
+ *
+ * @param {AST.Node} node
+ * @returns {AST.Node | null}
+ */
+function find_platform_flag(node) {
+	if (get_platform_flag(node) !== null) return node;
+
+	for (const child of child_nodes(node)) {
+		const found = find_platform_flag(child);
+		if (found) return found;
+	}
+
+	return null;
+}
+
+/** @param {AST.Node} node @returns {boolean} */
+export function has_platform_flag(node) {
+	return find_platform_flag(node) !== null;
+}
+
+/** @param {AST.Node} node @returns {boolean} */
+export function has_platform_namespace(node) {
+	if (is_platform_namespace(node)) return true;
+	return child_nodes(node).some(has_platform_namespace);
+}
+
+/**
+ * A location-free no-op used when a false platform guard has no `else` arm.
+ * Keeping a statement in single-statement slots (labels, loops, and outer
+ * if-statements) preserves a valid ESTree shape without mapping discarded
+ * source into generated output.
+ *
+ * @returns {AST.EmptyStatement}
+ */
+function empty_statement() {
+	return { type: 'EmptyStatement', metadata: { path: [] } };
+}
+
+/**
+ * Copy-on-write specialization of arbitrary AST properties. An exact ordinary
+ * `if (import.meta.env.platform.<name>)` is replaced by its selected original
+ * statement. A selected block therefore retains both its lexical scope and its
+ * authored source locations.
+ *
+ * @param {AST.Node} node
+ * @param {Platform} platform
+ * @returns {AST.Node}
+ */
+function specialize_node(node, platform) {
+	if (node.type === 'IfStatement') {
+		const flag = get_platform_flag(node.test);
+		if (flag !== null) {
+			const selected = flag === platform ? node.consequent : node.alternate;
+			return selected ? specialize_node(selected, platform) : empty_statement();
+		}
+	}
+
+	/** @type {Record<string, unknown> | null} */
+	let clone = null;
+	const record = /** @type {Record<string, unknown>} */ (node);
+
+	for (const key of Object.keys(record)) {
+		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') continue;
+
+		const value = record[key];
+		if (Array.isArray(value)) {
+			/** @type {unknown[] | null} */
+			let next_array = null;
+			for (let index = 0; index < value.length; index += 1) {
+				const item = value[index];
+				if (!is_ast_node(item)) continue;
+				const next_item = specialize_node(item, platform);
+				if (next_item !== item) {
+					next_array ??= [...value];
+					next_array[index] = next_item;
+				}
+			}
+			if (next_array) {
+				clone ??= { ...record };
+				clone[key] = next_array;
+			}
+			continue;
+		}
+
+		if (is_ast_node(value)) {
+			const next_value = specialize_node(value, platform);
+			if (next_value !== value) {
+				clone ??= { ...record };
+				clone[key] = next_value;
+			}
+		}
+	}
+
+	return /** @type {AST.Node} */ (clone ?? node);
+}
+
+/**
+ * Select ordinary platform-guarded branches before semantic analysis. Parsing
+ * has already visited every branch, so syntax errors still surface. Without a
+ * configured platform, use of any recognized flag is an actionable source
+ * diagnostic and the AST remains unchanged.
+ *
+ * @param {AST.Program} ast
+ * @param {unknown} platform_value
+ * @param {string | null | undefined} filename
+ * @param {PlatformSpecializationOptions} [options]
+ * @returns {AST.Program}
+ */
+export function specialize_platform(ast, platform_value, filename, options = {}) {
+	const platform = validate_platform(platform_value);
+	if (platform === undefined) {
+		const flag = find_platform_flag(ast);
+		if (flag) {
+			error(
+				'Platform flag usage requires a configured TSRX platform. Set `tsrx.platform` in tsconfig.json and pass the same `platform` to the build integration ("web", "ios", or "android").',
+				filename ?? null,
+				flag,
+				options.errors,
+				options.comments,
+				DIAGNOSTIC_CODES.PLATFORM_REQUIRED,
+			);
+		}
+		return ast;
+	}
+
+	return /** @type {AST.Program} */ (specialize_node(ast, platform));
+}
+
+/**
+ * Build the exact boolean definitions understood by supported bundlers.
+ *
+ * @param {unknown} platform_value
+ * @returns {Record<`import.meta.env.platform.${Platform}`, boolean>}
+ */
+export function create_platform_definitions(platform_value) {
+	const platform = validate_platform(platform_value);
+	if (platform === undefined) {
+		return /** @type {Record<`import.meta.env.platform.${Platform}`, boolean>} */ ({});
+	}
+
+	return {
+		'import.meta.env.platform.web': platform === 'web',
+		'import.meta.env.platform.ios': platform === 'ios',
+		'import.meta.env.platform.android': platform === 'android',
+	};
+}
+
+/**
+ * Merge platform constants into a builder's native definition map and reject
+ * an existing exact definition that selects a different value.
+ *
+ * @param {Record<string, unknown> | undefined} definitions
+ * @param {unknown} platform_value
+ * @param {{ integration?: string, serialize?: boolean }} [options]
+ * @returns {Record<string, unknown>}
+ */
+export function merge_platform_definitions(definitions, platform_value, options = {}) {
+	const platform_definitions = create_platform_definitions(platform_value);
+	const merged = { ...(definitions ?? {}) };
+	const integration = options.integration ?? 'build integration';
+	for (const parent of ['import.meta', 'import.meta.env', 'import.meta.env.platform']) {
+		if (Object.prototype.hasOwnProperty.call(merged, parent)) {
+			throw new Error(
+				`Conflicting ${integration} definition for ${parent}: TSRX defines the three exact import.meta.env.platform.* paths for platform ${render_value(platform_value)}.`,
+			);
+		}
+	}
+
+	for (const [key, expected] of Object.entries(platform_definitions)) {
+		if (Object.prototype.hasOwnProperty.call(merged, key)) {
+			const actual = merged[key];
+			const matches = actual === expected || actual === String(expected);
+			if (!matches) {
+				throw new Error(
+					`Conflicting ${integration} definition for ${key}: expected ${expected} for TSRX platform ${render_value(platform_value)}, received ${render_value(actual)}.`,
+				);
+			}
+		}
+		merged[key] = options.serialize ? String(expected) : expected;
+	}
+
+	return merged;
+}
+
+/**
+ * Add editor-only ambient types for flags retained in virtual TSX (for example
+ * a runtime `@if`). The original source is an external module by virtue of
+ * using `import.meta`; `export {}` preserves that status if early pruning
+ * removed its final import-meta expression.
+ *
+ * @param {import('../../types/index').VolarMappingsResult} result
+ * @param {unknown} platform_value
+ * @returns {import('../../types/index').VolarMappingsResult}
+ */
+export function with_platform_types(result, platform_value) {
+	const platform = validate_platform(platform_value);
+	const value_type = (/** @type {Platform} */ name) =>
+		platform === undefined ? 'boolean' : name === platform ? 'true' : 'false';
+	const declarations = `
+export {};
+declare global {
+	interface ImportMetaEnv {
+		readonly platform: string & {
+			readonly web: ${value_type('web')};
+			readonly ios: ${value_type('ios')};
+			readonly android: ${value_type('android')};
+		};
+	}
+	interface ImportMeta {
+		readonly [key: \`env\${string}\`]: ImportMetaEnv;
+	}
+}
+`;
+	return { ...result, code: result.code + declarations };
+}
+
+/**
+ * Replace exact platform flag expressions in a JavaScript/TypeScript module.
+ * This is used by integrations without a native `define` facility. It does not
+ * perform dead-code elimination; the downstream bundler sees literal booleans
+ * and owns that optimization.
+ *
+ * @param {string} source
+ * @param {string} filename
+ * @param {unknown} platform_value
+ * @returns {{ code: string, map: import('source-map').RawSourceMap }}
+ */
+export function replace_platform_flags(source, filename, platform_value) {
+	const platform = validate_platform(platform_value);
+	if (platform === undefined) {
+		throw new TypeError('Replacing TSRX platform flags requires a configured platform.');
+	}
+
+	const ast = parse_module(source, filename);
+	const output = new MagicString(source);
+
+	/** @param {AST.Node} node */
+	function visit(node) {
+		const flag = get_platform_flag(node);
+		if (flag !== null && node.start !== undefined && node.end !== undefined) {
+			output.overwrite(node.start, node.end, flag === platform ? 'true' : 'false');
+			return;
+		}
+
+		for (const child of child_nodes(node)) visit(child);
+	}
+
+	visit(ast);
+	return {
+		code: output.toString(),
+		map: output.generateMap({ source: filename, includeContent: true, hires: true }),
+	};
+}

--- a/packages/tsrx/src/transform/platform.js
+++ b/packages/tsrx/src/transform/platform.js
@@ -2,6 +2,7 @@
 /** @import { CompileError, Platform, PlatformSpecializationOptions } from '../../types/index' */
 
 import MagicString from 'magic-string';
+import { decode, encode } from '@jridgewell/sourcemap-codec';
 import { DIAGNOSTIC_CODES } from '../diagnostics.js';
 import { error } from '../errors.js';
 import { parse_module } from '../parse/parse-module.js';
@@ -327,6 +328,106 @@ declare global {
 }
 
 /**
+ * @param {unknown} map
+ * @returns {import('source-map').RawSourceMap | undefined}
+ */
+function normalize_source_map(map) {
+	if (map == null) return undefined;
+	const parsed = typeof map === 'string' ? JSON.parse(map) : map;
+	return parsed && typeof parsed === 'object' && typeof parsed.mappings === 'string'
+		? /** @type {import('source-map').RawSourceMap} */ (parsed)
+		: undefined;
+}
+
+/**
+ * Compose the high-resolution follow-up map through an incoming loader map.
+ *
+ * @param {import('source-map').RawSourceMap} input_map
+ * @param {import('source-map').RawSourceMap} output_map
+ * @returns {import('source-map').RawSourceMap}
+ */
+function compose_source_maps(input_map, output_map) {
+	const input_lines = decode(input_map.mappings);
+	const output_lines = decode(output_map.mappings);
+
+	/**
+	 * Trace an intermediate generated position through the prior map with the
+	 * source-map spec's greatest-lower-bound lookup.
+	 *
+	 * @param {number} line
+	 * @param {number} column
+	 * @returns {[number, number, number, number] | [number, number, number, number, number] | null}
+	 */
+	function trace(line, column) {
+		const segments = input_lines[line];
+		if (!segments?.length) return null;
+
+		let low = 0;
+		let high = segments.length - 1;
+		let found = -1;
+		while (low <= high) {
+			const middle = (low + high) >> 1;
+			if (segments[middle][0] <= column) {
+				found = middle;
+				low = middle + 1;
+			} else {
+				high = middle - 1;
+			}
+		}
+		if (found < 0 || segments[found].length < 4) return null;
+
+		const segment = segments[found];
+		return segment.length > 4
+			? [
+					column,
+					/** @type {number} */ (segment[1]),
+					/** @type {number} */ (segment[2]),
+					/** @type {number} */ (segment[3]),
+					/** @type {number} */ (segment[4]),
+				]
+			: [
+					column,
+					/** @type {number} */ (segment[1]),
+					/** @type {number} */ (segment[2]),
+					/** @type {number} */ (segment[3]),
+				];
+	}
+
+	/** @type {Array<Array<[number] | [number, number, number, number] | [number, number, number, number, number]>>} */
+	const composed = [];
+	for (const output_line of output_lines) {
+		/** @type {Array<[number] | [number, number, number, number] | [number, number, number, number, number]>} */
+		const composed_line = [];
+		for (const output_segment of output_line) {
+			if (output_segment.length < 4) {
+				composed_line.push([output_segment[0]]);
+				continue;
+			}
+
+			const traced = trace(
+				/** @type {number} */ (output_segment[2]),
+				/** @type {number} */ (output_segment[3]),
+			);
+			if (!traced) {
+				// Break any preceding mapping rather than allowing it to bleed across
+				// generated text that has no origin in the incoming map.
+				composed_line.push([output_segment[0]]);
+				continue;
+			}
+			traced[0] = output_segment[0];
+			composed_line.push(traced);
+		}
+		composed.push(composed_line);
+	}
+
+	return {
+		...input_map,
+		file: output_map.file ?? input_map.file,
+		mappings: encode(composed),
+	};
+}
+
+/**
  * Replace exact platform flag expressions in a JavaScript/TypeScript module.
  * This is used by integrations without a native `define` facility. It does not
  * perform dead-code elimination; the downstream bundler sees literal booleans
@@ -335,14 +436,16 @@ declare global {
  * @param {string} source
  * @param {string} filename
  * @param {unknown} platform_value
+ * @param {import('source-map').RawSourceMap | string | null} [input_map]
  * @returns {{ code: string, map: import('source-map').RawSourceMap }}
  */
-export function replace_platform_flags(source, filename, platform_value) {
+export function replace_platform_flags(source, filename, platform_value, input_map) {
 	const platform = validate_platform(platform_value);
 	if (platform === undefined) {
 		throw new TypeError('Replacing TSRX platform flags requires a configured platform.');
 	}
 
+	const incoming = normalize_source_map(input_map);
 	const ast = parse_module(source, filename);
 	const output = new MagicString(source);
 
@@ -358,8 +461,13 @@ export function replace_platform_flags(source, filename, platform_value) {
 	}
 
 	visit(ast);
+	if (!output.hasChanged() && incoming) {
+		return { code: source, map: incoming };
+	}
+
+	const map = output.generateMap({ source: filename, includeContent: true, hires: true });
 	return {
 		code: output.toString(),
-		map: output.generateMap({ source: filename, includeContent: true, hires: true }),
+		map: incoming ? compose_source_maps(incoming, map) : map,
 	};
 }

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -44,6 +44,34 @@ function virtual_parse_diagnostics(code) {
 		.parseDiagnostics;
 }
 
+/** @param {string} code @returns {readonly ts.Diagnostic[]} */
+function virtual_semantic_diagnostics(code) {
+	const file_name = '/virtual-platform.tsx';
+	const options = {
+		target: ts.ScriptTarget.ESNext,
+		module: ts.ModuleKind.ESNext,
+		noEmit: true,
+		noLib: true,
+	};
+	const source_file = ts.createSourceFile(
+		file_name,
+		code,
+		ts.ScriptTarget.Latest,
+		true,
+		ts.ScriptKind.TSX,
+	);
+	const base_host = ts.createCompilerHost(options);
+	const host = {
+		...base_host,
+		fileExists: (/** @type {string} */ name) => name === file_name,
+		readFile: (/** @type {string} */ name) => (name === file_name ? code : undefined),
+		getSourceFile: (/** @type {string} */ name) => (name === file_name ? source_file : undefined),
+		getCurrentDirectory: () => '/',
+	};
+	const program = ts.createProgram([file_name], options, host);
+	return program.getSemanticDiagnostics(source_file);
+}
+
 const TSRX_TEMPLATE_RETURN_ERROR =
 	'Return statements are not allowed inside TSRX templates. Move the return before the TSRX return value, or use conditional rendering instead.';
 
@@ -62,6 +90,22 @@ const UNSUPPORTED_LAZY_ASSIGNMENT_SOURCES = [
  * @param {CompileDiagnosticsHarness} harness
  */
 export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, name }) {
+	describe(`[${name}] platform flag virtual types`, () => {
+		it('types every retained flag with the selected boolean literal', () => {
+			const result = compile_to_volar_mappings(
+				`export const web: false = import.meta.env.platform.web;
+				export const ios: true = import.meta.env.platform.ios;
+				export const android: false = import.meta.env.platform.android;`,
+				'App.tsrx',
+				{ platform: 'ios' },
+			);
+
+			expect(result.errors).toEqual([]);
+			expect(virtual_parse_diagnostics(result.code)).toEqual([]);
+			expect(virtual_semantic_diagnostics(result.code)).toEqual([]);
+		});
+	});
+
 	describe(`[${name}] type-only style stand-ins`, () => {
 		it('keeps consecutive <style> siblings parseable as TSX', () => {
 			// Each stand-in is its own `void` expression statement; two adjacent
@@ -2567,6 +2611,8 @@ export function runSharedCompileTests({
 			? '{ className }: { className?: string }'
 			: '{ class: className }: { class?: string }';
 
+	runSharedPlatformTests({ compile, name });
+
 	runSharedComponentLoopControlFlowTests({ compile, name });
 	runSharedScopedStyleTests({ compile, name, classAttrName, generatedClassAttrName });
 	runSharedScopedStyleConformanceTests({ compile, name, classAttrName, generatedClassAttrName });
@@ -4867,6 +4913,141 @@ export function optionalFn(bar: string, baz?: string) {
 			});
 		},
 	);
+}
+
+/**
+ * Compile-time platform specialization shared by every built-in JSX target.
+ *
+ * @param {Pick<CompileHarness, 'compile' | 'name'>} harness
+ */
+function runSharedPlatformTests({ compile, name }) {
+	describe(`[${name}] compile-time platform flags`, () => {
+		it.each([
+			['web', 'selected_web'],
+			['ios', 'selected_ios'],
+			['android', 'selected_android'],
+		])('selects the %s branch before target lowering', (platform, selected) => {
+			const { code } = compile(
+				`if (import.meta.env.platform.web) {
+					const selected_web = 'selected_web';
+				} else if (import.meta.env.platform.ios) {
+					const selected_ios = 'selected_ios';
+				} else {
+					const selected_android = 'selected_android';
+				}`,
+				'App.tsrx',
+				{ platform: /** @type {import('../../types/index').Platform} */ (platform) },
+			);
+
+			expect(code).toContain(selected);
+			for (const discarded of ['selected_web', 'selected_ios', 'selected_android']) {
+				if (discarded !== selected) expect(code).not.toContain(discarded);
+			}
+			expect(code).not.toContain('import.meta.env.platform');
+		});
+
+		it('specializes nested guards and retains selected lexical blocks', () => {
+			const { code } = compile(
+				`if (import.meta.env.platform.ios) {
+					const outer = 'ios_outer';
+					if (import.meta.env.platform.ios) {
+						const inner = outer;
+						consume(inner);
+					}
+				} else {
+					consume('not_ios');
+				}`,
+				'App.tsrx',
+				{ platform: 'ios' },
+			);
+
+			expect(code).toContain("const outer = 'ios_outer'");
+			expect(code).toContain('const inner = outer');
+			expect(code).toMatch(/\{[\s\S]*const outer[\s\S]*\{[\s\S]*const inner/);
+			expect(code).not.toContain('not_ios');
+		});
+
+		it('drops inactive imports and scoped CSS before dependency/style analysis', () => {
+			const { code, css } = compile(
+				`if (import.meta.env.platform.web) {
+					import('./missing-web-only');
+					function PlatformView() @{ <>
+						<style>.web-only { color: red; }</style>
+						<div class="web-only" />
+					</> }
+				} else {
+					function PlatformView() @{ <>
+						<style>.native-only { color: blue; }</style>
+						<div class="native-only" />
+					</> }
+				}`,
+				'App.tsrx',
+				{ platform: 'android' },
+			);
+
+			expect(code).not.toContain('missing-web-only');
+			expect(code).not.toContain('web-only');
+			expect(code).toContain('native-only');
+			expect(css).not.toContain('web-only');
+			expect(css).toContain('native-only');
+		});
+
+		it('does not semantically analyze an inactive TSRX branch', () => {
+			expect(() =>
+				compile(
+					`if (import.meta.env.platform.web) {
+						function InvalidOnlyOnWeb() @{
+							<style>.invalid-lone-output { color: red; }</style>
+						}
+					} else {
+						const selected_native = true;
+					}`,
+					'App.tsrx',
+					{ platform: 'android' },
+				),
+			).not.toThrow();
+		});
+
+		it('keeps @if as runtime template control flow', () => {
+			const { code } = compile(
+				`function App() @{
+					@if (import.meta.env.platform.web) {
+						<div>{'web'}</div>
+					} @else {
+						<div>{'native'}</div>
+					}
+				}`,
+				'App.tsrx',
+				{ platform: 'web' },
+			);
+
+			expect(code).toContain('import.meta.env.platform.web');
+			expect(code).toContain('web');
+			expect(code).toContain('native');
+		});
+
+		it('requires configuration when a recognized flag is used', () => {
+			expect(() => compile('if (import.meta.env.platform.web) { consume(); }', 'App.tsrx')).toThrow(
+				/requires a configured TSRX platform/,
+			);
+
+			const result = compile('if (import.meta.env.platform.web) { consume(); }', 'App.tsrx', {
+				collect: true,
+			});
+			expect(diagnostic_codes(result)).toContain(DIAGNOSTIC_CODES.PLATFORM_REQUIRED);
+		});
+
+		it.each(['windows', null, true, 1, [], {}])(
+			'rejects invalid platform option %j',
+			(platform) => {
+				expect(() =>
+					compile('const value = 1;', 'App.tsrx', {
+						platform: /** @type {any} */ (platform),
+					}),
+				).toThrow(/Invalid TSRX platform/);
+			},
+		);
+	});
 }
 
 /**

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -21,6 +21,56 @@ export function runSharedSourceMappingTests({
 	name,
 	rejectsComponentAwait,
 }) {
+	describe(`[${name}] platform-specialized source mappings`, () => {
+		it('maps only the selected branch and keeps its authored block location', () => {
+			const source = `if (import.meta.env.platform.web) {
+	const inactive_web_value = window.innerWidth;
+} else {
+	const active_native_value = nativeHost.width;
+	consume(active_native_value);
+}`;
+			const result = compile_to_volar_mappings(source, 'App.tsrx', {
+				loose: true,
+				platform: 'ios',
+			});
+			const inactive_start = source.indexOf('inactive_web_value');
+			const inactive_end = source.indexOf('}', inactive_start);
+			const selected_block_start = source.indexOf('{', source.indexOf('else'));
+
+			expect(result.code).not.toContain('inactive_web_value');
+			expect(result.code).toContain('active_native_value');
+			expect(result.sourceAst.body[0].type).toBe('BlockStatement');
+			expect(result.sourceAst.body[0].start).toBe(selected_block_start);
+			expect(
+				result.mappings.some((mapping) => {
+					const start = mapping.sourceOffsets[0];
+					return start >= inactive_start && start < inactive_end;
+				}),
+			).toBe(false);
+		});
+
+		it('omits embedded CSS and script regions from the discarded branch', () => {
+			const source = `if (import.meta.env.platform.web) {
+	function Web() @{ <><style>.web-only { color: red; }</style><script>const webScript = 1;</script><div class="web-only" /></> }
+} else {
+	function Native() @{ <><style>.native-only { color: blue; }</style><script>const nativeScript = 1;</script><div class="native-only" /></> }
+}`;
+			const result = compile_to_volar_mappings(source, 'App.tsrx', {
+				loose: true,
+				platform: 'android',
+			});
+			const css_contents = result.cssMappings.map((mapping) => mapping.data.customData.content);
+
+			expect(css_contents.join('\n')).not.toContain('web-only');
+			expect(css_contents.join('\n')).toContain('native-only');
+			const script_contents = result.scriptMappings.map(
+				(mapping) => mapping.data.customData.content,
+			);
+			expect(script_contents.join('\n')).not.toContain('webScript');
+			expect(script_contents.join('\n')).toContain('nativeScript');
+		});
+	});
+
 	describe(`[${name}] shared TypeScript editor diagnostics`, () => {
 		it.each(['Value extends { id: string }', 'Value = string', 'Value,'])(
 			'accepts an unambiguous generic arrow (%s)',

--- a/packages/tsrx/tests/utils/config.test.js
+++ b/packages/tsrx/tests/utils/config.test.js
@@ -1,0 +1,88 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveBuildPlatform } from '../../src/config.js';
+
+/** @type {string} */
+let directory;
+
+/** @param {string} relative_path @param {string | object} config */
+function write_config(relative_path, config) {
+	const file_name = path.join(directory, relative_path);
+	fs.mkdirSync(path.dirname(file_name), { recursive: true });
+	fs.writeFileSync(
+		file_name,
+		typeof config === 'string' ? config : JSON.stringify(config, null, 2),
+	);
+	return file_name;
+}
+
+beforeEach(() => {
+	directory = fs.mkdtempSync(path.join(os.tmpdir(), 'tsrx-build-platform-'));
+});
+
+afterEach(() => {
+	fs.rmSync(directory, { recursive: true, force: true });
+});
+
+describe('build platform resolution', () => {
+	it.each(['web', 'ios', 'android'])('reads %s from the nearest tsconfig', (platform) => {
+		write_config('tsconfig.json', { tsrx: { platform } });
+		expect(resolveBuildPlatform({ root: path.join(directory, 'src') })).toBe(platform);
+	});
+
+	it('resolves JSONC, inheritance, and the platform key independently from compiler', () => {
+		write_config(
+			'configs/base.json',
+			`{
+				// Shared target and platform
+				"tsrx": { "compiler": "@tsrx/react", "platform": "ios", },
+			}`,
+		);
+		write_config('tsconfig.json', {
+			extends: './configs/base.json',
+			tsrx: { compiler: '@tsrx/preact' },
+		});
+
+		expect(resolveBuildPlatform({ root: directory })).toBe('ios');
+	});
+
+	it('uses TypeScript extends-array precedence', () => {
+		write_config('a.json', { tsrx: { platform: 'web' } });
+		write_config('b.json', { tsrx: { platform: 'android' } });
+		write_config('tsconfig.json', { extends: ['./a.json', './b.json'] });
+
+		expect(resolveBuildPlatform({ root: directory })).toBe('android');
+	});
+
+	it('honors an explicit custom tsconfig path', () => {
+		write_config('tsconfig.json', { tsrx: { platform: 'web' } });
+		write_config('configs/tsconfig.native.json', { tsrx: { platform: 'android' } });
+
+		expect(
+			resolveBuildPlatform({ root: directory, tsconfig: 'configs/tsconfig.native.json' }),
+		).toBe('android');
+	});
+
+	it('uses an explicit integration option only when tsconfig omits the platform', () => {
+		write_config('tsconfig.json', { tsrx: { compiler: '@tsrx/react' } });
+		expect(resolveBuildPlatform({ root: directory, platform: 'web' })).toBe('web');
+	});
+
+	it('rejects a mismatch between tsconfig and an explicit integration option', () => {
+		write_config('tsconfig.json', { tsrx: { platform: 'ios' } });
+		expect(() =>
+			resolveBuildPlatform({
+				root: directory,
+				platform: 'web',
+				integration: 'test builder',
+			}),
+		).toThrow(/platform mismatch.*tsconfig selects "ios".*option selects "web"/i);
+	});
+
+	it.each(['windows', null, true, 1, [], {}])('rejects invalid config value %j', (platform) => {
+		write_config('tsconfig.json', { tsrx: { platform } });
+		expect(() => resolveBuildPlatform({ root: directory })).toThrow(/Invalid TSRX platform/);
+	});
+});

--- a/packages/tsrx/tests/utils/config.test.js
+++ b/packages/tsrx/tests/utils/config.test.js
@@ -56,6 +56,41 @@ describe('build platform resolution', () => {
 		expect(resolveBuildPlatform({ root: directory })).toBe('android');
 	});
 
+	it('finds the platform in a referenced active application config', () => {
+		write_config('configs/base.json', { tsrx: { platform: 'ios' } });
+		write_config('tsconfig.app.json', {
+			extends: './configs/base.json',
+			tsrx: { compiler: '@tsrx/react' },
+		});
+		write_config('tsconfig.node.json', { compilerOptions: { types: ['node'] } });
+		write_config('tsconfig.json', {
+			files: [],
+			references: [{ path: './tsconfig.app.json' }, { path: './tsconfig.node.json' }],
+		});
+
+		expect(resolveBuildPlatform({ root: directory })).toBe('ios');
+	});
+
+	it('follows nested directory project references', () => {
+		write_config('apps/native/tsconfig.json', { tsrx: { platform: 'android' } });
+		write_config('apps/tsconfig.json', { references: [{ path: './native' }] });
+		write_config('tsconfig.json', { references: [{ path: './apps' }] });
+
+		expect(resolveBuildPlatform({ root: directory })).toBe('android');
+	});
+
+	it('rejects ambiguous platforms from referenced projects', () => {
+		write_config('tsconfig.web.json', { tsrx: { platform: 'web' } });
+		write_config('tsconfig.native.json', { tsrx: { platform: 'android' } });
+		write_config('tsconfig.json', {
+			references: [{ path: './tsconfig.web.json' }, { path: './tsconfig.native.json' }],
+		});
+
+		expect(() => resolveBuildPlatform({ root: directory })).toThrow(
+			/referenced TypeScript projects select multiple TSRX platforms/i,
+		);
+	});
+
 	it('honors an explicit custom tsconfig path', () => {
 		write_config('tsconfig.json', { tsrx: { platform: 'web' } });
 		write_config('configs/tsconfig.native.json', { tsrx: { platform: 'android' } });

--- a/packages/tsrx/tests/utils/platform.test.js
+++ b/packages/tsrx/tests/utils/platform.test.js
@@ -1,3 +1,4 @@
+import { encode } from '@jridgewell/sourcemap-codec';
 import { describe, expect, it } from 'vitest';
 import {
 	createPlatformDefinitions,
@@ -61,5 +62,42 @@ describe('platform specialization', () => {
 		expect(result.code).toContain("'import.meta.env.platform.ios'");
 		expect(result.code).toContain('const active = true;');
 		expect(result.map.sources).toEqual(['flags.ts']);
+		expect(result.map.sourcesContent?.[0]).toBe(source);
+	});
+
+	it('preserves an incoming map when there is nothing to rewrite', () => {
+		const source = 'export const ready = true;';
+		const incoming = {
+			version: 3,
+			file: 'App.js',
+			sources: ['App.tsrx'],
+			sourcesContent: ['export function App() @{ true }'],
+			names: [],
+			mappings: 'AAAA',
+		};
+
+		const result = replacePlatformFlags(source, 'App.tsrx', 'web', incoming);
+
+		expect(result.code).toBe(source);
+		expect(result.map).toBe(incoming);
+	});
+
+	it('composes rewritten output through an incoming compile map', () => {
+		const intermediate = 'const active = import.meta.env.platform.android;\n';
+		const original = 'const active = PLATFORM_FLAG;\n';
+		const incoming = {
+			version: 3,
+			file: 'App.js',
+			sources: ['App.tsrx'],
+			sourcesContent: [original],
+			names: [],
+			mappings: encode([[[0, 0, 0, 0]]]),
+		};
+
+		const result = replacePlatformFlags(intermediate, 'App.tsrx', 'android', incoming);
+
+		expect(result.code).toContain('const active = true;');
+		expect(result.map.sources).toEqual(['App.tsrx']);
+		expect(result.map.sourcesContent).toEqual([original]);
 	});
 });

--- a/packages/tsrx/tests/utils/platform.test.js
+++ b/packages/tsrx/tests/utils/platform.test.js
@@ -1,4 +1,4 @@
-import { encode } from '@jridgewell/sourcemap-codec';
+import { decode, encode } from '@jridgewell/sourcemap-codec';
 import { describe, expect, it } from 'vitest';
 import {
 	createPlatformDefinitions,
@@ -91,7 +91,7 @@ describe('platform specialization', () => {
 			sources: ['App.tsrx'],
 			sourcesContent: [original],
 			names: [],
-			mappings: encode([[[0, 0, 0, 0]]]),
+			mappings: encode([[[0, 0, 3, 5]]]),
 		};
 
 		const result = replacePlatformFlags(intermediate, 'App.tsrx', 'android', incoming);
@@ -99,5 +99,10 @@ describe('platform specialization', () => {
 		expect(result.code).toContain('const active = true;');
 		expect(result.map.sources).toEqual(['App.tsrx']);
 		expect(result.map.sourcesContent).toEqual([original]);
+		expect(
+			decode(result.map.mappings)
+				.flat()
+				.some((segment) => segment.length >= 4 && segment[2] === 3 && segment[3] === 5),
+		).toBe(true);
 	});
 });

--- a/packages/tsrx/tests/utils/platform.test.js
+++ b/packages/tsrx/tests/utils/platform.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+	createPlatformDefinitions,
+	parseModule,
+	replacePlatformFlags,
+	specializePlatform,
+} from '../../src/index.js';
+
+describe('platform specialization', () => {
+	it('is copy-on-write and retains the selected original statement', () => {
+		const ast = parseModule(
+			`if (import.meta.env.platform.web) {
+				const selected = 'web';
+			} else {
+				const selected = 'native';
+			}`,
+			'App.tsrx',
+		);
+		const original_if = ast.body[0];
+		if (original_if.type !== 'IfStatement') throw new Error('expected IfStatement');
+
+		const specialized = specializePlatform(ast, 'web', 'App.tsrx');
+
+		expect(specialized).not.toBe(ast);
+		expect(specialized.body[0]).toBe(original_if.consequent);
+		expect(ast.body[0]).toBe(original_if);
+		expect(ast.body[0].type).toBe('IfStatement');
+	});
+
+	it('returns an unguarded program unchanged', () => {
+		const ast = parseModule('if (ready) consume();', 'App.tsrx');
+		expect(specializePlatform(ast, 'web', 'App.tsrx')).toBe(ast);
+	});
+
+	it('recognizes only exact, non-computed property paths', () => {
+		const ast = parseModule(
+			`if (import.meta.env.platform['web']) consume('computed');
+			if (!import.meta.env.platform.web) consume('negated');`,
+			'App.tsrx',
+		);
+		const specialized = specializePlatform(ast, 'web', 'App.tsrx');
+
+		expect(specialized).toBe(ast);
+	});
+
+	it('creates exactly one true boolean definition', () => {
+		expect(createPlatformDefinitions('android')).toEqual({
+			'import.meta.env.platform.web': false,
+			'import.meta.env.platform.ios': false,
+			'import.meta.env.platform.android': true,
+		});
+	});
+
+	it('replaces exact flags without touching strings or comments', () => {
+		const source = `// import.meta.env.platform.web
+			const label = 'import.meta.env.platform.ios';
+			const active = import.meta.env.platform.android;`;
+		const result = replacePlatformFlags(source, 'flags.ts', 'android');
+
+		expect(result.code).toContain('// import.meta.env.platform.web');
+		expect(result.code).toContain("'import.meta.env.platform.ios'");
+		expect(result.code).toContain('const active = true;');
+		expect(result.map.sources).toEqual(['flags.ts']);
+	});
+});

--- a/packages/tsrx/types/config.d.ts
+++ b/packages/tsrx/types/config.d.ts
@@ -1,0 +1,16 @@
+import type { Platform } from './index';
+
+export interface BuildPlatformResolutionOptions {
+	/** Project root used to find the nearest tsconfig. Defaults to `process.cwd()`. */
+	root?: string;
+	/** Explicit tsconfig path, resolved relative to `root`. */
+	tsconfig?: string;
+	/** Optional integration override; it must agree with tsconfig when both exist. */
+	platform?: Platform;
+	/** Name included in actionable errors. */
+	integration?: string;
+}
+
+export function resolveBuildPlatform(
+	options?: BuildPlatformResolutionOptions,
+): Platform | undefined;

--- a/packages/tsrx/types/config.d.ts
+++ b/packages/tsrx/types/config.d.ts
@@ -1,7 +1,7 @@
 import type { Platform } from './index';
 
 export interface BuildPlatformResolutionOptions {
-	/** Project root used to find the nearest tsconfig. Defaults to `process.cwd()`. */
+	/** Project root used to find the nearest tsconfig and referenced projects. */
 	root?: string;
 	/** Explicit tsconfig path, resolved relative to `root`. */
 	tsconfig?: string;

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -2395,6 +2395,7 @@ export function replacePlatformFlags(
 	source: string,
 	filename: string,
 	platform: unknown,
+	inputMap?: import('source-map').RawSourceMap | string | null,
 ): { code: string; map: import('source-map').RawSourceMap };
 
 /**

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -79,6 +79,32 @@ export interface CompileError extends Error {
 	type: 'fatal' | 'usage';
 }
 
+/** Platform selected for compile-time `import.meta.env.platform` flags. */
+export type Platform = 'web' | 'ios' | 'android';
+
+/** The three compile-time flags exposed to TSRX and bundler-authored modules. */
+export interface TsrxPlatformFlags {
+	readonly web: boolean;
+	readonly ios: boolean;
+	readonly android: boolean;
+}
+
+declare global {
+	interface ImportMetaEnv {
+		/**
+		 * Intersecting with `string` remains compatible with hosts such as Bun that
+		 * constrain every ImportMetaEnv value through a string index signature,
+		 * while preserving typed access to the three nested flags.
+		 */
+		readonly platform: TsrxPlatformFlags & string;
+	}
+
+	interface ImportMeta {
+		/** Supplies `env` when the host has no explicit property without redeclaring it. */
+		readonly [key: `env${string}`]: ImportMetaEnv;
+	}
+}
+
 /**
  * Compilation options
  */
@@ -2326,6 +2352,8 @@ export type RuntimeImportMode = 'compiler' | 'direct';
 export interface BaseCompileOptions {
 	collect?: boolean;
 	loose?: boolean;
+	/** Selects the compile-time platform branch. No platform is implied when omitted. */
+	platform?: Platform;
 	/**
 	 * Selects where generated runtime helper imports resolve from. The default
 	 * `'compiler'` mode preserves compiler-package compatibility subpaths;
@@ -2334,6 +2362,40 @@ export interface BaseCompileOptions {
 	 */
 	runtimeImports?: RuntimeImportMode;
 }
+
+export interface PlatformSpecializationOptions {
+	errors?: CompileError[];
+	comments?: AST.CommentWithLocation[];
+}
+
+export const PLATFORMS: readonly ['web', 'ios', 'android'];
+export function validatePlatform(platform: unknown, optionName?: string): Platform | undefined;
+export function getPlatformFlag(node: AST.Node | null | undefined): Platform | null;
+export function hasPlatformFlag(node: AST.Node): boolean;
+export function hasPlatformNamespace(node: AST.Node): boolean;
+export function specializePlatform(
+	ast: AST.Program,
+	platform: unknown,
+	filename?: string | null,
+	options?: PlatformSpecializationOptions,
+): AST.Program;
+export function createPlatformDefinitions(
+	platform: unknown,
+): Record<`import.meta.env.platform.${Platform}`, boolean>;
+export function mergePlatformDefinitions(
+	definitions: Record<string, unknown> | undefined,
+	platform: unknown,
+	options?: { integration?: string; serialize?: boolean },
+): Record<string, unknown>;
+export function withPlatformTypes(
+	result: VolarMappingsResult,
+	platform: unknown,
+): VolarMappingsResult;
+export function replacePlatformFlags(
+	source: string,
+	filename: string,
+	platform: unknown,
+): { code: string; map: import('source-map').RawSourceMap };
 
 /**
  * Shared `compile` signature for every TSRX target package. Per-target
@@ -2358,7 +2420,7 @@ export type CompileFn<
  *   Defaults to {@link ParseOptions}; targets may intersect their own option
  *   type to add e.g. `suspenseSource`.
  */
-export type VolarCompileFn<TOptions = ParseOptions> = (
+export type VolarCompileFn<TOptions = ParseOptions & BaseCompileOptions> = (
 	source: string,
 	filename?: string,
 	options?: TOptions,

--- a/packages/turbopack-plugin-react/README.md
+++ b/packages/turbopack-plugin-react/README.md
@@ -14,9 +14,7 @@ pnpm add -D @tsrx/turbopack-plugin-react next
 ```ts
 import tsrxReactTurbopack from '@tsrx/turbopack-plugin-react';
 
-export default tsrxReactTurbopack({
-  reactStrictMode: true,
-});
+export default tsrxReactTurbopack({ reactStrictMode: true }, { platform: 'web' });
 ```
 
 The helper installs Turbopack rules that compile `.tsrx` modules with
@@ -33,6 +31,10 @@ Pass Next.js config as the first argument. The second argument is optional:
 
 - `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
   standalone runtime imports).
+- `platform`: optional compile-time platform (`'web'`, `'ios'`, or `'android'`).
+  Set the same `tsrx.platform` value in the active tsconfig. The helper installs
+  replacement rules for all three exact flags in both TSRX output and ordinary
+  application JavaScript/TypeScript modules.
 
 ```ts
 export default tsrxReactTurbopack({}, { runtimeImports: 'direct' });

--- a/packages/turbopack-plugin-react/README.md
+++ b/packages/turbopack-plugin-react/README.md
@@ -14,7 +14,7 @@ pnpm add -D @tsrx/turbopack-plugin-react next
 ```ts
 import tsrxReactTurbopack from '@tsrx/turbopack-plugin-react';
 
-export default tsrxReactTurbopack({ reactStrictMode: true }, { platform: 'web' });
+export default tsrxReactTurbopack({ reactStrictMode: true });
 ```
 
 The helper installs Turbopack rules that compile `.tsrx` modules with
@@ -31,10 +31,15 @@ Pass Next.js config as the first argument. The second argument is optional:
 
 - `runtimeImports`: helper import mode (`'compiler'` by default, or `'direct'` for
   standalone runtime imports).
-- `platform`: optional compile-time platform (`'web'`, `'ios'`, or `'android'`).
-  Set the same `tsrx.platform` value in the active tsconfig. The helper installs
-  replacement rules for all three exact flags in both TSRX output and ordinary
-  application JavaScript/TypeScript modules.
+- `platform`: optional override/fallback for the compile-time platform. Normally
+  the helper reads `tsrx.platform` from Next's `typescript.tsconfigPath` or the
+  nearest tsconfig under the Turbopack root. An override must match tsconfig.
+- `tsconfig`: optional config-path override when the Next config does not select
+  the desired TypeScript project.
+
+When a platform is selected, the helper installs replacement rules for all three
+exact flags in both TSRX output and ordinary application JavaScript/TypeScript
+modules.
 
 ```ts
 export default tsrxReactTurbopack({}, { runtimeImports: 'direct' });

--- a/packages/turbopack-plugin-react/package.json
+++ b/packages/turbopack-plugin-react/package.json
@@ -20,6 +20,7 @@
     }
   },
   "dependencies": {
+    "@tsrx/core": "workspace:*",
     "@tsrx/react": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/turbopack-plugin-react/src/css-loader.js
+++ b/packages/turbopack-plugin-react/src/css-loader.js
@@ -1,11 +1,11 @@
-/** @import { RuntimeImportMode } from '@tsrx/react' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/react' */
 
 import { compile } from '@tsrx/react';
 
 /**
  * @typedef {{
  * 	resourcePath: string,
- * 	getOptions?: () => { runtimeImports?: RuntimeImportMode },
+ * 	getOptions?: () => { runtimeImports?: RuntimeImportMode, platform?: Platform },
  * 	async: () => (err: unknown, output?: string | null, map?: unknown) => void,
  * }} LoaderContext
  */

--- a/packages/turbopack-plugin-react/src/index.js
+++ b/packages/turbopack-plugin-react/src/index.js
@@ -1,15 +1,27 @@
-/** @import { RuntimeImportMode } from '@tsrx/react' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/react' */
 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { validatePlatform } from '@tsrx/react';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const TURBOPACK_JS_LOADER = path.join(__dirname, 'loader.js');
 const TURBOPACK_CSS_LOADER = path.join(__dirname, 'css-loader.js');
+const TURBOPACK_PLATFORM_LOADER = path.join(__dirname, 'platform-loader.js');
 const DEFAULT_RESOLVE_EXTENSIONS = ['.tsrx', '.tsx', '.ts', '.jsx', '.js', '.mjs', '.json'];
 const CSS_QUERY = '?tsrx-css&lang.css';
+const PLATFORM_SOURCE_GLOBS = [
+	'*.js',
+	'*.jsx',
+	'*.mjs',
+	'*.cjs',
+	'*.ts',
+	'*.tsx',
+	'*.mts',
+	'*.cts',
+];
 
 /**
  * @typedef {{
@@ -25,19 +37,31 @@ const CSS_QUERY = '?tsrx-css&lang.css';
  */
 
 /**
- * @typedef {{ runtimeImports?: RuntimeImportMode }} TsrxReactTurbopackOptions
+ * @typedef {{ runtimeImports?: RuntimeImportMode, platform?: Platform }} TsrxReactTurbopackOptions
  */
+
+/** @param {TsrxReactTurbopackOptions} options @returns {TsrxReactTurbopackOptions} */
+function normalize_options(options) {
+	return { ...options, platform: validatePlatform(options.platform) };
+}
 
 /**
  * @param {TsrxReactTurbopackOptions} [options]
  * @returns {{ condition: { all: any[] }, loaders: Array<string | { loader: string, options: TsrxReactTurbopackOptions }>, as: string }}
  */
 export function create_tsrx_react_turbopack_rule(options = {}) {
+	options = normalize_options(options);
+	const loaders = [with_loader_options(TURBOPACK_JS_LOADER, options)];
+	if (options.platform !== undefined) {
+		// Webpack-compatible loaders execute right-to-left: compile TSRX first,
+		// then replace flags that intentionally remain in runtime expressions.
+		loaders.unshift({ loader: TURBOPACK_PLATFORM_LOADER, options: { platform: options.platform } });
+	}
 	return {
 		condition: {
 			all: [{ not: 'foreign' }, { not: { query: CSS_QUERY } }],
 		},
-		loaders: [with_loader_options(TURBOPACK_JS_LOADER, options)],
+		loaders,
 		as: '*.tsx',
 	};
 }
@@ -47,6 +71,7 @@ export function create_tsrx_react_turbopack_rule(options = {}) {
  * @returns {{ condition: { all: any[] }, loaders: Array<string | { loader: string, options: TsrxReactTurbopackOptions }>, type: string }}
  */
 export function create_tsrx_react_turbopack_css_rule(options = {}) {
+	options = normalize_options(options);
 	return {
 		condition: {
 			all: [{ not: 'foreign' }, { query: CSS_QUERY }],
@@ -65,7 +90,17 @@ export function create_tsrx_react_turbopack_css_rule(options = {}) {
  * @returns {string | { loader: string, options: TsrxReactTurbopackOptions }}
  */
 function with_loader_options(loader, options) {
-	return options.runtimeImports === undefined ? loader : { loader, options };
+	return options.runtimeImports === undefined && options.platform === undefined
+		? loader
+		: { loader, options };
+}
+
+/** @param {TsrxReactTurbopackOptions} options */
+function create_platform_rule(options) {
+	return {
+		condition: { all: [{ not: 'foreign' }] },
+		loaders: [{ loader: TURBOPACK_PLATFORM_LOADER, options: { platform: options.platform } }],
+	};
 }
 
 /**
@@ -108,9 +143,21 @@ function merge_tsrx_rule(existing_rule, options) {
  * @returns {NextTurbopackConfig}
  */
 export function tsrxReactTurbopack(next_config = {}, options = {}) {
+	options = normalize_options(options);
 	const turbopack = next_config.turbopack ?? {};
 	const rules = { ...(turbopack.rules ?? {}) };
 	rules['*.tsrx'] = merge_tsrx_rule(rules['*.tsrx'], options);
+	if (options.platform !== undefined) {
+		for (const glob of PLATFORM_SOURCE_GLOBS) {
+			const platform_rule = create_platform_rule(options);
+			const existing_rule = rules[glob];
+			rules[glob] = existing_rule
+				? Array.isArray(existing_rule)
+					? [platform_rule, ...existing_rule]
+					: [platform_rule, existing_rule]
+				: platform_rule;
+		}
+	}
 
 	return {
 		...next_config,

--- a/packages/turbopack-plugin-react/src/index.js
+++ b/packages/turbopack-plugin-react/src/index.js
@@ -2,7 +2,8 @@
 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { validatePlatform } from '@tsrx/react';
+import { validatePlatform } from '@tsrx/core';
+import { resolveBuildPlatform } from '@tsrx/core/config';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -32,12 +33,13 @@ const PLATFORM_SOURCE_GLOBS = [
  * 		resolveExtensions?: string[],
  * 		debugIds?: boolean,
  * 	},
+ * 	typescript?: { tsconfigPath?: string },
  * 	[key: string]: any,
  * }} NextTurbopackConfig
  */
 
 /**
- * @typedef {{ runtimeImports?: RuntimeImportMode, platform?: Platform }} TsrxReactTurbopackOptions
+ * @typedef {{ runtimeImports?: RuntimeImportMode, platform?: Platform, tsconfig?: string }} TsrxReactTurbopackOptions
  */
 
 /** @param {TsrxReactTurbopackOptions} options @returns {TsrxReactTurbopackOptions} */
@@ -145,6 +147,12 @@ function merge_tsrx_rule(existing_rule, options) {
 export function tsrxReactTurbopack(next_config = {}, options = {}) {
 	options = normalize_options(options);
 	const turbopack = next_config.turbopack ?? {};
+	options.platform = resolveBuildPlatform({
+		root: turbopack.root ?? process.cwd(),
+		tsconfig: options.tsconfig ?? next_config.typescript?.tsconfigPath,
+		platform: options.platform,
+		integration: '@tsrx/turbopack-plugin-react',
+	});
 	const rules = { ...(turbopack.rules ?? {}) };
 	rules['*.tsrx'] = merge_tsrx_rule(rules['*.tsrx'], options);
 	if (options.platform !== undefined) {

--- a/packages/turbopack-plugin-react/src/loader.js
+++ b/packages/turbopack-plugin-react/src/loader.js
@@ -1,4 +1,4 @@
-/** @import { RuntimeImportMode } from '@tsrx/react' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/react' */
 
 import { compile } from '@tsrx/react';
 
@@ -22,7 +22,7 @@ function append_css_import(code, resource_path) {
 /**
  * @typedef {{
  * 	resourcePath: string,
- * 	getOptions?: () => { runtimeImports?: RuntimeImportMode },
+ * 	getOptions?: () => { runtimeImports?: RuntimeImportMode, platform?: Platform },
  * 	async: () => (err: unknown, output?: string | null, map?: unknown) => void,
  * }} LoaderContext
  */

--- a/packages/turbopack-plugin-react/src/platform-loader.js
+++ b/packages/turbopack-plugin-react/src/platform-loader.js
@@ -1,6 +1,6 @@
 /** @import { Platform } from '@tsrx/react' */
 
-import { replacePlatformFlags } from '@tsrx/react';
+import { replacePlatformFlags } from '@tsrx/core';
 
 /**
  * @typedef {{

--- a/packages/turbopack-plugin-react/src/platform-loader.js
+++ b/packages/turbopack-plugin-react/src/platform-loader.js
@@ -1,0 +1,35 @@
+/** @import { Platform } from '@tsrx/react' */
+
+import { replacePlatformFlags } from '@tsrx/react';
+
+/**
+ * @typedef {{
+ * 	resourcePath: string,
+ * 	getOptions?: () => { platform?: Platform },
+ * 	async: () => (err: unknown, output?: string | null, map?: unknown) => void,
+ * }} LoaderContext
+ */
+
+/**
+ * Supply Turbopack's missing `define` equivalent. TSRX's own loader has already
+ * pruned exact ordinary-if guards; this pass handles flags left in runtime
+ * expressions and ordinary JavaScript/TypeScript modules.
+ *
+ * @this {LoaderContext}
+ * @param {string} source
+ * @returns {void}
+ */
+export default function tsrx_react_turbopack_platform_loader(source) {
+	const callback = this.async();
+
+	try {
+		const { code, map } = replacePlatformFlags(
+			source,
+			this.resourcePath,
+			this.getOptions?.().platform,
+		);
+		callback(null, code, map);
+	} catch (/** @type {any} */ error) {
+		callback(error);
+	}
+}

--- a/packages/turbopack-plugin-react/src/platform-loader.js
+++ b/packages/turbopack-plugin-react/src/platform-loader.js
@@ -17,9 +17,10 @@ import { replacePlatformFlags } from '@tsrx/core';
  *
  * @this {LoaderContext}
  * @param {string} source
+ * @param {import('source-map').RawSourceMap | string | undefined} [input_map]
  * @returns {void}
  */
-export default function tsrx_react_turbopack_platform_loader(source) {
+export default function tsrx_react_turbopack_platform_loader(source, input_map) {
 	const callback = this.async();
 
 	try {
@@ -27,6 +28,7 @@ export default function tsrx_react_turbopack_platform_loader(source) {
 			source,
 			this.resourcePath,
 			this.getOptions?.().platform,
+			input_map,
 		);
 		callback(null, code, map);
 	} catch (/** @type {any} */ error) {

--- a/packages/turbopack-plugin-react/tests/platform-builders.test.js
+++ b/packages/turbopack-plugin-react/tests/platform-builders.test.js
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import { tsrxReact as viteReact } from '../../vite-plugin-react/src/index.js';
+import { tsrxPreact as vitePreact } from '../../vite-plugin-preact/src/index.js';
+import { tsrxSolid as viteSolid } from '../../vite-plugin-solid/src/index.js';
+import { tsrxVue as viteVue } from '../../vite-plugin-vue/src/index.js';
+import { TsrxReactRspackPlugin } from '../../rspack-plugin-react/src/index.js';
+import { TsrxPreactRspackPlugin } from '../../rspack-plugin-preact/src/index.js';
+import { TsrxSolidRspackPlugin } from '../../rspack-plugin-solid/src/index.js';
+import { TsrxVueRspackPlugin } from '../../rspack-plugin-vue/src/index.js';
+import { tsrxReact as bunReact } from '../../bun-plugin-react/src/index.js';
+import { tsrxPreact as bunPreact } from '../../bun-plugin-preact/src/index.js';
+import { tsrxSolid as bunSolid } from '../../bun-plugin-solid/src/index.js';
+import { tsrxVue as bunVue } from '../../bun-plugin-vue/src/index.js';
+import { create_tsrx_react_turbopack_rule, tsrxReactTurbopack } from '../src/index.js';
+import turbopackPlatformLoader from '../src/platform-loader.js';
+
+const IOS_DEFINITIONS = {
+	'import.meta.env.platform.web': false,
+	'import.meta.env.platform.ios': true,
+	'import.meta.env.platform.android': false,
+};
+
+/** @param {import('vite').Plugin} plugin */
+function call_vite_config(plugin) {
+	const hook = typeof plugin.config === 'function' ? plugin.config : plugin.config?.handler;
+	if (!hook) throw new Error(`${plugin.name} has no config hook`);
+	return hook.call(
+		/** @type {any} */ ({}),
+		{},
+		{ command: 'build', mode: 'production', isSsrBuild: false, isPreview: false },
+	);
+}
+
+/** @param {ReturnType<typeof viteVue>} plugins */
+function get_vue_vite_plugin(plugins) {
+	const plugin = plugins.find((entry) => entry.name === '@tsrx/vite-plugin-vue');
+	if (!plugin) throw new Error('missing Vue TSRX plugin');
+	return plugin;
+}
+
+/** @param {{ apply(compiler: any): void }} plugin */
+function apply_rspack_plugin(plugin) {
+	const applied_definitions = [];
+	class DefinePlugin {
+		/** @param {Record<string, boolean>} definitions */
+		constructor(definitions) {
+			this.definitions = definitions;
+		}
+		/** @param {unknown} _compiler */
+		apply(_compiler) {
+			applied_definitions.push(this.definitions);
+		}
+	}
+	const compiler = {
+		webpack: { DefinePlugin },
+		options: {
+			mode: 'development',
+			plugins: [],
+			module: { rules: [] },
+			resolve: { extensions: [] },
+			experiments: {},
+		},
+	};
+	plugin.apply(compiler);
+	return { compiler, applied_definitions };
+}
+
+/** @param {import('bun').BunPlugin} plugin @param {Record<string, string>} [define] */
+function setup_bun_plugin(plugin, define) {
+	const build = {
+		config: { entrypoints: [], plugins: [], define },
+		onResolve() {
+			return build;
+		},
+		onLoad() {
+			return build;
+		},
+	};
+	plugin.setup(/** @type {any} */ (build));
+	return build.config;
+}
+
+describe('platform options across build integrations', () => {
+	it.each([
+		['React', () => viteReact({ platform: 'ios' })],
+		['Preact', () => vitePreact({ platform: 'ios' })],
+		['Solid', () => viteSolid({ platform: 'ios' })],
+		['Vue', () => get_vue_vite_plugin(viteVue({ platform: 'ios' }))],
+	])('configures all three Vite definitions for %s', (_, create_plugin) => {
+		expect(call_vite_config(create_plugin())?.define).toEqual(IOS_DEFINITIONS);
+	});
+
+	it('reports conflicting Vite definitions', () => {
+		const plugin = viteReact({ platform: 'ios' });
+		const hook = typeof plugin.config === 'function' ? plugin.config : plugin.config?.handler;
+		expect(() =>
+			hook?.call(
+				/** @type {any} */ ({}),
+				{ define: { 'import.meta.env.platform.ios': false } },
+				{ command: 'build', mode: 'production', isSsrBuild: false, isPreview: false },
+			),
+		).toThrow(/Conflicting Vite definition/);
+	});
+
+	it.each([
+		['React', () => new TsrxReactRspackPlugin({ platform: 'ios' }), 0],
+		['Preact', () => new TsrxPreactRspackPlugin({ platform: 'ios' }), 0],
+		['Solid', () => new TsrxSolidRspackPlugin({ platform: 'ios' }), 0],
+		['Vue', () => new TsrxVueRspackPlugin({ platform: 'ios' }), 1],
+	])('configures definitions and loader options for Rspack %s', (_, create_plugin, rule_index) => {
+		const { compiler, applied_definitions } = apply_rspack_plugin(create_plugin());
+		expect(applied_definitions).toEqual([IOS_DEFINITIONS]);
+		expect(compiler.options.module.rules[rule_index].use.at(-1).options.platform).toBe('ios');
+	});
+
+	it('reports conflicting Rspack definitions', () => {
+		const plugin = new TsrxReactRspackPlugin({ platform: 'ios' });
+		const conflict = {
+			name: 'DefinePlugin',
+			_args: [{ 'import.meta.env.platform.web': true }],
+		};
+		const compiler = {
+			options: {
+				plugins: [conflict],
+				module: { rules: [] },
+				resolve: { extensions: [] },
+				experiments: {},
+			},
+		};
+		expect(() => plugin.apply(/** @type {any} */ (compiler))).toThrow(
+			/Conflicting Rspack definition/,
+		);
+	});
+
+	it.each([
+		['React', () => bunReact({ platform: 'ios' })],
+		['Preact', () => bunPreact({ platform: 'ios' })],
+		['Solid', () => bunSolid({ platform: 'ios' })],
+		['Vue', () => bunVue({ platform: 'ios' })],
+	])('configures all three Bun definitions for %s', (_, create_plugin) => {
+		expect(setup_bun_plugin(create_plugin()).define).toEqual({
+			'import.meta.env.platform.web': 'false',
+			'import.meta.env.platform.ios': 'true',
+			'import.meta.env.platform.android': 'false',
+		});
+	});
+
+	it('reports conflicting Bun definitions', () => {
+		expect(() =>
+			setup_bun_plugin(bunReact({ platform: 'ios' }), {
+				'import.meta.env.platform.ios': 'false',
+			}),
+		).toThrow(/Conflicting Bun definition/);
+	});
+
+	it('passes the platform through TSRX and ordinary-module Turbopack rules', () => {
+		const tsrx_rule = create_tsrx_react_turbopack_rule({ platform: 'ios' });
+		const config = tsrxReactTurbopack({}, { platform: 'ios' });
+
+		expect(tsrx_rule.loaders).toHaveLength(2);
+		expect(tsrx_rule.loaders[0]).toMatchObject({ options: { platform: 'ios' } });
+		expect(tsrx_rule.loaders[1]).toMatchObject({ options: { platform: 'ios' } });
+		for (const glob of ['*.js', '*.jsx', '*.mjs', '*.cjs', '*.ts', '*.tsx', '*.mts', '*.cts']) {
+			expect(config.turbopack.rules[glob]).toMatchObject({
+				loaders: [expect.objectContaining({ options: { platform: 'ios' } })],
+			});
+		}
+	});
+
+	it('replaces exact flags in Turbopack ordinary modules', async () => {
+		const transformed = await new Promise((resolve) => {
+			turbopackPlatformLoader.call(
+				{
+					resourcePath: '/virtual/example.ts',
+					getOptions: () => ({ platform: 'ios' }),
+					async: () => (error, output, map) => resolve({ error, output, map }),
+				},
+				'export const flags = [import.meta.env.platform.web, import.meta.env.platform.ios];',
+			);
+		});
+
+		expect(transformed).toMatchObject({ error: null });
+		expect(transformed.output).toContain('[false, true]');
+		expect(transformed.map).toBeTruthy();
+	});
+});

--- a/packages/turbopack-plugin-react/tests/platform-builders.test.js
+++ b/packages/turbopack-plugin-react/tests/platform-builders.test.js
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { tsrxReact as viteReact } from '../../vite-plugin-react/src/index.js';
 import { tsrxPreact as vitePreact } from '../../vite-plugin-preact/src/index.js';
 import { tsrxSolid as viteSolid } from '../../vite-plugin-solid/src/index.js';
@@ -20,15 +23,16 @@ const IOS_DEFINITIONS = {
 	'import.meta.env.platform.android': false,
 };
 
-/** @param {import('vite').Plugin} plugin */
-function call_vite_config(plugin) {
+/** @param {import('vite').Plugin} plugin @param {import('vite').UserConfig} [config] */
+function call_vite_config(plugin, config = {}) {
 	const hook = typeof plugin.config === 'function' ? plugin.config : plugin.config?.handler;
 	if (!hook) throw new Error(`${plugin.name} has no config hook`);
-	return hook.call(
-		/** @type {any} */ ({}),
-		{},
-		{ command: 'build', mode: 'production', isSsrBuild: false, isPreview: false },
-	);
+	return hook.call(/** @type {any} */ ({}), config, {
+		command: 'build',
+		mode: 'production',
+		isSsrBuild: false,
+		isPreview: false,
+	});
 }
 
 /** @param {ReturnType<typeof viteVue>} plugins */
@@ -38,8 +42,8 @@ function get_vue_vite_plugin(plugins) {
 	return plugin;
 }
 
-/** @param {{ apply(compiler: any): void }} plugin */
-function apply_rspack_plugin(plugin) {
+/** @param {{ apply(compiler: any): void }} plugin @param {{ root?: string, tsconfig?: string }} [config] */
+function apply_rspack_plugin(plugin, config = {}) {
 	const applied_definitions = [];
 	class DefinePlugin {
 		/** @param {Record<string, boolean>} definitions */
@@ -52,12 +56,16 @@ function apply_rspack_plugin(plugin) {
 		}
 	}
 	const compiler = {
+		context: config.root,
 		webpack: { DefinePlugin },
 		options: {
 			mode: 'development',
 			plugins: [],
 			module: { rules: [] },
-			resolve: { extensions: [] },
+			resolve: {
+				extensions: [],
+				...(config.tsconfig ? { tsConfig: config.tsconfig } : {}),
+			},
 			experiments: {},
 		},
 	};
@@ -65,10 +73,10 @@ function apply_rspack_plugin(plugin) {
 	return { compiler, applied_definitions };
 }
 
-/** @param {import('bun').BunPlugin} plugin @param {Record<string, string>} [define] */
-function setup_bun_plugin(plugin, define) {
+/** @param {import('bun').BunPlugin} plugin @param {{ root?: string, tsconfig?: string, define?: Record<string, string> }} [config] */
+function setup_bun_plugin(plugin, config = {}) {
 	const build = {
-		config: { entrypoints: [], plugins: [], define },
+		config: { entrypoints: [], plugins: [], ...config },
 		onResolve() {
 			return build;
 		},
@@ -81,6 +89,100 @@ function setup_bun_plugin(plugin, define) {
 }
 
 describe('platform options across build integrations', () => {
+	it('infers the inherited tsconfig platform in every builder', () => {
+		const root = mkdtempSync(path.join(os.tmpdir(), 'tsrx-platform-builders-'));
+		try {
+			writeFileSync(
+				path.join(root, 'base.json'),
+				JSON.stringify({ tsrx: { compiler: '@tsrx/react', platform: 'ios' } }),
+			);
+			writeFileSync(
+				path.join(root, 'tsconfig.json'),
+				JSON.stringify({ extends: './base.json', tsrx: { compiler: '@tsrx/react' } }),
+			);
+
+			for (const create_plugin of [
+				() => viteReact(),
+				() => vitePreact(),
+				() => viteSolid(),
+				() => get_vue_vite_plugin(viteVue()),
+			]) {
+				expect(call_vite_config(create_plugin(), { root })?.define).toEqual(IOS_DEFINITIONS);
+			}
+
+			for (const [create_plugin, rule_index] of [
+				[() => new TsrxReactRspackPlugin(), 0],
+				[() => new TsrxPreactRspackPlugin(), 0],
+				[() => new TsrxSolidRspackPlugin(), 0],
+				[() => new TsrxVueRspackPlugin(), 1],
+			]) {
+				const { compiler, applied_definitions } = apply_rspack_plugin(create_plugin(), { root });
+				expect(applied_definitions).toEqual([IOS_DEFINITIONS]);
+				expect(compiler.options.module.rules[rule_index].use.at(-1).options.platform).toBe('ios');
+			}
+
+			for (const create_plugin of [
+				() => bunReact(),
+				() => bunPreact(),
+				() => bunSolid(),
+				() => bunVue(),
+			]) {
+				expect(setup_bun_plugin(create_plugin(), { root }).define).toEqual({
+					'import.meta.env.platform.web': 'false',
+					'import.meta.env.platform.ios': 'true',
+					'import.meta.env.platform.android': 'false',
+				});
+			}
+
+			const turbopack = tsrxReactTurbopack({ turbopack: { root } });
+			expect(turbopack.turbopack.rules['*.tsrx'][0].loaders[0]).toMatchObject({
+				options: { platform: 'ios' },
+			});
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("honors each builder's selected tsconfig path", () => {
+		const root = mkdtempSync(path.join(os.tmpdir(), 'tsrx-platform-config-paths-'));
+		try {
+			writeFileSync(
+				path.join(root, 'tsconfig.json'),
+				JSON.stringify({ tsrx: { platform: 'web' } }),
+			);
+			writeFileSync(
+				path.join(root, 'tsconfig.native.json'),
+				JSON.stringify({ tsrx: { platform: 'ios' } }),
+			);
+
+			expect(
+				call_vite_config(viteReact({ tsconfig: 'tsconfig.native.json' }), { root })?.define,
+			).toEqual(IOS_DEFINITIONS);
+			expect(
+				apply_rspack_plugin(new TsrxReactRspackPlugin(), {
+					root,
+					tsconfig: 'tsconfig.native.json',
+				}).applied_definitions,
+			).toEqual([IOS_DEFINITIONS]);
+			expect(
+				setup_bun_plugin(bunReact(), { root, tsconfig: 'tsconfig.native.json' }).define,
+			).toEqual({
+				'import.meta.env.platform.web': 'false',
+				'import.meta.env.platform.ios': 'true',
+				'import.meta.env.platform.android': 'false',
+			});
+			const next_config = tsrxReactTurbopack({
+				turbopack: { root },
+				typescript: { tsconfigPath: 'tsconfig.native.json' },
+			});
+			expect(next_config.turbopack.rules['*.tsrx'][0].loaders[0]).toMatchObject({
+				options: { platform: 'ios' },
+			});
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it.each([
 		['React', () => viteReact({ platform: 'ios' })],
 		['Preact', () => vitePreact({ platform: 'ios' })],
@@ -148,7 +250,7 @@ describe('platform options across build integrations', () => {
 	it('reports conflicting Bun definitions', () => {
 		expect(() =>
 			setup_bun_plugin(bunReact({ platform: 'ios' }), {
-				'import.meta.env.platform.ios': 'false',
+				define: { 'import.meta.env.platform.ios': 'false' },
 			}),
 		).toThrow(/Conflicting Bun definition/);
 	});

--- a/packages/turbopack-plugin-react/tests/platform-builders.test.js
+++ b/packages/turbopack-plugin-react/tests/platform-builders.test.js
@@ -90,7 +90,7 @@ function setup_bun_plugin(plugin, config = {}) {
 }
 
 describe('platform options across build integrations', () => {
-	it('infers the inherited tsconfig platform in every builder', () => {
+	it('infers an inherited platform from a referenced app config in every builder', () => {
 		const root = mkdtempSync(path.join(os.tmpdir(), 'tsrx-platform-builders-'));
 		try {
 			writeFileSync(
@@ -98,8 +98,19 @@ describe('platform options across build integrations', () => {
 				JSON.stringify({ tsrx: { compiler: '@tsrx/react', platform: 'ios' } }),
 			);
 			writeFileSync(
-				path.join(root, 'tsconfig.json'),
+				path.join(root, 'tsconfig.app.json'),
 				JSON.stringify({ extends: './base.json', tsrx: { compiler: '@tsrx/react' } }),
+			);
+			writeFileSync(
+				path.join(root, 'tsconfig.node.json'),
+				JSON.stringify({ compilerOptions: { types: ['node'] } }),
+			);
+			writeFileSync(
+				path.join(root, 'tsconfig.json'),
+				JSON.stringify({
+					files: [],
+					references: [{ path: './tsconfig.app.json' }, { path: './tsconfig.node.json' }],
+				}),
 			);
 
 			for (const create_plugin of [

--- a/packages/turbopack-plugin-react/tests/platform-builders.test.js
+++ b/packages/turbopack-plugin-react/tests/platform-builders.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { compile } from '@tsrx/react';
 import { tsrxReact as viteReact } from '../../vite-plugin-react/src/index.js';
 import { tsrxPreact as vitePreact } from '../../vite-plugin-preact/src/index.js';
 import { tsrxSolid as viteSolid } from '../../vite-plugin-solid/src/index.js';
@@ -215,12 +216,21 @@ describe('platform options across build integrations', () => {
 		expect(compiler.options.module.rules[rule_index].use.at(-1).options.platform).toBe('ios');
 	});
 
-	it('reports conflicting Rspack definitions', () => {
+	it.each([
+		['Rspack _args', { name: 'DefinePlugin', _args: [{ 'import.meta.env.platform.web': true }] }],
+		[
+			'webpack definitions',
+			{ name: 'DefinePlugin', definitions: { 'import.meta.env.platform.web': true } },
+		],
+		['plugin options', { name: 'DefinePlugin', options: { 'import.meta.env.platform.web': true } }],
+		[
+			'constructor name',
+			new (class DefinePlugin {
+				definitions = { 'import.meta.env.platform.web': true };
+			})(),
+		],
+	])('reports conflicting Rspack definitions from %s', (_, conflict) => {
 		const plugin = new TsrxReactRspackPlugin({ platform: 'ios' });
-		const conflict = {
-			name: 'DefinePlugin',
-			_args: [{ 'import.meta.env.platform.web': true }],
-		};
 		const compiler = {
 			options: {
 				plugins: [conflict],
@@ -270,6 +280,13 @@ describe('platform options across build integrations', () => {
 	});
 
 	it('replaces exact flags in Turbopack ordinary modules', async () => {
+		const input_map = {
+			version: 3,
+			sources: ['/original/example.ts'],
+			sourcesContent: ['export const flags = ORIGINAL;'],
+			names: [],
+			mappings: 'AAAA',
+		};
 		const transformed = await new Promise((resolve) => {
 			turbopackPlatformLoader.call(
 				{
@@ -278,11 +295,60 @@ describe('platform options across build integrations', () => {
 					async: () => (error, output, map) => resolve({ error, output, map }),
 				},
 				'export const flags = [import.meta.env.platform.web, import.meta.env.platform.ios];',
+				input_map,
 			);
 		});
 
 		expect(transformed).toMatchObject({ error: null });
 		expect(transformed.output).toContain('[false, true]');
 		expect(transformed.map).toBeTruthy();
+		expect(transformed.map.sources).toEqual(['/original/example.ts']);
+		expect(transformed.map.sourcesContent).toEqual(['export const flags = ORIGINAL;']);
+	});
+
+	it('preserves the TSRX compile map when no runtime flags remain', async () => {
+		const source = `export function App() @{
+			<div>{'Hello world'}</div>
+		}`;
+		const compiled = compile(source, '/virtual/App.tsrx', { platform: 'ios' });
+		const transformed = await new Promise((resolve) => {
+			turbopackPlatformLoader.call(
+				{
+					resourcePath: '/virtual/App.tsrx',
+					getOptions: () => ({ platform: 'ios' }),
+					async: () => (error, output, map) => resolve({ error, output, map }),
+				},
+				compiled.code,
+				compiled.map,
+			);
+		});
+
+		expect(transformed.error).toBeNull();
+		expect(transformed.output).toBe(compiled.code);
+		expect(transformed.map).toBe(compiled.map);
+		expect(transformed.map.sourcesContent?.[0]).toBe(source);
+	});
+
+	it('composes the TSRX compile map when runtime flags are rewritten', async () => {
+		const source = `export function App() @{
+			<div>{import.meta.env.platform.ios ? 'ios' : 'other'}</div>
+		}`;
+		const compiled = compile(source, '/virtual/App.tsrx', { platform: 'ios' });
+		const transformed = await new Promise((resolve) => {
+			turbopackPlatformLoader.call(
+				{
+					resourcePath: '/virtual/App.tsrx',
+					getOptions: () => ({ platform: 'ios' }),
+					async: () => (error, output, map) => resolve({ error, output, map }),
+				},
+				compiled.code,
+				compiled.map,
+			);
+		});
+
+		expect(transformed.error).toBeNull();
+		expect(transformed.output).toContain("true ? 'ios' : 'other'");
+		expect(transformed.map.sourcesContent?.[0]).toBe(source);
+		expect(transformed.map.sourcesContent?.[0]).not.toBe(compiled.code);
 	});
 });

--- a/packages/turbopack-plugin-react/types/index.d.ts
+++ b/packages/turbopack-plugin-react/types/index.d.ts
@@ -1,6 +1,9 @@
 import type { Platform, RuntimeImportMode } from '@tsrx/react';
 
 export interface NextTurbopackConfig {
+	typescript?: {
+		tsconfigPath?: string;
+	};
 	turbopack?: {
 		root?: string;
 		rules?: Record<string, unknown>;
@@ -14,8 +17,10 @@ export interface NextTurbopackConfig {
 export interface TsrxReactTurbopackOptions {
 	/** Direct mode requires `@tsrx/react-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
-	/** Must match `tsrx.platform` in the active tsconfig. */
+	/** Optional override; inferred from tsconfig by default and must agree when both exist. */
 	platform?: Platform;
+	/** Optional tsconfig path override, resolved from the Turbopack project root. */
+	tsconfig?: string;
 }
 
 export interface TsrxReactTurbopackLoader {

--- a/packages/turbopack-plugin-react/types/index.d.ts
+++ b/packages/turbopack-plugin-react/types/index.d.ts
@@ -1,4 +1,4 @@
-import type { RuntimeImportMode } from '@tsrx/react';
+import type { Platform, RuntimeImportMode } from '@tsrx/react';
 
 export interface NextTurbopackConfig {
 	turbopack?: {
@@ -14,6 +14,8 @@ export interface NextTurbopackConfig {
 export interface TsrxReactTurbopackOptions {
 	/** Direct mode requires `@tsrx/react-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
+	/** Must match `tsrx.platform` in the active tsconfig. */
+	platform?: Platform;
 }
 
 export interface TsrxReactTurbopackLoader {

--- a/packages/typescript-plugin/README.md
+++ b/packages/typescript-plugin/README.md
@@ -21,7 +21,8 @@ chosen target. For example, a React project can use:
 ```json
 {
   "tsrx": {
-    "compiler": "@tsrx/react"
+    "compiler": "@tsrx/react",
+    "platform": "web"
   },
   "compilerOptions": {
     "jsx": "preserve",
@@ -39,6 +40,12 @@ All targets use the `.tsrx` extension. The `tsrx.compiler` value must be a bare
 package specifier such as `@tsrx/react`, `@tsrx/preact`, `@tsrx/solid`,
 `@tsrx/vue`, `@tsrx/ripple`, `octane`, or a third-party TSRX compiler. Package
 subpaths are supported; relative and absolute paths are not.
+
+`tsrx.platform` is optional. When present, it must be exactly `"web"`, `"ios"`, or
+`"android"`; it selects compile-time `import.meta.env.platform` guards in virtual
+TSX and must match the `platform` option passed to the project's build
+integration. There is no implicit default. Both `compiler` and `platform` follow
+the active project's complete `extends` graph, including nested projects.
 
 Compiler declarations follow the active TypeScript project's `extends` graph. If
 no compiler is declared, the plugin detects installed target packages and uses the

--- a/packages/typescript-plugin/README.md
+++ b/packages/typescript-plugin/README.md
@@ -43,9 +43,11 @@ subpaths are supported; relative and absolute paths are not.
 
 `tsrx.platform` is optional. When present, it must be exactly `"web"`, `"ios"`, or
 `"android"`; it selects compile-time `import.meta.env.platform` guards in virtual
-TSX and must match the `platform` option passed to the project's build
-integration. There is no implicit default. Both `compiler` and `platform` follow
-the active project's complete `extends` graph, including nested projects.
+TSX. In-repo build integrations read the same setting automatically. Their
+explicit `platform` option is only an override/fallback and must agree with
+tsconfig when both are present. There is no implicit default. Both `compiler` and
+`platform` follow the active project's complete `extends` graph, including nested
+projects.
 
 Compiler declarations follow the active TypeScript project's `extends` graph. If
 no compiler is declared, the plugin detects installed target packages and uses the

--- a/packages/typescript-plugin/src/consumer-compiler.js
+++ b/packages/typescript-plugin/src/consumer-compiler.js
@@ -1,4 +1,5 @@
 /** @typedef {{actual_type: string, actual_value: string}} InvalidConfigValueDetails */
+/** @typedef {'web' | 'ios' | 'android'} Platform */
 /**
  * @typedef {
  * 	| {state: 'absent'}
@@ -8,11 +9,20 @@
  */
 
 /**
+ * @typedef {
+ * 	| {state: 'absent'}
+ * 	| {state: 'declared', value: Platform}
+ * 	| ({state: 'invalid', target: 'tsrx' | 'platform'} & InvalidConfigValueDetails)
+ * } PlatformDeclaration
+ */
+
+/**
  * @typedef {object} CompilerResolutionOptions
  * @property {typeof import('typescript')} [ts]
  * @property {string} [configFileName]
  * @property {import('./tsconfig-resolution.js').TsconfigHost} [configHost]
  * @property {Set<string>} [dependencies]
+ * @property {boolean} [requirePlatformResolution]
  */
 
 /**
@@ -113,6 +123,32 @@ function get_compiler_declaration(config) {
 		return { state: 'declared', value: compiler.trim() };
 	}
 	return { state: 'invalid', target: 'compiler', ...describe_config_value(compiler) };
+}
+
+/**
+ * @param {unknown} config
+ * @returns {PlatformDeclaration}
+ */
+function get_platform_declaration(config) {
+	const tsrx_result = get_own_config_value(config, ['tsrx']);
+	if (tsrx_result.state === 'absent') {
+		return { state: 'absent' };
+	}
+
+	const tsrx_value = tsrx_result.value;
+	if (tsrx_value === null || typeof tsrx_value !== 'object' || Array.isArray(tsrx_value)) {
+		return { state: 'invalid', target: 'tsrx', ...describe_config_value(tsrx_value) };
+	}
+	const platform_result = get_own_config_value(tsrx_value, ['platform']);
+	if (platform_result.state === 'absent') {
+		return { state: 'absent' };
+	}
+
+	const platform = platform_result.value;
+	if (platform === 'web' || platform === 'ios' || platform === 'android') {
+		return { state: 'declared', value: platform };
+	}
+	return { state: 'invalid', target: 'platform', ...describe_config_value(platform) };
 }
 
 /**
@@ -393,6 +429,104 @@ export function resolve_consumer_compiler_for_file(normalized_file_name, options
 		);
 	}
 	return undefined;
+}
+
+/**
+ * Resolve the compile-time platform selected by the active TypeScript project.
+ * The same inheritance graph and dependency tracking as compiler selection are
+ * used so nested projects and config edits cannot silently drift.
+ *
+ * @param {string} normalized_file_name
+ * @param {CompilerResolutionOptions} [options]
+ * @returns {Platform | undefined}
+ */
+export function resolve_consumer_platform_for_file(normalized_file_name, options = {}) {
+	const typescript = options.ts ?? ts;
+	const config_host = options.configHost ?? typescript.sys;
+	const host_cache = get_config_host_cache(config_host);
+	const root_config_path =
+		options.configFileName ??
+		get_nearest_root_tsconfig(path.dirname(normalized_file_name), config_host, host_cache);
+	if (root_config_path === null) {
+		return undefined;
+	}
+
+	const resolved_layers = get_tsconfig_layers(
+		typescript,
+		config_host,
+		root_config_path,
+		host_cache,
+	);
+	for (const dependency of resolved_layers.dependencies) {
+		options.dependencies?.add(dependency);
+	}
+
+	const unreadable_layer = resolved_layers.layers.find((layer) => layer.raw_source === undefined);
+	if (unreadable_layer) {
+		const message = `Unable to read tsconfig layer while resolving TSRX platform: ${unreadable_layer.path}`;
+		logError(message);
+		throw new Error(message);
+	}
+
+	const malformed_layers = resolved_layers.layers.filter(
+		(layer) => layer.parse_diagnostics.length > 0,
+	);
+	if (malformed_layers.length > 0) {
+		const has_tsrx_intent = resolved_layers.layers.some((layer) => {
+			if (get_own_config_value(layer.config, ['tsrx']).state === 'found') return true;
+			return (
+				layer.parse_diagnostics.length > 0 &&
+				layer.raw_source !== undefined &&
+				tsrx_key_pattern.test(layer.raw_source)
+			);
+		});
+		if (!has_tsrx_intent) return undefined;
+
+		const layer = malformed_layers[0];
+		const detail = typescript.flattenDiagnosticMessageText(
+			layer.parse_diagnostics[0].messageText,
+			'\n',
+		);
+		const message = `Unable to parse tsconfig layer while resolving TSRX platform: ${layer.path}: ${detail}`;
+		logError(message);
+		throw new Error(message);
+	}
+
+	const declaration = resolve_inherited_config_value(resolved_layers.layers, (layer) =>
+		get_platform_declaration(layer.config),
+	);
+	if (declaration.state === 'invalid') {
+		const expected =
+			declaration.target === 'platform' ? ' Expected "web", "ios", or "android".' : '';
+		const message = `Invalid TSRX ${declaration.target} declaration: ${declaration.actual_type} ${declaration.actual_value} in ${declaration.config_path}.${expected}`;
+		logError(message);
+		throw new TypeError(message);
+	}
+
+	const effective_extends_failures = resolved_layers.extends_failures.filter(
+		(failure) =>
+			declaration.state !== 'declared' ||
+			!is_extends_failure_overridden(resolved_layers.layers, failure, declaration.config_path),
+	);
+	if (effective_extends_failures.length > 0) {
+		// An unresolved lower-precedence config must not break a file that does not
+		// use platform flags. Known declarations are still validated above. When a
+		// flag is present, the caller requests a complete graph so an unknown base
+		// cannot silently choose the wrong branch.
+		if (!options.requirePlatformResolution) {
+			return declaration.state === 'declared' ? declaration.value : undefined;
+		}
+		const failure = effective_extends_failures[0];
+		const detail =
+			failure.diagnostics.length > 0
+				? `: ${typescript.flattenDiagnosticMessageText(failure.diagnostics[0].messageText, '\n')}`
+				: '';
+		const message = `Unable to resolve tsconfig extends entry ${JSON.stringify(failure.extends_value)} in ${failure.config_path} while resolving TSRX platform${detail}`;
+		logError(message);
+		throw new Error(message);
+	}
+
+	return declaration.state === 'declared' ? declaration.value : undefined;
 }
 
 /** Drop all filesystem-derived consumer compiler resolution state. */

--- a/packages/typescript-plugin/src/language.js
+++ b/packages/typescript-plugin/src/language.js
@@ -2,7 +2,7 @@
 /** @import {CompileError, VolarMappingsResult, CodeMapping} from '@tsrx/core/types' */
 
 /** @typedef {{ code?: string, errors?: CompileError[] }} TSRXCompileResult */
-/** @typedef {{ compile?: (source: string, filename: string, options?: { loose?: boolean }) => TSRXCompileResult, compile_to_volar_mappings(source: string, filename: string, options?: { loose?: boolean }): VolarMappingsResult }} TSRXCompilerModule */
+/** @typedef {{ compile?: (source: string, filename: string, options?: { loose?: boolean, platform?: 'web' | 'ios' | 'android' }) => TSRXCompileResult, compile_to_volar_mappings(source: string, filename: string, options?: { loose?: boolean, platform?: 'web' | 'ios' | 'android' }): VolarMappingsResult }} TSRXCompilerModule */
 
 /** @typedef {Map<string, CodeMapping>} CachedMappings */
 /** @typedef {import('typescript').CompilerOptions} CompilerOptions */
@@ -25,6 +25,7 @@ import { fileURLToPath } from 'url';
 import {
 	reset_consumer_compiler_resolution_caches,
 	resolve_consumer_compiler_for_file,
+	resolve_consumer_platform_for_file,
 } from './consumer-compiler.js';
 import { createLogging, DEBUG } from './utils.js';
 
@@ -100,6 +101,49 @@ export function is_tsrx_file(file_name) {
 }
 
 /**
+ * Detect exact platform property paths without matching comments or string
+ * literals. TypeScript's scanner remains usable for partially authored TSRX
+ * because it tokenizes independently of the parser's grammar.
+ *
+ * @param {string} source
+ * @param {typeof import('typescript')} [typescript]
+ * @returns {boolean}
+ */
+export function source_uses_platform_flag(source, typescript = ts) {
+	const scanner = typescript.createScanner(
+		typescript.ScriptTarget.Latest,
+		true,
+		typescript.LanguageVariant.JSX,
+		source,
+	);
+	/** @type {Array<{ kind: number, text: string }>} */
+	const tokens = [];
+	for (
+		let kind = scanner.scan();
+		kind !== typescript.SyntaxKind.EndOfFileToken;
+		kind = scanner.scan()
+	) {
+		tokens.push({ kind, text: scanner.getTokenText() });
+	}
+
+	const prefix = ['import', '.', 'meta', '.', 'env', '.', 'platform', '.'];
+	for (let index = 0; index + prefix.length < tokens.length; index += 1) {
+		if (
+			index > 0 &&
+			(tokens[index - 1].kind === typescript.SyntaxKind.DotToken ||
+				tokens[index - 1].kind === typescript.SyntaxKind.QuestionDotToken)
+		) {
+			continue;
+		}
+		if (!prefix.every((text, offset) => tokens[index + offset].text === text)) continue;
+		const name = tokens[index + prefix.length].text;
+		if (name === 'web' || name === 'ios' || name === 'android') return true;
+	}
+
+	return false;
+}
+
+/**
  * @param {CompilerResolutionOptions} [options]
  * @returns {TsrxLanguagePlugin}
  */
@@ -134,7 +178,12 @@ export function getTsrxLanguagePlugin(options = {}) {
 				}
 				log('Creating virtual code for:', file_name);
 				try {
-					return new TSRXVirtualCode(file_name, snapshot, compiler);
+					return new TSRXVirtualCode(file_name, snapshot, compiler, (required) =>
+						resolve_consumer_platform_for_file(file_name, {
+							...compiler_resolution_options,
+							requirePlatformResolution: required,
+						}),
+					);
 				} catch (err) {
 					logError('Failed to create virtual code for:', file_name, ':', err);
 					throw err;
@@ -226,6 +275,8 @@ export class TSRXVirtualCode {
 	codegenStacks = [];
 	/** @type {TSRXCompilerModule} */
 	tsrx;
+	/** @type {((required: boolean) => 'web' | 'ios' | 'android' | undefined) | undefined} */
+	platformProvider;
 	/** @type {string} */
 	generatedCode = '';
 	/** @type {VirtualCode['embeddedCodes']} */
@@ -257,12 +308,14 @@ export class TSRXVirtualCode {
 	 * @param {string} file_name
 	 * @param {IScriptSnapshot} snapshot
 	 * @param {TSRXCompilerModule} tsrx
+	 * @param {(required: boolean) => 'web' | 'ios' | 'android' | undefined} [platform_provider]
 	 */
-	constructor(file_name, snapshot, tsrx) {
+	constructor(file_name, snapshot, tsrx, platform_provider) {
 		log('Initializing TSRXVirtualCode for:', file_name);
 
 		this.fileName = file_name;
 		this.tsrx = tsrx;
+		this.platformProvider = platform_provider;
 		this.snapshot = snapshot;
 		this.sourceSnapshot = snapshot;
 		this.originalCode = snapshot.getText(0, snapshot.getLength());
@@ -336,6 +389,7 @@ export class TSRXVirtualCode {
 		}
 
 		try {
+			const platform = this.platformProvider?.(source_uses_platform_flag(newCode));
 			// If user typed a ".", compile without it and then stitch it back into
 			// the generated output so completions can still resolve.
 			if (isDotTyped && dotPosition >= 0) {
@@ -346,6 +400,7 @@ export class TSRXVirtualCode {
 				log('Compiling without typed dot at position', dotPosition);
 				transpiled = this.tsrx.compile_to_volar_mappings(codeWithoutDot, this.fileName, {
 					loose: true,
+					platform,
 				});
 				log('Compilation without dot successful');
 
@@ -363,6 +418,7 @@ export class TSRXVirtualCode {
 				log('Compiling TSRX code...');
 				transpiled = this.tsrx.compile_to_volar_mappings(newCode, this.fileName, {
 					loose: true,
+					platform,
 				});
 				log('Compilation successful, generated code length:', transpiled?.code?.length || 0);
 			}

--- a/packages/typescript-plugin/tests/compiler-resolution.test.js
+++ b/packages/typescript-plugin/tests/compiler-resolution.test.js
@@ -13,6 +13,7 @@ const {
 	COMPILER_CANDIDATES,
 	TSRX_EXTENSIONS,
 	invalidateCompilerResolutionCaches,
+	source_uses_platform_flag,
 	_reset_for_test,
 } = require('../src/language.js');
 
@@ -83,6 +84,19 @@ describe('typescript-plugin compiler resolution', () => {
 			['', false],
 		])('returns %j for %j', (file_name, expected) => {
 			expect(is_tsrx_file(file_name)).toBe(expected);
+		});
+	});
+
+	describe('platform flag source detection', () => {
+		it.each([
+			['if (import.meta.env.platform.web) {}', true],
+			['const value = import /* comment */ . meta.env.platform.ios;', true],
+			['// import.meta.env.platform.android\nconst value = 1;', false],
+			["const value = 'import.meta.env.platform.web';", false],
+			['if (import.meta.env.platform["web"]) {}', false],
+			['if (other.import.meta.env.platform.web) {}', false],
+		])('returns %j for %j', (source, expected) => {
+			expect(source_uses_platform_flag(source)).toBe(expected);
 		});
 	});
 

--- a/packages/typescript-plugin/tests/platform-resolution.test.js
+++ b/packages/typescript-plugin/tests/platform-resolution.test.js
@@ -1,0 +1,107 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import ts from 'typescript';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	reset_consumer_compiler_resolution_caches,
+	resolve_consumer_platform_for_file,
+} from '../src/consumer-compiler.js';
+
+/** @type {string} */
+let directory;
+
+/** @param {string} relative_path @param {unknown} config */
+function write_config(relative_path, config) {
+	const config_path = path.join(directory, relative_path);
+	fs.mkdirSync(path.dirname(config_path), { recursive: true });
+	fs.writeFileSync(config_path, JSON.stringify(config, null, 2) + '\n');
+	return config_path;
+}
+
+/** @param {string} config_path @param {string[]} [dependencies] */
+function resolve_platform(config_path, dependencies) {
+	return resolve_consumer_platform_for_file(
+		path.join(path.dirname(config_path), 'src', 'App.tsrx'),
+		{
+			ts,
+			configFileName: config_path,
+			configHost: ts.sys,
+			dependencies: dependencies ? new Set(dependencies) : undefined,
+		},
+	);
+}
+
+beforeEach(() => {
+	directory = fs.mkdtempSync(path.join(os.tmpdir(), 'tsrx-platform-resolution-'));
+	reset_consumer_compiler_resolution_caches();
+	vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	fs.rmSync(directory, { recursive: true, force: true });
+});
+
+describe('consumer TSRX platform resolution', () => {
+	it.each(['web', 'ios', 'android'])('resolves the %s truth-table selection', (platform) => {
+		const config_path = write_config('tsconfig.json', {
+			tsrx: { compiler: '@tsrx/react', platform },
+		});
+
+		expect(resolve_platform(config_path)).toBe(platform);
+	});
+
+	it('allows platform to be omitted', () => {
+		const config_path = write_config('tsconfig.json', {
+			tsrx: { compiler: '@tsrx/react' },
+		});
+
+		expect(resolve_platform(config_path)).toBeUndefined();
+	});
+
+	it('resolves inherited and nested project selections with child precedence', () => {
+		const base_path = write_config('configs/base.json', {
+			tsrx: { compiler: '@tsrx/react', platform: 'web' },
+		});
+		const root_path = write_config('tsconfig.json', {
+			extends: './configs/base.json',
+		});
+		const nested_path = write_config('native/tsconfig.json', {
+			extends: '../tsconfig.json',
+			tsrx: { platform: 'android' },
+		});
+		const dependencies = new Set();
+
+		const platform = resolve_consumer_platform_for_file(
+			path.join(directory, 'native', 'src', 'App.tsrx'),
+			{
+				ts,
+				configFileName: nested_path,
+				configHost: ts.sys,
+				dependencies,
+			},
+		);
+
+		expect(platform).toBe('android');
+		expect(dependencies).toEqual(new Set([nested_path, root_path, base_path]));
+	});
+
+	it.each([
+		['another string', 'windows'],
+		['null', null],
+		['boolean', true],
+		['number', 1],
+		['array', ['web']],
+		['object', { name: 'web' }],
+	])('rejects a %s platform without coercion', (_, platform) => {
+		const config_path = write_config(`invalid-${String(_).replace(/\s/g, '-')}.json`, {
+			tsrx: { compiler: '@tsrx/react', platform },
+		});
+		reset_consumer_compiler_resolution_caches();
+
+		expect(() => resolve_platform(config_path)).toThrow(
+			/Invalid TSRX platform declaration.*Expected "web", "ios", or "android"/,
+		);
+	});
+});

--- a/packages/typescript-plugin/tests/plugin-integration.test.js
+++ b/packages/typescript-plugin/tests/plugin-integration.test.js
@@ -16,7 +16,6 @@ import {
 	_reset_for_test,
 } from '../src/language.js';
 import { resolve_consumer_compiler_for_file } from '../src/consumer-compiler.js';
-import * as reactCompiler from '../../tsrx-react/src/index.js';
 
 /** @import {WORKSPACE_CONFIGS} from './workspace-fixtures.js' */
 /** @typedef {keyof typeof WORKSPACE_CONFIGS} WorkspaceName */
@@ -54,9 +53,10 @@ function create_snapshot(source) {
  */
 function create_edit_snapshot(source, previous, change_range) {
 	return {
-		getText: (start, end) => source.slice(start, end),
+		getText: (/** @type {number} */ start, /** @type {number} */ end) => source.slice(start, end),
 		getLength: () => source.length,
-		getChangeRange: (old_snapshot) => (old_snapshot === previous ? change_range : undefined),
+		getChangeRange: (/** @type {import('typescript').IScriptSnapshot} */ old_snapshot) =>
+			old_snapshot === previous ? change_range : undefined,
 	};
 }
 
@@ -282,11 +282,36 @@ describe('typescript-plugin language plugin integration', () => {
 	it('keeps platform typing and selection in dot-completion compilation', () => {
 		const source = 'export const active = import.meta.env.platform';
 		const initial_snapshot = create_snapshot(source);
+		/** @type {boolean[]} */
 		const required_values = [];
+		const compiler = /** @type {any} */ ({
+			compile_to_volar_mappings(
+				/** @type {string} */ code,
+				/** @type {string} */ _filename,
+				/** @type {{ platform?: string }} */ options,
+			) {
+				return {
+					code: `${code}\nexport {};\ndeclare global { interface ImportMetaEnv { readonly platform: string & { readonly ios: ${options.platform === 'ios'} } } interface ImportMeta { readonly [key: \`env\${string}\`]: ImportMetaEnv } }`,
+					mappings: [
+						{
+							sourceOffsets: [0],
+							generatedOffsets: [0],
+							lengths: [code.length],
+							generatedLengths: [code.length],
+							data: { completion: true, verification: true, customData: {} },
+						},
+					],
+					cssMappings: [],
+					scriptMappings: [],
+					errors: [],
+					sourceAst: null,
+				};
+			},
+		});
 		const virtual_code = new TSRXVirtualCode(
 			'/virtual/App.tsrx',
 			initial_snapshot,
-			reactCompiler,
+			compiler,
 			(required) => {
 				required_values.push(required);
 				return 'ios';

--- a/packages/typescript-plugin/tests/plugin-integration.test.js
+++ b/packages/typescript-plugin/tests/plugin-integration.test.js
@@ -11,10 +11,12 @@ import {
 	getTsrxLanguagePlugin,
 	getTsrxCompilerDirForFile,
 	get_tsrx_compiler_name_for_file,
+	invalidateCompilerResolutionCaches,
 	TSRXVirtualCode,
 	_reset_for_test,
 } from '../src/language.js';
 import { resolve_consumer_compiler_for_file } from '../src/consumer-compiler.js';
+import * as reactCompiler from '../../tsrx-react/src/index.js';
 
 /** @import {WORKSPACE_CONFIGS} from './workspace-fixtures.js' */
 /** @typedef {keyof typeof WORKSPACE_CONFIGS} WorkspaceName */
@@ -43,6 +45,19 @@ import { resolve_consumer_compiler_for_file } from '../src/consumer-compiler.js'
  */
 function create_snapshot(source) {
 	return ts.ScriptSnapshot.fromString(source);
+}
+
+/**
+ * @param {string} source
+ * @param {import('typescript').IScriptSnapshot} previous
+ * @param {import('typescript').TextChangeRange} change_range
+ */
+function create_edit_snapshot(source, previous, change_range) {
+	return {
+		getText: (start, end) => source.slice(start, end),
+		getLength: () => source.length,
+		getChangeRange: (old_snapshot) => (old_snapshot === previous ? change_range : undefined),
+	};
 }
 
 /**
@@ -233,6 +248,65 @@ function token_mapping(sourceStart, sourceLength, generatedStart, generatedLengt
 }
 
 describe('typescript-plugin language plugin integration', () => {
+	it('passes the inherited active-project platform to virtual TSX compilation', () => {
+		const { config_path, file_name } = prepare_fixture('react-only', (workspace, config) => {
+			write_config(path.join(workspace, 'base.json'), {
+				tsrx: { compiler: '@tsrx/react', platform: 'ios' },
+			});
+			write_config(config, { extends: './base.json' });
+		});
+		const plugin = create_plugin({ ts, configFileName: config_path, configHost: ts.sys });
+		const virtual_code = create_virtual_code(plugin, file_name, 'export default <div />;');
+
+		expect(virtual_code.fatalErrors).toEqual([]);
+		expect(virtual_code.generatedCode).toContain('export const platform = "ios";');
+	});
+
+	it('refreshes a virtual script after the active platform changes', () => {
+		const source = 'export default <div />;';
+		const { config_path, file_name } = prepare_fixture('react-only', (_workspace, config) => {
+			write_config(config, { tsrx: { compiler: '@tsrx/react', platform: 'ios' } });
+		});
+		const plugin = create_plugin({ ts, configFileName: config_path, configHost: ts.sys });
+		const virtual_code = create_virtual_code(plugin, file_name, source);
+		expect(virtual_code.generatedCode).toContain('export const platform = "ios";');
+
+		write_config(config_path, { tsrx: { compiler: '@tsrx/react', platform: 'android' } });
+		invalidateCompilerResolutionCaches();
+		virtual_code.update(create_snapshot(`${source}\n`));
+
+		expect(virtual_code.fatalErrors).toEqual([]);
+		expect(virtual_code.generatedCode).toContain('export const platform = "android";');
+	});
+
+	it('keeps platform typing and selection in dot-completion compilation', () => {
+		const source = 'export const active = import.meta.env.platform';
+		const initial_snapshot = create_snapshot(source);
+		const required_values = [];
+		const virtual_code = new TSRXVirtualCode(
+			'/virtual/App.tsrx',
+			initial_snapshot,
+			reactCompiler,
+			(required) => {
+				required_values.push(required);
+				return 'ios';
+			},
+		);
+		const with_dot = `${source}.`;
+		virtual_code.update(
+			create_edit_snapshot(with_dot, initial_snapshot, {
+				span: { start: source.length, length: 0 },
+				newLength: 1,
+			}),
+		);
+
+		expect(virtual_code.fatalErrors).toEqual([]);
+		expect(virtual_code.isDotCompletionMode).toBe(true);
+		expect(virtual_code.generatedCode).toContain('import.meta.env.platform.');
+		expect(virtual_code.generatedCode).toContain('readonly ios: true');
+		expect(required_values).toEqual([false, false]);
+	});
+
 	beforeEach(() => {
 		_reset_for_test();
 	});

--- a/packages/typescript-plugin/tests/workspace-fixtures.js
+++ b/packages/typescript-plugin/tests/workspace-fixtures.js
@@ -80,11 +80,11 @@ function collect_css_mappings(source) {
 function compiler_stub(marker, export_name = 'compile_to_volar_mappings') {
 	return `${STUB_PRELUDE}
 module.exports = {
-	${export_name}(source, filename) {
+	${export_name}(source, filename, options = {}) {
 		if (source.includes(COMPILE_FAILURE_MARKER)) {
 			throw new Error('compile failure requested by fixture source');
 		}
-		const code = \`/* compiler:${marker} */\\nexport const filename = \${JSON.stringify(filename)};\\nexport default \${JSON.stringify(source)};\`;
+		const code = \`/* compiler:${marker} */\\nexport const filename = \${JSON.stringify(filename)};\\nexport const platform = \${JSON.stringify(options.platform)};\\nexport default \${JSON.stringify(source)};\`;
 		return {
 			code,
 			mappings: [

--- a/packages/vite-plugin-preact/src/index.js
+++ b/packages/vite-plugin-preact/src/index.js
@@ -1,6 +1,6 @@
 /** @import { Plugin } from 'vite' */
 /** @import { DepScanTransformPlugin } from '@tsrx/core/types/vite/dep-scan' */
-/** @import { RuntimeImportMode } from '@tsrx/preact' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/preact' */
 
 /**
  * @typedef {{ code: string, map: unknown }} TsrxPreactTransformResult
@@ -34,7 +34,7 @@
  */
 
 import { transformWithOxc } from 'vite';
-import { compile } from '@tsrx/preact';
+import { compile, mergePlatformDefinitions, validatePlatform } from '@tsrx/preact';
 import { createDepScanTransformPlugin } from '@tsrx/core/vite/dep-scan';
 
 const TSRX_EXTENSION_PATTERN = /\.tsrx$/;
@@ -50,14 +50,17 @@ const CSS_QUERY = '?tsrx-css&lang.css';
  *   jsxImportSource?: string,
  *   suspenseSource?: string,
  *   runtimeImports?: RuntimeImportMode,
+ *   platform?: Platform,
  * }} [options]
  * @returns {TsrxPreactPlugin}
  */
 export function tsrxPreact(options = {}) {
+	const platform = validatePlatform(options.platform);
 	const jsxImportSource = options.jsxImportSource ?? 'preact';
 	const compile_options = {
 		suspenseSource: options.suspenseSource,
 		runtimeImports: options.runtimeImports,
+		platform,
 	};
 
 	/** @type {Map<string, string>} */
@@ -81,8 +84,15 @@ export function tsrxPreact(options = {}) {
 		name: '@tsrx/vite-plugin-preact',
 		enforce: 'pre',
 
-		config() {
+		config(config = /** @type {import('vite').UserConfig} */ ({})) {
 			return {
+				...(platform === undefined
+					? {}
+					: {
+							define: mergePlatformDefinitions(config.define, platform, {
+								integration: 'Vite',
+							}),
+						}),
 				optimizeDeps: {
 					// The scanner externalizes anything that is not a known JS
 					// type unless its extension is listed here, so without this
@@ -98,6 +108,15 @@ export function tsrxPreact(options = {}) {
 						plugins: [create_dep_scan_plugin(jsxImportSource, compile_options)],
 					},
 				},
+			};
+		},
+
+		configEnvironment(name, config = /** @type {import('vite').EnvironmentOptions} */ ({})) {
+			if (platform === undefined) return;
+			return {
+				define: mergePlatformDefinitions(config.define, platform, {
+					integration: `Vite environment ${JSON.stringify(name)}`,
+				}),
 			};
 		},
 
@@ -163,7 +182,7 @@ export function tsrxPreact(options = {}) {
 
 /**
  * @param {string} jsxImportSource
- * @param {{ suspenseSource?: string, runtimeImports?: RuntimeImportMode }} compile_options
+ * @param {{ suspenseSource?: string, runtimeImports?: RuntimeImportMode, platform?: Platform }} compile_options
  * @returns {DepScanTransformPlugin}
  */
 function create_dep_scan_plugin(jsxImportSource, compile_options) {

--- a/packages/vite-plugin-preact/src/index.js
+++ b/packages/vite-plugin-preact/src/index.js
@@ -34,7 +34,9 @@
  */
 
 import { transformWithOxc } from 'vite';
-import { compile, mergePlatformDefinitions, validatePlatform } from '@tsrx/preact';
+import { compile } from '@tsrx/preact';
+import { mergePlatformDefinitions, validatePlatform } from '@tsrx/core';
+import { resolveBuildPlatform } from '@tsrx/core/config';
 import { createDepScanTransformPlugin } from '@tsrx/core/vite/dep-scan';
 
 const TSRX_EXTENSION_PATTERN = /\.tsrx$/;
@@ -51,17 +53,32 @@ const CSS_QUERY = '?tsrx-css&lang.css';
  *   suspenseSource?: string,
  *   runtimeImports?: RuntimeImportMode,
  *   platform?: Platform,
+ *   tsconfig?: string,
  * }} [options]
  * @returns {TsrxPreactPlugin}
  */
 export function tsrxPreact(options = {}) {
-	const platform = validatePlatform(options.platform);
+	const explicit_platform = validatePlatform(options.platform);
+	let platform = explicit_platform;
 	const jsxImportSource = options.jsxImportSource ?? 'preact';
 	const compile_options = {
 		suspenseSource: options.suspenseSource,
 		runtimeImports: options.runtimeImports,
 		platform,
 	};
+
+	/** @param {import('vite').UserConfig} config */
+	function resolve_platform(config) {
+		platform = resolveBuildPlatform({
+			root: config.root ?? process.cwd(),
+			tsconfig:
+				options.tsconfig ??
+				/** @type {{ tsconfig?: string }} */ (/** @type {unknown} */ (config)).tsconfig,
+			platform: explicit_platform,
+			integration: '@tsrx/vite-plugin-preact',
+		});
+		compile_options.platform = platform;
+	}
 
 	/** @type {Map<string, string>} */
 	const css_cache = new Map();
@@ -85,6 +102,7 @@ export function tsrxPreact(options = {}) {
 		enforce: 'pre',
 
 		config(config = /** @type {import('vite').UserConfig} */ ({})) {
+			resolve_platform(config);
 			return {
 				...(platform === undefined
 					? {}

--- a/packages/vite-plugin-preact/types/index.d.ts
+++ b/packages/vite-plugin-preact/types/index.d.ts
@@ -6,8 +6,10 @@ export interface TsrxPreactPluginOptions {
 	suspenseSource?: string;
 	/** Direct mode requires `@tsrx/preact-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
-	/** Must match `tsrx.platform` in the active tsconfig. */
+	/** Optional override; inferred from tsconfig by default and must agree when both exist. */
 	platform?: Platform;
+	/** Optional tsconfig path override, resolved from Vite's project root. */
+	tsconfig?: string;
 }
 
 export function tsrxPreact(options?: TsrxPreactPluginOptions): Plugin;

--- a/packages/vite-plugin-preact/types/index.d.ts
+++ b/packages/vite-plugin-preact/types/index.d.ts
@@ -1,11 +1,13 @@
 import type { Plugin } from 'vite';
-import type { RuntimeImportMode } from '@tsrx/preact';
+import type { Platform, RuntimeImportMode } from '@tsrx/preact';
 
 export interface TsrxPreactPluginOptions {
 	jsxImportSource?: string;
 	suspenseSource?: string;
 	/** Direct mode requires `@tsrx/preact-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
+	/** Must match `tsrx.platform` in the active tsconfig. */
+	platform?: Platform;
 }
 
 export function tsrxPreact(options?: TsrxPreactPluginOptions): Plugin;

--- a/packages/vite-plugin-react/src/index.js
+++ b/packages/vite-plugin-react/src/index.js
@@ -39,7 +39,9 @@
  */
 
 import { transformWithOxc } from 'vite';
-import { compile, mergePlatformDefinitions, validatePlatform } from '@tsrx/react';
+import { compile } from '@tsrx/react';
+import { mergePlatformDefinitions, validatePlatform } from '@tsrx/core';
+import { resolveBuildPlatform } from '@tsrx/core/config';
 import { createDepScanTransformPlugin } from '@tsrx/core/vite/dep-scan';
 
 const TSRX_EXTENSION_PATTERN = /\.tsrx$/;
@@ -51,13 +53,27 @@ const CSS_QUERY = '?tsrx-css&lang.css';
  * `jsx-runtime`. Per-component `<style>` blocks are emitted as virtual CSS
  * modules that are imported by the compiled JS output.
  *
- * @param {{ jsxImportSource?: string, runtimeImports?: RuntimeImportMode, platform?: Platform }} [options]
+ * @param {{ jsxImportSource?: string, runtimeImports?: RuntimeImportMode, platform?: Platform, tsconfig?: string }} [options]
  * @returns {TsrxReactPlugin}
  */
 export function tsrxReact(options = {}) {
-	const platform = validatePlatform(options.platform);
+	const explicit_platform = validatePlatform(options.platform);
+	let platform = explicit_platform;
 	const jsxImportSource = options.jsxImportSource ?? 'react';
 	const compile_options = { runtimeImports: options.runtimeImports, platform };
+
+	/** @param {import('vite').UserConfig} config */
+	function resolve_platform(config) {
+		platform = resolveBuildPlatform({
+			root: config.root ?? process.cwd(),
+			tsconfig:
+				options.tsconfig ??
+				/** @type {{ tsconfig?: string }} */ (/** @type {unknown} */ (config)).tsconfig,
+			platform: explicit_platform,
+			integration: '@tsrx/vite-plugin-react',
+		});
+		compile_options.platform = platform;
+	}
 
 	/** @type {Map<string, string>} */
 	const css_cache = new Map();
@@ -81,6 +97,7 @@ export function tsrxReact(options = {}) {
 		enforce: 'pre',
 
 		config(config = /** @type {import('vite').UserConfig} */ ({})) {
+			resolve_platform(config);
 			if (platform === undefined) return;
 			return {
 				define: mergePlatformDefinitions(config.define, platform, {

--- a/packages/vite-plugin-react/src/index.js
+++ b/packages/vite-plugin-react/src/index.js
@@ -1,6 +1,6 @@
 /** @import { Plugin } from 'vite' */
 /** @import { DepScanTransformPlugin } from '@tsrx/core/types/vite/dep-scan' */
-/** @import { RuntimeImportMode } from '@tsrx/react' */
+/** @import { Platform, RuntimeImportMode } from '@tsrx/react' */
 
 /**
  * @typedef {{ code: string, map: unknown }} TsrxReactTransformResult
@@ -17,7 +17,8 @@
  *   (id: string): string | null,
  * }} TsrxReactLoad
  * @typedef {{
- *   optimizeDeps: {
+ *   define?: Record<string, unknown>,
+ *   optimizeDeps?: {
  *     extensions: string[],
  *     rolldownOptions: {
  *       transform: { jsx: { importSource: string } },
@@ -27,7 +28,7 @@
  * }} TsrxReactEnvironmentConfig
  * @typedef {(
  *   name: string,
- *   config: import('vite').EnvironmentOptions,
+ *   config?: import('vite').EnvironmentOptions,
  * ) => TsrxReactEnvironmentConfig | undefined} TsrxReactConfigEnvironmentHook
  * @typedef {Omit<Plugin, 'configEnvironment' | 'transform' | 'resolveId' | 'load'> & {
  *   configEnvironment: TsrxReactConfigEnvironmentHook,
@@ -38,7 +39,7 @@
  */
 
 import { transformWithOxc } from 'vite';
-import { compile } from '@tsrx/react';
+import { compile, mergePlatformDefinitions, validatePlatform } from '@tsrx/react';
 import { createDepScanTransformPlugin } from '@tsrx/core/vite/dep-scan';
 
 const TSRX_EXTENSION_PATTERN = /\.tsrx$/;
@@ -50,12 +51,13 @@ const CSS_QUERY = '?tsrx-css&lang.css';
  * `jsx-runtime`. Per-component `<style>` blocks are emitted as virtual CSS
  * modules that are imported by the compiled JS output.
  *
- * @param {{ jsxImportSource?: string, runtimeImports?: RuntimeImportMode }} [options]
+ * @param {{ jsxImportSource?: string, runtimeImports?: RuntimeImportMode, platform?: Platform }} [options]
  * @returns {TsrxReactPlugin}
  */
 export function tsrxReact(options = {}) {
+	const platform = validatePlatform(options.platform);
 	const jsxImportSource = options.jsxImportSource ?? 'react';
-	const compile_options = { runtimeImports: options.runtimeImports };
+	const compile_options = { runtimeImports: options.runtimeImports, platform };
 
 	/** @type {Map<string, string>} */
 	const css_cache = new Map();
@@ -78,14 +80,32 @@ export function tsrxReact(options = {}) {
 		name: '@tsrx/vite-plugin-react',
 		enforce: 'pre',
 
-		configEnvironment(name, config) {
+		config(config = /** @type {import('vite').UserConfig} */ ({})) {
+			if (platform === undefined) return;
+			return {
+				define: mergePlatformDefinitions(config.define, platform, {
+					integration: 'Vite',
+				}),
+			};
+		},
+
+		configEnvironment(name, config = /** @type {import('vite').EnvironmentOptions} */ ({})) {
 			const discovers_dependencies =
 				name === 'client' || config.optimizeDeps?.noDiscovery === false;
-			if (!discovers_dependencies) {
+			if (!discovers_dependencies && platform === undefined) {
 				return;
 			}
 
-			return create_dep_scan_config(jsxImportSource, compile_options);
+			return {
+				...(platform === undefined
+					? {}
+					: {
+							define: mergePlatformDefinitions(config.define, platform, {
+								integration: `Vite environment ${JSON.stringify(name)}`,
+							}),
+						}),
+				...(discovers_dependencies ? create_dep_scan_config(jsxImportSource, compile_options) : {}),
+			};
 		},
 
 		resolveId(/** @type {string} */ source) {
@@ -150,7 +170,7 @@ export function tsrxReact(options = {}) {
 
 /**
  * @param {string} jsxImportSource
- * @param {{ runtimeImports?: RuntimeImportMode }} compile_options
+ * @param {{ runtimeImports?: RuntimeImportMode, platform?: Platform }} compile_options
  * @returns {TsrxReactEnvironmentConfig}
  */
 function create_dep_scan_config(jsxImportSource, compile_options) {
@@ -174,7 +194,7 @@ function create_dep_scan_config(jsxImportSource, compile_options) {
 
 /**
  * @param {string} jsxImportSource
- * @param {{ runtimeImports?: RuntimeImportMode }} compile_options
+ * @param {{ runtimeImports?: RuntimeImportMode, platform?: Platform }} compile_options
  * @returns {DepScanTransformPlugin}
  */
 function create_dep_scan_plugin(jsxImportSource, compile_options) {

--- a/packages/vite-plugin-react/types/index.d.ts
+++ b/packages/vite-plugin-react/types/index.d.ts
@@ -1,11 +1,13 @@
 import type { EnvironmentOptions, Plugin } from 'vite';
-import type { RuntimeImportMode } from '@tsrx/react';
+import type { Platform, RuntimeImportMode } from '@tsrx/react';
 import type { DepScanTransformPlugin } from '@tsrx/core/types/vite/dep-scan';
 
 export interface TsrxReactPluginOptions {
 	jsxImportSource?: string;
 	/** Direct mode requires `@tsrx/react-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
+	/** Must match `tsrx.platform` in the active tsconfig. */
+	platform?: Platform;
 }
 
 export interface TsrxReactTransformResult {
@@ -22,7 +24,8 @@ export interface TsrxReactPlugin extends Omit<
 		config: EnvironmentOptions,
 	) =>
 		| {
-				optimizeDeps: {
+				define?: Record<string, unknown>;
+				optimizeDeps?: {
 					extensions: string[];
 					rolldownOptions: {
 						transform: { jsx: { importSource: string } };

--- a/packages/vite-plugin-react/types/index.d.ts
+++ b/packages/vite-plugin-react/types/index.d.ts
@@ -6,8 +6,10 @@ export interface TsrxReactPluginOptions {
 	jsxImportSource?: string;
 	/** Direct mode requires `@tsrx/react-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
-	/** Must match `tsrx.platform` in the active tsconfig. */
+	/** Optional override; inferred from tsconfig by default and must agree when both exist. */
 	platform?: Platform;
+	/** Optional tsconfig path override, resolved from Vite's project root. */
+	tsconfig?: string;
 }
 
 export interface TsrxReactTransformResult {

--- a/packages/vite-plugin-solid/src/index.js
+++ b/packages/vite-plugin-solid/src/index.js
@@ -3,7 +3,7 @@
 import { readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { resolve as path_resolve, isAbsolute } from 'node:path';
-import { compile } from '@tsrx/solid';
+import { compile, mergePlatformDefinitions, validatePlatform } from '@tsrx/solid';
 import { createDepScanLoadPlugin } from '@tsrx/core/vite/dep-scan';
 
 const DEFAULT_TSRX_PATTERN = /\.tsrx$/;
@@ -21,6 +21,7 @@ const CSS_QUERY = '?tsrx-solid-css&lang.css';
  * @returns {Plugin}
  */
 export function tsrxSolid(options = {}) {
+	const platform = validatePlatform(options.platform);
 	/** @type {Map<string, string>} */
 	const css_cache = new Map();
 
@@ -28,7 +29,7 @@ export function tsrxSolid(options = {}) {
 	let root_dir = process.cwd();
 
 	const include_pattern = options.include ?? DEFAULT_TSRX_PATTERN;
-	const compile_options = { runtimeImports: options.runtimeImports };
+	const compile_options = { runtimeImports: options.runtimeImports, platform };
 
 	/**
 	 * Decide whether a real (on-disk) path should be treated as a tsrx
@@ -76,8 +77,15 @@ export function tsrxSolid(options = {}) {
 		name: '@tsrx/vite-plugin-solid',
 		enforce: 'pre',
 
-		config() {
+		config(config = /** @type {import('vite').UserConfig} */ ({})) {
 			return {
+				...(platform === undefined
+					? {}
+					: {
+							define: mergePlatformDefinitions(config.define, platform, {
+								integration: 'Vite',
+							}),
+						}),
 				optimizeDeps: {
 					rolldownOptions: {
 						// The scan runs its own jsx transform over the tsx the
@@ -98,6 +106,15 @@ export function tsrxSolid(options = {}) {
 						],
 					},
 				},
+			};
+		},
+
+		configEnvironment(name, config = /** @type {import('vite').EnvironmentOptions} */ ({})) {
+			if (platform === undefined) return;
+			return {
+				define: mergePlatformDefinitions(config.define, platform, {
+					integration: `Vite environment ${JSON.stringify(name)}`,
+				}),
 			};
 		},
 

--- a/packages/vite-plugin-solid/src/index.js
+++ b/packages/vite-plugin-solid/src/index.js
@@ -3,7 +3,9 @@
 import { readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { resolve as path_resolve, isAbsolute } from 'node:path';
-import { compile, mergePlatformDefinitions, validatePlatform } from '@tsrx/solid';
+import { compile } from '@tsrx/solid';
+import { mergePlatformDefinitions, validatePlatform } from '@tsrx/core';
+import { resolveBuildPlatform } from '@tsrx/core/config';
 import { createDepScanLoadPlugin } from '@tsrx/core/vite/dep-scan';
 
 const DEFAULT_TSRX_PATTERN = /\.tsrx$/;
@@ -21,7 +23,8 @@ const CSS_QUERY = '?tsrx-solid-css&lang.css';
  * @returns {Plugin}
  */
 export function tsrxSolid(options = {}) {
-	const platform = validatePlatform(options.platform);
+	const explicit_platform = validatePlatform(options.platform);
+	let platform = explicit_platform;
 	/** @type {Map<string, string>} */
 	const css_cache = new Map();
 
@@ -30,6 +33,19 @@ export function tsrxSolid(options = {}) {
 
 	const include_pattern = options.include ?? DEFAULT_TSRX_PATTERN;
 	const compile_options = { runtimeImports: options.runtimeImports, platform };
+
+	/** @param {import('vite').UserConfig} config */
+	function resolve_platform(config) {
+		platform = resolveBuildPlatform({
+			root: config.root ?? process.cwd(),
+			tsconfig:
+				options.tsconfig ??
+				/** @type {{ tsconfig?: string }} */ (/** @type {unknown} */ (config)).tsconfig,
+			platform: explicit_platform,
+			integration: '@tsrx/vite-plugin-solid',
+		});
+		compile_options.platform = platform;
+	}
 
 	/**
 	 * Decide whether a real (on-disk) path should be treated as a tsrx
@@ -78,6 +94,7 @@ export function tsrxSolid(options = {}) {
 		enforce: 'pre',
 
 		config(config = /** @type {import('vite').UserConfig} */ ({})) {
+			resolve_platform(config);
 			return {
 				...(platform === undefined
 					? {}

--- a/packages/vite-plugin-solid/types/index.d.ts
+++ b/packages/vite-plugin-solid/types/index.d.ts
@@ -4,8 +4,10 @@ import type { Platform, RuntimeImportMode } from '@tsrx/solid';
 export interface TsrxSolidOptions {
 	/** Direct mode requires `@tsrx/solid-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
-	/** Must match `tsrx.platform` in the active tsconfig. */
+	/** Optional override; inferred from tsconfig by default and must agree when both exist. */
 	platform?: Platform;
+	/** Optional tsconfig path override, resolved from Vite's project root. */
+	tsconfig?: string;
 	/**
 	 * Regular expression matched against file paths to decide which modules
 	 * the plugin should compile as tsrx sources. Defaults to `/\.tsrx$/`,

--- a/packages/vite-plugin-solid/types/index.d.ts
+++ b/packages/vite-plugin-solid/types/index.d.ts
@@ -1,9 +1,11 @@
 import type { Plugin } from 'vite';
-import type { RuntimeImportMode } from '@tsrx/solid';
+import type { Platform, RuntimeImportMode } from '@tsrx/solid';
 
 export interface TsrxSolidOptions {
 	/** Direct mode requires `@tsrx/solid-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
+	/** Must match `tsrx.platform` in the active tsconfig. */
+	platform?: Platform;
 	/**
 	 * Regular expression matched against file paths to decide which modules
 	 * the plugin should compile as tsrx sources. Defaults to `/\.tsrx$/`,

--- a/packages/vite-plugin-vue/src/index.js
+++ b/packages/vite-plugin-vue/src/index.js
@@ -5,7 +5,7 @@
 import { readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { isAbsolute, resolve as pathResolve } from 'node:path';
-import { compile } from '@tsrx/vue';
+import { compile, mergePlatformDefinitions, validatePlatform } from '@tsrx/vue';
 import { createDepScanLoadPlugin } from '@tsrx/core/vite/dep-scan';
 import vueJsxVaporModule from 'vue-jsx-vapor/vite';
 import { createVaporInteropPlugin } from './interop.js';
@@ -77,6 +77,7 @@ function resolve_vapor_options(options) {
  * @returns {Plugin}
  */
 function create_tsrx_vue_plugin(options) {
+	const platform = validatePlatform(options.platform);
 	/** @type {Map<string, string>} */
 	const cssCache = new Map();
 
@@ -84,7 +85,7 @@ function create_tsrx_vue_plugin(options) {
 	let rootDir = process.cwd();
 
 	const includePattern = options.include ?? DEFAULT_TSRX_PATTERN;
-	const compile_options = { runtimeImports: options.runtimeImports };
+	const compile_options = { runtimeImports: options.runtimeImports, platform };
 
 	/**
 	 * @param {string} path
@@ -120,8 +121,15 @@ function create_tsrx_vue_plugin(options) {
 		name: '@tsrx/vite-plugin-vue',
 		enforce: 'pre',
 
-		config() {
+		config(config = /** @type {import('vite').UserConfig} */ ({})) {
 			return {
+				...(platform === undefined
+					? {}
+					: {
+							define: mergePlatformDefinitions(config.define, platform, {
+								integration: 'Vite',
+							}),
+						}),
 				resolve: {
 					dedupe: ['vue', 'vue-jsx-vapor'],
 				},
@@ -138,6 +146,15 @@ function create_tsrx_vue_plugin(options) {
 						plugins: [create_tsrx_vue_scan_plugin(isVirtual, toRealPath, compile_options)],
 					},
 				},
+			};
+		},
+
+		configEnvironment(name, config = /** @type {import('vite').EnvironmentOptions} */ ({})) {
+			if (platform === undefined) return;
+			return {
+				define: mergePlatformDefinitions(config.define, platform, {
+					integration: `Vite environment ${JSON.stringify(name)}`,
+				}),
 			};
 		},
 
@@ -225,7 +242,7 @@ function create_tsrx_vue_plugin(options) {
  *
  * @param {(id: string) => boolean} isVirtual
  * @param {(id: string) => string} toRealPath
- * @param {{ runtimeImports?: RuntimeImportMode }} compile_options
+ * @param {{ runtimeImports?: RuntimeImportMode, platform?: import('@tsrx/vue').Platform }} compile_options
  * @returns {DepScanLoadPlugin}
  */
 function create_tsrx_vue_scan_plugin(isVirtual, toRealPath, compile_options) {

--- a/packages/vite-plugin-vue/src/index.js
+++ b/packages/vite-plugin-vue/src/index.js
@@ -5,7 +5,9 @@
 import { readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { isAbsolute, resolve as pathResolve } from 'node:path';
-import { compile, mergePlatformDefinitions, validatePlatform } from '@tsrx/vue';
+import { compile } from '@tsrx/vue';
+import { mergePlatformDefinitions, validatePlatform } from '@tsrx/core';
+import { resolveBuildPlatform } from '@tsrx/core/config';
 import { createDepScanLoadPlugin } from '@tsrx/core/vite/dep-scan';
 import vueJsxVaporModule from 'vue-jsx-vapor/vite';
 import { createVaporInteropPlugin } from './interop.js';
@@ -77,7 +79,8 @@ function resolve_vapor_options(options) {
  * @returns {Plugin}
  */
 function create_tsrx_vue_plugin(options) {
-	const platform = validatePlatform(options.platform);
+	const explicit_platform = validatePlatform(options.platform);
+	let platform = explicit_platform;
 	/** @type {Map<string, string>} */
 	const cssCache = new Map();
 
@@ -86,6 +89,19 @@ function create_tsrx_vue_plugin(options) {
 
 	const includePattern = options.include ?? DEFAULT_TSRX_PATTERN;
 	const compile_options = { runtimeImports: options.runtimeImports, platform };
+
+	/** @param {import('vite').UserConfig} config */
+	function resolve_platform(config) {
+		platform = resolveBuildPlatform({
+			root: config.root ?? process.cwd(),
+			tsconfig:
+				options.tsconfig ??
+				/** @type {{ tsconfig?: string }} */ (/** @type {unknown} */ (config)).tsconfig,
+			platform: explicit_platform,
+			integration: '@tsrx/vite-plugin-vue',
+		});
+		compile_options.platform = platform;
+	}
 
 	/**
 	 * @param {string} path
@@ -122,6 +138,7 @@ function create_tsrx_vue_plugin(options) {
 		enforce: 'pre',
 
 		config(config = /** @type {import('vite').UserConfig} */ ({})) {
+			resolve_platform(config);
 			return {
 				...(platform === undefined
 					? {}

--- a/packages/vite-plugin-vue/types/index.d.ts
+++ b/packages/vite-plugin-vue/types/index.d.ts
@@ -1,9 +1,11 @@
 import type { Plugin } from 'vite';
-import type { RuntimeImportMode } from '@tsrx/vue';
+import type { Platform, RuntimeImportMode } from '@tsrx/vue';
 
 export interface TsrxVueOptions {
 	/** Direct mode requires `@tsrx/vue-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
+	/** Must match `tsrx.platform` in the active tsconfig. */
+	platform?: Platform;
 	/**
 	 * Regular expression matched against file paths to decide which modules
 	 * the plugin should compile as tsrx sources. Defaults to `/\.tsrx$/`.

--- a/packages/vite-plugin-vue/types/index.d.ts
+++ b/packages/vite-plugin-vue/types/index.d.ts
@@ -4,8 +4,10 @@ import type { Platform, RuntimeImportMode } from '@tsrx/vue';
 export interface TsrxVueOptions {
 	/** Direct mode requires `@tsrx/vue-runtime` as a direct production dependency. */
 	runtimeImports?: RuntimeImportMode;
-	/** Must match `tsrx.platform` in the active tsconfig. */
+	/** Optional override; inferred from tsconfig by default and must agree when both exist. */
 	platform?: Platform;
+	/** Optional tsconfig path override, resolved from Vite's project root. */
+	tsconfig?: string;
 	/**
 	 * Regular expression matched against file paths to decide which modules
 	 * the plugin should compile as tsrx sources. Defaults to `/\.tsrx$/`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ catalogs:
     eslint:
       specifier: ^10.3.0
       version: 10.3.0
+    get-tsconfig:
+      specifier: 5.0.0-beta.6
+      version: 5.0.0-beta.6
     is-reference:
       specifier: ^3.0.3
       version: 3.0.3
@@ -305,6 +308,9 @@ importers:
 
   packages/bun-plugin-preact:
     dependencies:
+      '@tsrx/core':
+        specifier: workspace:*
+        version: link:../tsrx
       '@tsrx/preact':
         specifier: workspace:*
         version: link:../tsrx-preact
@@ -324,6 +330,9 @@ importers:
 
   packages/bun-plugin-react:
     dependencies:
+      '@tsrx/core':
+        specifier: workspace:*
+        version: link:../tsrx
       '@tsrx/react':
         specifier: workspace:*
         version: link:../tsrx-react
@@ -349,6 +358,9 @@ importers:
       '@babel/preset-typescript':
         specifier: catalog:default
         version: 7.28.5(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@tsrx/core':
+        specifier: workspace:*
+        version: link:../tsrx
       '@tsrx/solid':
         specifier: workspace:*
         version: link:../tsrx-solid
@@ -377,6 +389,9 @@ importers:
 
   packages/bun-plugin-vue:
     dependencies:
+      '@tsrx/core':
+        specifier: workspace:*
+        version: link:../tsrx
       '@tsrx/vue':
         specifier: workspace:*
         version: link:../tsrx-vue
@@ -511,6 +526,9 @@ importers:
 
   packages/rspack-plugin-preact:
     dependencies:
+      '@tsrx/core':
+        specifier: workspace:*
+        version: link:../tsrx
       '@tsrx/preact':
         specifier: workspace:*
         version: link:../tsrx-preact
@@ -527,6 +545,9 @@ importers:
 
   packages/rspack-plugin-react:
     dependencies:
+      '@tsrx/core':
+        specifier: workspace:*
+        version: link:../tsrx
       '@tsrx/react':
         specifier: workspace:*
         version: link:../tsrx-react
@@ -558,6 +579,9 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.28.5
         version: 7.28.5(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@tsrx/core':
+        specifier: workspace:*
+        version: link:../tsrx
       '@tsrx/solid':
         specifier: workspace:*
         version: link:../tsrx-solid
@@ -586,6 +610,9 @@ importers:
 
   packages/rspack-plugin-vue:
     dependencies:
+      '@tsrx/core':
+        specifier: workspace:*
+        version: link:../tsrx
       '@tsrx/vue':
         specifier: workspace:*
         version: link:../tsrx-vue
@@ -647,6 +674,9 @@ importers:
       esrap:
         specifier: ^2.3.2
         version: 2.3.2(@typescript-eslint/types@8.56.1)
+      get-tsconfig:
+        specifier: catalog:default
+        version: 5.0.0-beta.6
       magic-string:
         specifier: catalog:default
         version: 0.30.21
@@ -878,6 +908,9 @@ importers:
 
   packages/turbopack-plugin-react:
     dependencies:
+      '@tsrx/core':
+        specifier: workspace:*
+        version: link:../tsrx
       '@tsrx/react':
         specifier: workspace:*
         version: link:../tsrx-react
@@ -4219,6 +4252,10 @@ packages:
 
   get-tsconfig@5.0.0-beta.5:
     resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
+    engines: {node: '>=20.20.0'}
+
+  get-tsconfig@5.0.0-beta.6:
+    resolution: {integrity: sha512-X6fBC0pmImC70gvX2zm56go9hx0MyoGVdG0tUCkg/D+Xnh5TJsOZ7iDbOdI3PvmtrDxnu1YdDufpK2QJX1Meqw==}
     engines: {node: '>=20.20.0'}
 
   github-from-package@0.0.0:
@@ -9442,6 +9479,10 @@ snapshots:
       is-stream: 4.0.1
 
   get-tsconfig@5.0.0-beta.5:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  get-tsconfig@5.0.0-beta.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -97,6 +97,7 @@ catalogs:
     eslint: ^10.3.0
     esm-env: ^1.2.2
     esrap: *esrap_common
+    get-tsconfig: 5.0.0-beta.6
     is-reference: ^3.0.3
     jsdom: ^29.0.2
     kleur: ^4.1.5

--- a/website-tsrx/public/llms.txt
+++ b/website-tsrx/public/llms.txt
@@ -122,22 +122,29 @@ builders still replace exact flags in their remaining output. Use an ordinary
 exact-flag `if` when platform-only types, dependencies, scripts, or styles must
 be excluded before TSRX/TypeScript analysis.
 
-Pass the same platform to the build integration so ordinary `.ts`, `.tsx`, and
-JavaScript modules receive matching compile-time constants:
+In-repo build integrations read the same inherited tsconfig automatically, so
+ordinary `.ts`, `.tsx`, and JavaScript modules receive matching compile-time
+constants without repeating the selection:
 
 ```js
-tsrxReact({ platform: 'ios' });
-new TsrxReactRspackPlugin({ platform: 'ios' });
-tsrxReactBun({ platform: 'ios' });
-tsrxReactTurbopack({}, { platform: 'ios' });
+tsrxReact();
+new TsrxReactRspackPlugin();
+tsrxReactBun();
+tsrxReactTurbopack({});
 ```
+
+For a non-default project config, use the Vite plugin's `tsconfig` option,
+Rspack's `resolve.tsConfig`, Bun's `build.tsconfig`, or Next's
+`typescript.tsconfigPath`. Paths are resolved from the corresponding builder
+root.
 
 Vite, Rspack, Bun, and the available React Turbopack integration support the
 option. The same option is available for every React, Preact, Solid, and Vue
-integration that exists. Vite, Rspack, and Bun reject conflicting user-provided
-definitions. Omitting the platform remains valid until a recognized flag is
-used; using a flag without configuration, or supplying any other value, is an
-actionable error.
+integration that exists. An explicit builder `platform` remains available as an
+override/fallback, but it must agree with tsconfig when both exist. Vite, Rspack,
+and Bun reject conflicting user-provided definitions. Omitting the platform
+remains valid until a recognized flag is used; using a flag without
+configuration, or supplying any other value, is an actionable error.
 
 ### Runtime helper imports
 

--- a/website-tsrx/public/llms.txt
+++ b/website-tsrx/public/llms.txt
@@ -69,6 +69,76 @@ npm install octane @octanejs/vite-plugin
 Vue's Vite setup should use `tsrxVue()` from `@tsrx/vite-plugin-vue`,
 and editor/typecheck configs should set `jsxImportSource: 'vue-jsx-vapor'`.
 
+### Compile-time platform flags
+
+Shared source can select one of three exact platforms through the active
+TypeScript project:
+
+```json
+{
+	"tsrx": {
+		"compiler": "@tsrx/react",
+		"platform": "ios"
+	},
+	"compilerOptions": {
+		"lib": ["ES2022"],
+		"types": ["my-native-host-types"]
+	}
+}
+```
+
+The only accepted values are `"web"`, `"ios"`, and `"android"`. There is no
+default. When configured, all three boolean properties exist and exactly one is
+true:
+
+```ts
+import.meta.env.platform.web;
+import.meta.env.platform.ios;
+import.meta.env.platform.android;
+```
+
+An ordinary `if` whose complete test is one of those exact paths is specialized
+immediately after parsing. TSRX parses every branch for syntax, then performs
+semantic analysis, style extraction, target lowering, source mapping, and
+virtual TypeScript generation only on the selected AST. This removes inactive
+platform code, guarded dynamic imports, embedded script regions, and scoped CSS
+before they can affect diagnostics or output. The retained statement keeps its
+original lexical block and source location.
+
+```tsx
+if (import.meta.env.platform.web) {
+	window.addEventListener('resize', onResize);
+} else if (import.meta.env.platform.ios) {
+	iosHost.subscribe(onResize);
+} else {
+	androidHost.subscribe(onResize);
+}
+```
+
+Template `@if` deliberately remains runtime control flow in this version, and
+expressions such as `!import.meta.env.platform.web` or
+`import.meta.env.platform.web === true` are not specialized by TSRX. Supported
+builders still replace exact flags in their remaining output. Use an ordinary
+exact-flag `if` when platform-only types, dependencies, scripts, or styles must
+be excluded before TSRX/TypeScript analysis.
+
+Pass the same platform to the build integration so ordinary `.ts`, `.tsx`, and
+JavaScript modules receive matching compile-time constants:
+
+```js
+tsrxReact({ platform: 'ios' });
+new TsrxReactRspackPlugin({ platform: 'ios' });
+tsrxReactBun({ platform: 'ios' });
+tsrxReactTurbopack({}, { platform: 'ios' });
+```
+
+Vite, Rspack, Bun, and the available React Turbopack integration support the
+option. The same option is available for every React, Preact, Solid, and Vue
+integration that exists. Vite, Rspack, and Bun reject conflicting user-provided
+definitions. Omitting the platform remains valid until a recognized flag is
+used; using a flag without configuration, or supplying any other value, is an
+actionable error.
+
 ### Runtime helper imports
 
 Compiler output uses compiler-package helper subpaths by default, so applications

--- a/website-tsrx/public/llms.txt
+++ b/website-tsrx/public/llms.txt
@@ -122,9 +122,9 @@ builders still replace exact flags in their remaining output. Use an ordinary
 exact-flag `if` when platform-only types, dependencies, scripts, or styles must
 be excluded before TSRX/TypeScript analysis.
 
-In-repo build integrations read the same inherited tsconfig automatically, so
-ordinary `.ts`, `.tsx`, and JavaScript modules receive matching compile-time
-constants without repeating the selection:
+In-repo build integrations read the same inherited or project-referenced
+tsconfig automatically, so ordinary `.ts`, `.tsx`, and JavaScript modules
+receive matching compile-time constants without repeating the selection:
 
 ```js
 tsrxReact();

--- a/website-tsrx/src/pages/getting-started.tsrx
+++ b/website-tsrx/src/pages/getting-started.tsrx
@@ -319,6 +319,25 @@ export function OptIn() @{
 }`,
 );
 
+const PLATFORM_TSCONFIG_HTML = [
+	'<span class="ln">1</span> <span class="br">{</span>',
+	'<span class="ln">2</span>   <span class="attr">"tsrx"</span>: <span class="br">{</span>',
+	'<span class="ln">3</span>     <span class="attr">"compiler"</span>: <span class="str">"@tsrx/react"</span>,',
+	'<span class="ln">4</span>     <span class="attr">"platform"</span>: <span class="str">"ios"</span>',
+	'<span class="ln">5</span>   <span class="br">}</span>',
+	'<span class="ln">6</span> <span class="br">}</span>',
+].join('\n');
+
+const PLATFORM_GUARD_HTML = highlight_tsrx(
+	`if (import.meta.env.platform.web) {
+  window.addEventListener('resize', onResize);
+} else if (import.meta.env.platform.ios) {
+  iosHost.subscribe(onResize);
+} else {
+  androidHost.subscribe(onResize);
+}`,
+);
+
 const NAV_GROUPS = [
 	{
 		heading: 'Frameworks',
@@ -336,6 +355,7 @@ const NAV_GROUPS = [
 			{ id: 'vue-vite', label: 'Vue + Vite' },
 			{ id: 'vue-rspack', label: 'Vue + Rspack' },
 			{ id: 'vue-bun', label: 'Vue + Bun' },
+			{ id: 'platform-flags', label: 'Platform flags' },
 			{ id: 'direct-runtime-imports', label: 'Direct runtime imports' },
 			{ id: 'ripple', label: 'Ripple' },
 			{ id: 'octane', label: 'Octane' },
@@ -803,6 +823,46 @@ export function GettingStartedPage() @{
 								in your
 								<code class="inline-code">tsconfig.json</code>
 								.
+							</p>
+						</section>
+
+						<section class="doc-section" id="platform-flags">
+							<p class="section-kicker">Shared source</p>
+							<h2 class="section-heading">Compile-time platform flags</h2>
+							<p class="section-body">
+								Select exactly one of
+								<code class="inline-code">web</code>
+								,
+								<code class="inline-code">ios</code>
+								, or
+								<code class="inline-code">android</code>
+								in the active TypeScript project. Pass the same
+								<code class="inline-code">platform</code>
+								option to your Vite, Rspack, Bun, or available React Turbopack integration. There is
+								no implicit web default.
+							</p>
+							<pre class="code-block">
+								<code innerHTML={PLATFORM_TSCONFIG_HTML} />
+							</pre>
+							<pre class="code-block">
+								<code innerHTML={PLATFORM_GUARD_HTML} />
+							</pre>
+							<p class="section-body">
+								An ordinary
+								<code class="inline-code">if</code>
+								whose whole test is one exact flag is selected before TSRX analyzes styles,
+								dependencies, or target output. The inactive branch therefore contributes no
+								diagnostics, generated code, dynamic imports, embedded scripts, source mappings, or
+								CSS. All branches are still parsed for syntax.
+							</p>
+							<p class="section-body">
+								Template
+								<code class="inline-code">@if</code>
+								remains runtime control flow. Use an ordinary exact-flag
+								<code class="inline-code">if</code>
+								when platform-only code or styles must disappear before type checking and CSS
+								extraction. A recognized flag without configuration—or any other platform value—is
+								an error.
 							</p>
 						</section>
 

--- a/website-tsrx/src/pages/getting-started.tsrx
+++ b/website-tsrx/src/pages/getting-started.tsrx
@@ -836,10 +836,12 @@ export function GettingStartedPage() @{
 								<code class="inline-code">ios</code>
 								, or
 								<code class="inline-code">android</code>
-								in the active TypeScript project. Pass the same
+								in the active TypeScript project. The Vite, Rspack, Bun, and available React
+								Turbopack integrations read that inherited tsconfig setting automatically. Their
+								explicit
 								<code class="inline-code">platform</code>
-								option to your Vite, Rspack, Bun, or available React Turbopack integration. There is
-								no implicit web default.
+								option is only an override/fallback and must agree with tsconfig. There is no
+								implicit web default.
 							</p>
 							<pre class="code-block">
 								<code innerHTML={PLATFORM_TSCONFIG_HTML} />

--- a/website-tsrx/src/pages/getting-started.tsrx
+++ b/website-tsrx/src/pages/getting-started.tsrx
@@ -837,8 +837,8 @@ export function GettingStartedPage() @{
 								, or
 								<code class="inline-code">android</code>
 								in the active TypeScript project. The Vite, Rspack, Bun, and available React
-								Turbopack integrations read that inherited tsconfig setting automatically. Their
-								explicit
+								Turbopack integrations read that inherited or project-referenced tsconfig setting
+								automatically. Their explicit
 								<code class="inline-code">platform</code>
 								option is only an override/fallback and must agree with tsconfig. There is no
 								implicit web default.


### PR DESCRIPTION
Closes #95.

## Summary

- add the shared web, ios, and android platform option and compatible import.meta.env.platform typing
- specialize exact ordinary-if platform guards immediately after parsing and before TSRX semantic analysis, CSS extraction, target lowering, source mapping, and virtual TypeScript generation
- resolve tsrx.platform through inherited, nested, and project-referenced TypeScript configs, including config refreshes and dot completion
- make every in-repo builder read the project tsconfig automatically, while retaining a validated explicit override/fallback that must agree with tsconfig
- define the same three boolean paths in every React, Preact, Solid, and Vue Vite/Rspack/Bun integration
- add equivalent replacement rules to the existing React Turbopack integration, preserving and composing upstream source maps
- reject invalid platform values and conflicting Vite, Rspack, or Bun definitions
- document the ordinary-if versus runtime @if boundary

## Builder coverage

- Vite: React, Preact, Solid, Vue; nearest/referenced config or plugin tsconfig override
- Rspack: React, Preact, Solid, Vue; context plus resolve.tsConfig
- Bun: React, Preact, Solid, Vue; build root plus build.tsconfig
- Turbopack: React (the integration currently present); Next typescript.tsconfigPath or Turbopack root

## Validation

- pnpm test — 96 files, 4,155 passed, 33 skipped
- pnpm typecheck
- pnpm changeset:check
- pnpm install --frozen-lockfile
- pnpm --filter tsrx-website build

Cursor Bugbot findings from earlier revisions were addressed with regression coverage: chained Turbopack source maps, broader Rspack DefinePlugin conflict detection, and solution-style project-reference resolution.

The local all-files formatting check also inspected machine-generated IntelliJ cache files that are absent from a clean checkout; all touched source and documentation files are formatted.
