### PR TITLE
fix: match TSX highlighting roles in TSRX

### DIFF
--- a/.changeset/bright-tags-match.md
+++ b/.changeset/bright-tags-match.md
@@ -1,0 +1,6 @@
+---
+"@tsrx/intellij-plugin": patch
+"@tsrx/vscode-plugin": patch
+---
+
+Recognize multiline JSX expression boundaries and align theme-relative highlighting roles for member access inside embedded JSX expressions.

--- a/assets/TSRX.tmbundle/Syntaxes/tsrx.tmLanguage
+++ b/assets/TSRX.tmbundle/Syntaxes/tsrx.tmLanguage
@@ -3146,7 +3146,31 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#jsx</string>
+					<string>#jsx-tag-code-in-expression</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-style-in-expression</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-script-in-expression</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-fragment</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-dynamic-in-expression</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-without-attributes-in-expression</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-in-expression</string>
 				</dict>
 				<dict>
 					<key>include</key>

--- a/assets/TSRX.tmbundle/Syntaxes/tsrx.tmLanguage
+++ b/assets/TSRX.tmbundle/Syntaxes/tsrx.tmLanguage
@@ -3146,6 +3146,10 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#jsx</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#tsrx-template-child-directive</string>
 				</dict>
 				<dict>

--- a/grammars/textmate/tsrx.tmLanguage.json
+++ b/grammars/textmate/tsrx.tmLanguage.json
@@ -668,7 +668,25 @@
     "expressionWithoutIdentifiers": {
       "patterns": [
         {
-          "include": "#jsx"
+          "include": "#jsx-tag-code-in-expression"
+        },
+        {
+          "include": "#jsx-tag-style-in-expression"
+        },
+        {
+          "include": "#jsx-tag-script-in-expression"
+        },
+        {
+          "include": "#jsx-tag-fragment"
+        },
+        {
+          "include": "#jsx-tag-dynamic-in-expression"
+        },
+        {
+          "include": "#jsx-tag-without-attributes-in-expression"
+        },
+        {
+          "include": "#jsx-tag-in-expression"
         },
         {
           "include": "#tsrx-template-child-directive"

--- a/grammars/textmate/tsrx.tmLanguage.json
+++ b/grammars/textmate/tsrx.tmLanguage.json
@@ -668,6 +668,9 @@
     "expressionWithoutIdentifiers": {
       "patterns": [
         {
+          "include": "#jsx"
+        },
+        {
           "include": "#tsrx-template-child-directive"
         },
         {

--- a/packages/intellij-plugin/DEVELOPMENT.md
+++ b/packages/intellij-plugin/DEVELOPMENT.md
@@ -29,6 +29,12 @@ comments, syntax highlighting, diagnostics, completion, navigation, and
 formatting. In a syntax-only IDE, confirm the file type and highlighting work
 without starting a language-server download.
 
+For JSX highlighting parity, open `src/test/resources/highlighting/issue-100.tsx`
+and `issue-100.tsrx` side by side in WebStorm 2025.2.4 under Darcula. Compare tag
+names and delimiters, `key` and `className`, and the `length`, `map`, and `text`
+member names. The comparison is theme-relative; it checks equivalent syntax roles,
+not full TypeScript PSI-backed semantics for `.tsrx` files.
+
 The managed language server is installed with npm lifecycle scripts disabled.
 Gradle derives its exact pinned version directly from
 `packages/language-server/package.json`; do not duplicate that version in IntelliJ

--- a/packages/intellij-plugin/src/main/kotlin/dev/tsrx/intellij_plugin/TsrxSyntaxHighlighterFactory.kt
+++ b/packages/intellij-plugin/src/main/kotlin/dev/tsrx/intellij_plugin/TsrxSyntaxHighlighterFactory.kt
@@ -1,0 +1,90 @@
+package dev.tsrx.intellij_plugin
+
+import com.intellij.lexer.Lexer
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.fileTypes.SyntaxHighlighter
+import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.tree.IElementType
+import org.jetbrains.plugins.textmate.language.syntax.highlighting.TextMateSyntaxHighlighterFactory
+import org.jetbrains.plugins.textmate.language.syntax.lexer.TextMateElementType
+import org.jetbrains.plugins.textmate.language.syntax.lexer.TextMateScope
+
+class TsrxSyntaxHighlighterFactory : SyntaxHighlighterFactory() {
+	private val textMateFactory = TextMateSyntaxHighlighterFactory()
+
+	override fun getSyntaxHighlighter(project: Project?, virtualFile: VirtualFile?): SyntaxHighlighter =
+		TsrxSyntaxHighlighter(textMateFactory.getSyntaxHighlighter(project, virtualFile))
+}
+
+internal class TsrxSyntaxHighlighter(
+	private val delegate: SyntaxHighlighter,
+) : SyntaxHighlighter {
+	override fun getHighlightingLexer(): Lexer = delegate.highlightingLexer
+
+	override fun getTokenHighlights(tokenType: IElementType): Array<TextAttributesKey> {
+		val delegated = delegate.getTokenHighlights(tokenType)
+		val textMateToken = tokenType as? TextMateElementType ?: return delegated
+		val scopes = textMateToken.scope.names()
+		if (!scopes.containsAll(JSX_EXPRESSION_SCOPES)) return delegated
+
+		return when {
+			textMateToken.scope.scopeName in PROPERTY_SCOPES ->
+				delegated.withMemberRole(
+					DefaultLanguageHighlighterColors.INSTANCE_FIELD,
+					TsrxMemberRoleKeys.INSTANCE_MEMBER_VARIABLE,
+				)
+
+			textMateToken.scope.scopeName == FUNCTION_SCOPE && FUNCTION_CALL_SCOPE in scopes ->
+				delegated.withMemberRole(
+					DefaultLanguageHighlighterColors.INSTANCE_METHOD,
+					TsrxMemberRoleKeys.INSTANCE_MEMBER_FUNCTION,
+				)
+
+			else -> delegated
+		}
+	}
+
+	private fun Array<TextAttributesKey>.withMemberRole(
+		platformFallback: TextAttributesKey,
+		targetRole: TextAttributesKey,
+	): Array<TextAttributesKey> = this + platformFallback + targetRole
+
+	private fun TextMateScope.names(): Set<String> = buildSet {
+		var current: TextMateScope? = this@names
+		while (current != null) {
+			add(current.scopeName.toString())
+			current = current.parent
+		}
+	}
+
+	companion object {
+		private val JSX_EXPRESSION_SCOPES = setOf(
+			"source.tsrx",
+			"meta.jsx.children.js",
+			"meta.embedded.expression.js",
+		)
+		private val PROPERTY_SCOPES = setOf(
+			"support.variable.property.js",
+			"variable.other.property.js",
+		)
+		private const val FUNCTION_SCOPE = "entity.name.function.js"
+		private const val FUNCTION_CALL_SCOPE = "meta.function-call.js"
+	}
+}
+
+internal object TsrxMemberRoleKeys {
+	// Referencing WebStorm's role by external identity keeps this plugin loadable on
+	// products that provide TextMate without the JavaScript plugin. The platform key
+	// returned alongside it is the fallback when that optional role is not styled.
+	val INSTANCE_MEMBER_VARIABLE: TextAttributesKey = TextAttributesKey.createTextAttributesKey(
+		"TSRX.INSTANCE_MEMBER_VARIABLE",
+		TextAttributesKey.find("TS.INSTANCE_MEMBER_VARIABLE"),
+	)
+	val INSTANCE_MEMBER_FUNCTION: TextAttributesKey = TextAttributesKey.createTextAttributesKey(
+		"TSRX.INSTANCE_MEMBER_FUNCTION",
+		TextAttributesKey.find("TS.INSTANCE_MEMBER_FUNCTION"),
+	)
+}

--- a/packages/intellij-plugin/src/main/kotlin/dev/tsrx/intellij_plugin/TsrxSyntaxHighlighterFactory.kt
+++ b/packages/intellij-plugin/src/main/kotlin/dev/tsrx/intellij_plugin/TsrxSyntaxHighlighterFactory.kt
@@ -4,6 +4,7 @@ import com.intellij.lexer.Lexer
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.fileTypes.SyntaxHighlighter
+import com.intellij.openapi.fileTypes.SyntaxHighlighterBase
 import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
@@ -27,52 +28,63 @@ internal class TsrxSyntaxHighlighter(
 	override fun getTokenHighlights(tokenType: IElementType): Array<TextAttributesKey> {
 		val delegated = delegate.getTokenHighlights(tokenType)
 		val textMateToken = tokenType as? TextMateElementType ?: return delegated
-		val scopes = textMateToken.scope.names()
-		if (!scopes.containsAll(JSX_EXPRESSION_SCOPES)) return delegated
+		val leafScope = textMateToken.scope.scopeName.toString()
+		val memberRole = when {
+			leafScope in PROPERTY_SCOPES -> MemberRole.PROPERTY
+			leafScope == FUNCTION_SCOPE -> MemberRole.FUNCTION
+			else -> return delegated
+		}
+		if (!textMateToken.scope.isJsxExpressionMember(memberRole)) return delegated
 
-		return when {
-			textMateToken.scope.scopeName in PROPERTY_SCOPES ->
-				delegated.withMemberRole(
+		return when (memberRole) {
+			MemberRole.PROPERTY ->
+				SyntaxHighlighterBase.pack(
+					delegated,
 					DefaultLanguageHighlighterColors.INSTANCE_FIELD,
 					TsrxMemberRoleKeys.INSTANCE_MEMBER_VARIABLE,
 				)
 
-			textMateToken.scope.scopeName == FUNCTION_SCOPE && FUNCTION_CALL_SCOPE in scopes ->
-				delegated.withMemberRole(
+			MemberRole.FUNCTION ->
+				SyntaxHighlighterBase.pack(
+					delegated,
 					DefaultLanguageHighlighterColors.INSTANCE_METHOD,
 					TsrxMemberRoleKeys.INSTANCE_MEMBER_FUNCTION,
 				)
-
-			else -> delegated
 		}
 	}
 
-	private fun Array<TextAttributesKey>.withMemberRole(
-		platformFallback: TextAttributesKey,
-		targetRole: TextAttributesKey,
-	): Array<TextAttributesKey> = this + platformFallback + targetRole
-
-	private fun TextMateScope.names(): Set<String> = buildSet {
-		var current: TextMateScope? = this@names
+	private fun TextMateScope.isJsxExpressionMember(memberRole: MemberRole): Boolean {
+		var hasSource = false
+		var hasJsxContext = false
+		var hasEmbeddedExpression = false
+		var hasFunctionCall = memberRole != MemberRole.FUNCTION
+		var current: TextMateScope? = this
 		while (current != null) {
-			add(current.scopeName.toString())
+			when (current.scopeName.toString()) {
+				SOURCE_SCOPE -> hasSource = true
+				JSX_CHILDREN_SCOPE, JSX_ATTRIBUTES_SCOPE -> hasJsxContext = true
+				EMBEDDED_EXPRESSION_SCOPE -> hasEmbeddedExpression = true
+				FUNCTION_CALL_SCOPE -> hasFunctionCall = true
+			}
 			current = current.parent
 		}
+		return hasSource && hasJsxContext && hasEmbeddedExpression && hasFunctionCall
 	}
 
 	companion object {
-		private val JSX_EXPRESSION_SCOPES = setOf(
-			"source.tsrx",
-			"meta.jsx.children.js",
-			"meta.embedded.expression.js",
-		)
 		private val PROPERTY_SCOPES = setOf(
 			"support.variable.property.js",
 			"variable.other.property.js",
 		)
+		private const val SOURCE_SCOPE = "source.tsrx"
+		private const val JSX_CHILDREN_SCOPE = "meta.jsx.children.js"
+		private const val JSX_ATTRIBUTES_SCOPE = "meta.tag.attributes.js"
+		private const val EMBEDDED_EXPRESSION_SCOPE = "meta.embedded.expression.js"
 		private const val FUNCTION_SCOPE = "entity.name.function.js"
 		private const val FUNCTION_CALL_SCOPE = "meta.function-call.js"
 	}
+
+	private enum class MemberRole { PROPERTY, FUNCTION }
 }
 
 internal object TsrxMemberRoleKeys {

--- a/packages/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/packages/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -32,7 +32,7 @@
 					 language="TSRX" extensions="tsrx"/>
 		<lang.commenter language="TSRX" implementationClass="dev.tsrx.intellij_plugin.TsrxCommenter"/>
 		<lang.syntaxHighlighterFactory language="TSRX"
-									 implementationClass="org.jetbrains.plugins.textmate.language.syntax.highlighting.TextMateSyntaxHighlighterFactory"/>
+									 implementationClass="dev.tsrx.intellij_plugin.TsrxSyntaxHighlighterFactory"/>
 		<editorHighlighterProvider filetype="TSRX"
 								 implementationClass="org.jetbrains.plugins.textmate.language.syntax.highlighting.TextMateEditorHighlighterProvider"/>
 		<textmate.bundleProvider implementation="dev.tsrx.intellij_plugin.TsrxTextMateBundleProvider"/>

--- a/packages/intellij-plugin/src/test/kotlin/dev/tsrx/intellij_plugin/TsrxSyntaxHighlightingTest.kt
+++ b/packages/intellij-plugin/src/test/kotlin/dev/tsrx/intellij_plugin/TsrxSyntaxHighlightingTest.kt
@@ -1,0 +1,204 @@
+package dev.tsrx.intellij_plugin
+
+import com.intellij.lexer.Lexer
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.fileTypes.PlainSyntaxHighlighter
+import com.intellij.openapi.fileTypes.SyntaxHighlighter
+import com.intellij.psi.TokenType
+import com.intellij.psi.tree.IElementType
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import java.nio.file.Path
+import kotlin.io.path.readText
+import org.jetbrains.plugins.textmate.language.syntax.lexer.TextMateElementType
+import org.jetbrains.plugins.textmate.language.syntax.lexer.TextMateScope
+
+class TsrxSyntaxHighlightingTest : BasePlatformTestCase() {
+	fun testIssue100RolesMatchTsxReference() {
+		val tsx = capture("tsx")
+		val tsrx = capture("tsrx")
+
+		for (probe in ROLE_PROBES) {
+			assertEquals(
+				"Native TSX role for ${probe.text}",
+				probe.expectedRole,
+				tsx.getValue(probe).normalizedRole(FileKind.TSX),
+			)
+			assertEquals(
+				"TSRX TextMate role for ${probe.text}",
+				probe.expectedRole,
+				tsrx.getValue(probe).normalizedRole(FileKind.TSRX),
+			)
+			assertTrue(
+				"TSRX must use TextMate for ${probe.text}, not a plain-text fallback",
+				tsrx.getValue(probe).tokenType is TextMateElementType,
+			)
+		}
+	}
+
+	fun testAdapterChangesOnlyMembersInsideJsxExpressions() {
+		val delegated = TextAttributesKey.createTextAttributesKey("TSRX.TEST.DELEGATED")
+		val highlighter = TsrxSyntaxHighlighter(object : SyntaxHighlighter {
+			override fun getHighlightingLexer(): Lexer = PlainSyntaxHighlighter().highlightingLexer
+
+			override fun getTokenHighlights(tokenType: IElementType): Array<TextAttributesKey> =
+				arrayOf(delegated)
+		})
+
+		assertEquals(
+			listOf(
+				delegated,
+				DefaultLanguageHighlighterColors.INSTANCE_FIELD,
+				TsrxMemberRoleKeys.INSTANCE_MEMBER_VARIABLE,
+			),
+			highlighter.getTokenHighlights(textMateToken(*JSX_PROPERTY_SCOPES)).toList(),
+		)
+		assertEquals(
+			listOf(
+				delegated,
+				DefaultLanguageHighlighterColors.INSTANCE_METHOD,
+				TsrxMemberRoleKeys.INSTANCE_MEMBER_FUNCTION,
+			),
+			highlighter.getTokenHighlights(textMateToken(*JSX_METHOD_SCOPES)).toList(),
+		)
+
+		val unchangedTokens = listOf(
+			textMateToken("source.tsrx", "support.variable.property.js"),
+			textMateToken(*JSX_BASE_SCOPES, "entity.name.tag.js"),
+			textMateToken(*JSX_BASE_SCOPES, "entity.other.attribute-name.js"),
+			textMateToken(*JSX_BASE_SCOPES, "string.quoted.double.js"),
+			textMateToken(*JSX_BASE_SCOPES, "comment.line.double-slash.js"),
+			textMateToken(*JSX_BASE_SCOPES, "constant.numeric.decimal.js"),
+			textMateToken(*JSX_BASE_SCOPES, "keyword.control.directive.tsrx"),
+			textMateToken("source.tsrx", "meta.tag.js", "entity.name.tag.js"),
+			textMateToken(*JSX_BASE_SCOPES, "variable.other.readwrite.js"),
+			TokenType.BAD_CHARACTER,
+		)
+		for (token in unchangedTokens) {
+			assertEquals(listOf(delegated), highlighter.getTokenHighlights(token).toList())
+		}
+	}
+
+	private fun capture(extension: String): Map<RoleProbe, TokenEvidence> {
+		val source = fixture("issue-100.$extension")
+		myFixture.configureByText("issue-100.$extension", source)
+		val editor = myFixture.editor as EditorEx
+		// TSX member roles are semantic overlays, not EditorHighlighter lexer keys.
+		// TSRX has no PSI overlay, so its TextMate syntax keys carry the role.
+		val semanticHighlights = if (extension == "tsx") myFixture.doHighlighting() else emptyList()
+		return ROLE_PROBES.associateWith { probe ->
+			val offset = source.indexOfOccurrence(probe.text, probe.occurrence)
+			val iterator = editor.highlighter.createIterator(offset)
+			val semanticKeys = semanticHighlights
+				.filter { it.startOffset <= offset && offset < it.endOffset }
+				.mapNotNull { it.forcedTextAttributesKey ?: it.type.attributesKey }
+			TokenEvidence(
+				tokenType = iterator.tokenType,
+				syntaxKeys = iterator.textAttributesKeys.toList(),
+				semanticKeys = semanticKeys,
+			)
+		}
+	}
+
+	private fun TokenEvidence.normalizedRole(fileKind: FileKind): TokenRole? {
+		val identities = (syntaxKeys + semanticKeys).flatMapTo(linkedSetOf()) { it.fallbackIdentities() }
+		return when (fileKind) {
+			FileKind.TSX -> when {
+				"TS.INSTANCE_MEMBER_VARIABLE" in identities -> TokenRole.INSTANCE_FIELD
+				"TS.INSTANCE_MEMBER_FUNCTION" in identities -> TokenRole.INSTANCE_METHOD
+				"XML_TAG_NAME" in identities -> TokenRole.TAG
+				"DEFAULT_ATTRIBUTE" in identities -> TokenRole.ATTRIBUTE
+				"DEFAULT_TAG" in identities -> TokenRole.DELIMITER
+				else -> null
+			}
+
+			FileKind.TSRX -> {
+				val scopes = (tokenType as? TextMateElementType)?.scope?.names().orEmpty()
+				when {
+					"TS.INSTANCE_MEMBER_VARIABLE" in identities -> TokenRole.INSTANCE_FIELD
+					"TS.INSTANCE_MEMBER_FUNCTION" in identities -> TokenRole.INSTANCE_METHOD
+					"entity.name.tag.js" in scopes -> TokenRole.TAG
+					"punctuation.definition.tag.begin.js" in scopes ||
+						"punctuation.definition.tag.end.js" in scopes -> TokenRole.DELIMITER
+					"entity.other.attribute-name.js" in scopes -> TokenRole.ATTRIBUTE
+					else -> null
+				}
+			}
+		}
+	}
+
+	private fun TextAttributesKey.fallbackIdentities(): List<String> =
+		generateSequence(this) { it.fallbackAttributeKey }
+			.map(TextAttributesKey::getExternalName)
+			.toList()
+
+	private fun TextMateScope.names(): Set<String> = buildSet {
+		var current: TextMateScope? = this@names
+		while (current != null) {
+			add(current.scopeName.toString())
+			current = current.parent
+		}
+	}
+
+	private fun textMateToken(vararg scopes: String): TextMateElementType {
+		var scope = TextMateScope.EMPTY
+		for (name in scopes) scope = scope.add(name)
+		return TextMateElementType(scope)
+	}
+
+	private fun fixture(name: String): String =
+		Path.of("src/test/resources/highlighting", name).readText()
+
+	private fun String.indexOfOccurrence(text: String, occurrence: Int): Int {
+		var offset = -1
+		repeat(occurrence + 1) {
+			offset = indexOf(text, offset + 1)
+			check(offset >= 0) { "Missing occurrence $occurrence of $text" }
+		}
+		return offset
+	}
+
+	private data class TokenEvidence(
+		val tokenType: IElementType,
+		val syntaxKeys: List<TextAttributesKey>,
+		val semanticKeys: List<TextAttributesKey>,
+	)
+
+	private data class RoleProbe(
+		val text: String,
+		val expectedRole: TokenRole,
+		val occurrence: Int = 0,
+	)
+
+	private enum class FileKind { TSX, TSRX }
+
+	private enum class TokenRole { TAG, DELIMITER, ATTRIBUTE, INSTANCE_FIELD, INSTANCE_METHOD }
+
+	companion object {
+		private val ROLE_PROBES = listOf(
+			RoleProbe("ul", TokenRole.TAG),
+			RoleProbe("<", TokenRole.DELIMITER),
+			RoleProbe("key", TokenRole.ATTRIBUTE),
+			RoleProbe("className", TokenRole.ATTRIBUTE),
+			RoleProbe("length", TokenRole.INSTANCE_FIELD),
+			RoleProbe("map", TokenRole.INSTANCE_METHOD),
+			RoleProbe("text", TokenRole.INSTANCE_FIELD),
+		)
+		private val JSX_BASE_SCOPES = arrayOf(
+			"source.tsrx",
+			"meta.jsx.children.js",
+			"meta.embedded.expression.js",
+			"source.js.embedded.tsrx",
+		)
+		private val JSX_PROPERTY_SCOPES = arrayOf(
+			*JSX_BASE_SCOPES,
+			"support.variable.property.js",
+		)
+		private val JSX_METHOD_SCOPES = arrayOf(
+			*JSX_BASE_SCOPES,
+			"meta.function-call.js",
+			"entity.name.function.js",
+		)
+	}
+}

--- a/packages/intellij-plugin/src/test/kotlin/dev/tsrx/intellij_plugin/TsrxSyntaxHighlightingTest.kt
+++ b/packages/intellij-plugin/src/test/kotlin/dev/tsrx/intellij_plugin/TsrxSyntaxHighlightingTest.kt
@@ -9,15 +9,13 @@ import com.intellij.openapi.fileTypes.SyntaxHighlighter
 import com.intellij.psi.TokenType
 import com.intellij.psi.tree.IElementType
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import java.nio.file.Path
-import kotlin.io.path.readText
 import org.jetbrains.plugins.textmate.language.syntax.lexer.TextMateElementType
 import org.jetbrains.plugins.textmate.language.syntax.lexer.TextMateScope
 
 class TsrxSyntaxHighlightingTest : BasePlatformTestCase() {
 	fun testIssue100RolesMatchTsxReference() {
-		val tsx = capture("tsx")
-		val tsrx = capture("tsrx")
+		val tsx = capture(FileKind.TSX)
+		val tsrx = capture(FileKind.TSRX)
 
 		for (probe in ROLE_PROBES) {
 			assertEquals(
@@ -62,6 +60,14 @@ class TsrxSyntaxHighlightingTest : BasePlatformTestCase() {
 			),
 			highlighter.getTokenHighlights(textMateToken(*JSX_METHOD_SCOPES)).toList(),
 		)
+		assertEquals(
+			listOf(
+				delegated,
+				DefaultLanguageHighlighterColors.INSTANCE_FIELD,
+				TsrxMemberRoleKeys.INSTANCE_MEMBER_VARIABLE,
+			),
+			highlighter.getTokenHighlights(textMateToken(*JSX_ATTRIBUTE_PROPERTY_SCOPES)).toList(),
+		)
 
 		val unchangedTokens = listOf(
 			textMateToken("source.tsrx", "support.variable.property.js"),
@@ -80,13 +86,13 @@ class TsrxSyntaxHighlightingTest : BasePlatformTestCase() {
 		}
 	}
 
-	private fun capture(extension: String): Map<RoleProbe, TokenEvidence> {
-		val source = fixture("issue-100.$extension")
-		myFixture.configureByText("issue-100.$extension", source)
+	private fun capture(fileKind: FileKind): Map<RoleProbe, TokenEvidence> {
+		val source = fixture("issue-100.${fileKind.extension}")
+		myFixture.configureByText("issue-100.${fileKind.extension}", source)
 		val editor = myFixture.editor as EditorEx
 		// TSX member roles are semantic overlays, not EditorHighlighter lexer keys.
 		// TSRX has no PSI overlay, so its TextMate syntax keys carry the role.
-		val semanticHighlights = if (extension == "tsx") myFixture.doHighlighting() else emptyList()
+		val semanticHighlights = if (fileKind == FileKind.TSX) myFixture.doHighlighting() else emptyList()
 		return ROLE_PROBES.associateWith { probe ->
 			val offset = source.indexOfOccurrence(probe.text, probe.occurrence)
 			val iterator = editor.highlighter.createIterator(offset)
@@ -103,27 +109,21 @@ class TsrxSyntaxHighlightingTest : BasePlatformTestCase() {
 
 	private fun TokenEvidence.normalizedRole(fileKind: FileKind): TokenRole? {
 		val identities = (syntaxKeys + semanticKeys).flatMapTo(linkedSetOf()) { it.fallbackIdentities() }
+		if ("TS.INSTANCE_MEMBER_VARIABLE" in identities) return TokenRole.INSTANCE_FIELD
+		if ("TS.INSTANCE_MEMBER_FUNCTION" in identities) return TokenRole.INSTANCE_METHOD
 		return when (fileKind) {
 			FileKind.TSX -> when {
-				"TS.INSTANCE_MEMBER_VARIABLE" in identities -> TokenRole.INSTANCE_FIELD
-				"TS.INSTANCE_MEMBER_FUNCTION" in identities -> TokenRole.INSTANCE_METHOD
 				"XML_TAG_NAME" in identities -> TokenRole.TAG
 				"DEFAULT_ATTRIBUTE" in identities -> TokenRole.ATTRIBUTE
 				"DEFAULT_TAG" in identities -> TokenRole.DELIMITER
 				else -> null
 			}
 
-			FileKind.TSRX -> {
-				val scopes = (tokenType as? TextMateElementType)?.scope?.names().orEmpty()
-				when {
-					"TS.INSTANCE_MEMBER_VARIABLE" in identities -> TokenRole.INSTANCE_FIELD
-					"TS.INSTANCE_MEMBER_FUNCTION" in identities -> TokenRole.INSTANCE_METHOD
-					"entity.name.tag.js" in scopes -> TokenRole.TAG
-					"punctuation.definition.tag.begin.js" in scopes ||
-						"punctuation.definition.tag.end.js" in scopes -> TokenRole.DELIMITER
-					"entity.other.attribute-name.js" in scopes -> TokenRole.ATTRIBUTE
-					else -> null
-				}
+			FileKind.TSRX -> when {
+				"HTML_TAG_NAME" in identities -> TokenRole.TAG
+				"DEFAULT_ATTRIBUTE" in identities -> TokenRole.ATTRIBUTE
+				"DEFAULT_TAG" in identities -> TokenRole.DELIMITER
+				else -> null
 			}
 		}
 	}
@@ -133,14 +133,6 @@ class TsrxSyntaxHighlightingTest : BasePlatformTestCase() {
 			.map(TextAttributesKey::getExternalName)
 			.toList()
 
-	private fun TextMateScope.names(): Set<String> = buildSet {
-		var current: TextMateScope? = this@names
-		while (current != null) {
-			add(current.scopeName.toString())
-			current = current.parent
-		}
-	}
-
 	private fun textMateToken(vararg scopes: String): TextMateElementType {
 		var scope = TextMateScope.EMPTY
 		for (name in scopes) scope = scope.add(name)
@@ -148,7 +140,9 @@ class TsrxSyntaxHighlightingTest : BasePlatformTestCase() {
 	}
 
 	private fun fixture(name: String): String =
-		Path.of("src/test/resources/highlighting", name).readText()
+		checkNotNull(javaClass.classLoader.getResource("highlighting/$name")) {
+			"Missing highlighting fixture: $name"
+		}.readText()
 
 	private fun String.indexOfOccurrence(text: String, occurrence: Int): Int {
 		var offset = -1
@@ -171,7 +165,10 @@ class TsrxSyntaxHighlightingTest : BasePlatformTestCase() {
 		val occurrence: Int = 0,
 	)
 
-	private enum class FileKind { TSX, TSRX }
+	private enum class FileKind(val extension: String) {
+		TSX("tsx"),
+		TSRX("tsrx"),
+	}
 
 	private enum class TokenRole { TAG, DELIMITER, ATTRIBUTE, INSTANCE_FIELD, INSTANCE_METHOD }
 
@@ -184,6 +181,7 @@ class TsrxSyntaxHighlightingTest : BasePlatformTestCase() {
 			RoleProbe("length", TokenRole.INSTANCE_FIELD),
 			RoleProbe("map", TokenRole.INSTANCE_METHOD),
 			RoleProbe("text", TokenRole.INSTANCE_FIELD),
+			RoleProbe("title", TokenRole.INSTANCE_FIELD, occurrence = 1),
 		)
 		private val JSX_BASE_SCOPES = arrayOf(
 			"source.tsrx",
@@ -199,6 +197,13 @@ class TsrxSyntaxHighlightingTest : BasePlatformTestCase() {
 			*JSX_BASE_SCOPES,
 			"meta.function-call.js",
 			"entity.name.function.js",
+		)
+		private val JSX_ATTRIBUTE_PROPERTY_SCOPES = arrayOf(
+			"source.tsrx",
+			"meta.tag.attributes.js",
+			"meta.embedded.expression.js",
+			"source.js.embedded.tsrx",
+			"support.variable.property.js",
 		)
 	}
 }

--- a/packages/intellij-plugin/src/test/resources/highlighting/issue-100.tsrx
+++ b/packages/intellij-plugin/src/test/resources/highlighting/issue-100.tsrx
@@ -1,11 +1,5 @@
-const output = (
-	<ul title={viewModel.title}>
-		{visibleItems.length > 0
-			? visibleItems.map((item) => (
-					<li key={item.text}>{item.label}</li>
-				))
-			: (
-					<li className="no-todos">No todos</li>
-			)}
-	</ul>
-);
+const list = <ul title={viewModel.title} />;
+const count = <p>{visibleItems.length}</p>;
+const items = <p>{visibleItems.map(renderItem)}</p>;
+const keyed = <li key={item.text}>{item.label}</li>;
+const empty = <li className="no-todos">No todos</li>;

--- a/packages/intellij-plugin/src/test/resources/highlighting/issue-100.tsrx
+++ b/packages/intellij-plugin/src/test/resources/highlighting/issue-100.tsrx
@@ -1,0 +1,11 @@
+const output = (
+	<ul>
+		{visibleItems.length > 0
+			? visibleItems.map((item) => (
+					<li key={item.text}>{item.label}</li>
+				))
+			: (
+					<li className="no-todos">No todos</li>
+			)}
+	</ul>
+);

--- a/packages/intellij-plugin/src/test/resources/highlighting/issue-100.tsrx
+++ b/packages/intellij-plugin/src/test/resources/highlighting/issue-100.tsrx
@@ -1,5 +1,5 @@
 const output = (
-	<ul>
+	<ul title={viewModel.title}>
 		{visibleItems.length > 0
 			? visibleItems.map((item) => (
 					<li key={item.text}>{item.label}</li>

--- a/packages/intellij-plugin/src/test/resources/highlighting/issue-100.tsrx
+++ b/packages/intellij-plugin/src/test/resources/highlighting/issue-100.tsrx
@@ -1,5 +1,5 @@
 const list = <ul title={viewModel.title} />;
 const count = <p>{visibleItems.length}</p>;
 const items = <p>{visibleItems.map(renderItem)}</p>;
-const keyed = <li key={item.text}>{item.label}</li>;
+const row = <li key={item.text}>{item.label}</li>;
 const empty = <li className="no-todos">No todos</li>;

--- a/packages/intellij-plugin/src/test/resources/highlighting/issue-100.tsx
+++ b/packages/intellij-plugin/src/test/resources/highlighting/issue-100.tsx
@@ -1,11 +1,5 @@
-const output = (
-	<ul title={viewModel.title}>
-		{visibleItems.length > 0
-			? visibleItems.map((item) => (
-					<li key={item.text}>{item.label}</li>
-				))
-			: (
-					<li className="no-todos">No todos</li>
-			)}
-	</ul>
-);
+const list = <ul title={viewModel.title} />;
+const count = <p>{visibleItems.length}</p>;
+const items = <p>{visibleItems.map(renderItem)}</p>;
+const keyed = <li key={item.text}>{item.label}</li>;
+const empty = <li className="no-todos">No todos</li>;

--- a/packages/intellij-plugin/src/test/resources/highlighting/issue-100.tsx
+++ b/packages/intellij-plugin/src/test/resources/highlighting/issue-100.tsx
@@ -1,0 +1,11 @@
+const output = (
+	<ul>
+		{visibleItems.length > 0
+			? visibleItems.map((item) => (
+					<li key={item.text}>{item.label}</li>
+				))
+			: (
+					<li className="no-todos">No todos</li>
+			)}
+	</ul>
+);

--- a/packages/intellij-plugin/src/test/resources/highlighting/issue-100.tsx
+++ b/packages/intellij-plugin/src/test/resources/highlighting/issue-100.tsx
@@ -1,5 +1,5 @@
 const output = (
-	<ul>
+	<ul title={viewModel.title}>
 		{visibleItems.length > 0
 			? visibleItems.map((item) => (
 					<li key={item.text}>{item.label}</li>

--- a/packages/intellij-plugin/src/test/resources/highlighting/issue-100.tsx
+++ b/packages/intellij-plugin/src/test/resources/highlighting/issue-100.tsx
@@ -1,5 +1,5 @@
 const list = <ul title={viewModel.title} />;
 const count = <p>{visibleItems.length}</p>;
 const items = <p>{visibleItems.map(renderItem)}</p>;
-const keyed = <li key={item.text}>{item.label}</li>;
+const row = <li key={item.text}>{item.label}</li>;
 const empty = <li className="no-todos">No todos</li>;

--- a/packages/vscode-plugin/tests/grammar.test.js
+++ b/packages/vscode-plugin/tests/grammar.test.js
@@ -186,3 +186,97 @@ describe('TSRX TextMate grammar: <style> blocks', () => {
 		expect(find(tokens, '</').scopes).toContain('style.tag.js');
 	});
 });
+
+describe('TSRX TextMate grammar: JSX expression boundaries', () => {
+	it('highlights the issue #100 JSX structure and embedded expressions independently', () => {
+		const tokens = tokenize(
+			[
+				'const output = (',
+				'  <ul>',
+				'    {visibleItems.length > 0',
+				'      ? visibleItems.map((item) => (',
+				'          <li key={item.text}>{item.text}</li>',
+				'        ))',
+				'      : (',
+				'          <li className="no-todos">No todos</li>',
+				'        )}',
+				'  </ul>',
+				');',
+			].join('\n'),
+		);
+
+		// Tag names and delimiters are separate evidence categories.
+		expect(find(tokens, 'ul').scopes).toContain('entity.name.tag.js');
+		expect(find(tokens, 'ul', 1).scopes).toContain('entity.name.tag.js');
+		expect(find(tokens, 'li').scopes).toContain('entity.name.tag.js');
+		expect(find(tokens, 'li', 1).scopes).toContain('entity.name.tag.js');
+		expect(find(tokens, '<').scopes).toContain('punctuation.definition.tag.begin.js');
+		expect(find(tokens, '</').scopes).toContain('punctuation.definition.tag.begin.js');
+		expect(find(tokens, '>').scopes).toContain('punctuation.definition.tag.end.js');
+
+		// Attribute names are asserted independently from their values.
+		expect(find(tokens, 'key').scopes).toContain('entity.other.attribute-name.js');
+		expect(find(tokens, 'className').scopes).toContain('entity.other.attribute-name.js');
+
+		// Embedded expression objects, methods, and properties keep distinct roles.
+		expect(find(tokens, 'visibleItems').scopes).toContain('variable.other.object.js');
+		expect(find(tokens, 'length').scopes).toContain('support.variable.property.js');
+		expect(find(tokens, 'visibleItems', 1).scopes).toContain('variable.other.object.js');
+		expect(find(tokens, 'map').scopes).toContain('entity.name.function.js');
+		expect(find(tokens, 'text').scopes).toContain('variable.other.property.js');
+		expect(find(tokens, 'text', 1).scopes).toContain('variable.other.property.js');
+	});
+
+	it.each([
+		['return', ['function view() {', '  return (', '    <div />', '  );', '}'].join('\n')],
+		['arrow body', ['const view = () => (', '  <div />', ');'].join('\n')],
+		['initializer', ['const view = (', '  <div />', ');'].join('\n')],
+	])('recognizes JSX after a multiline %s boundary', (_name, code) => {
+		const tokens = tokenize(code);
+
+		expect(find(tokens, 'div').scopes).toContain('entity.name.tag.js');
+		expect(find(tokens, '<').scopes).toContain('punctuation.definition.tag.begin.js');
+		expect(find(tokens, '/>').scopes).toContain('punctuation.definition.tag.end.js');
+	});
+
+	it('does not reclassify relational, shift, generic, or type syntax as JSX', () => {
+		const tokens = tokenize(
+			[
+				'const less = a < b;',
+				'const lessOrEqual = a <= b;',
+				'const shifted = a << b;',
+				'const called = fn<T>(x);',
+				'const identity = <T,>(value: T): T => value;',
+				'type Box<T> = { value: T };',
+			].join('\n'),
+		);
+
+		for (const token of tokens) {
+			expect(token.scopes).not.toContain('meta.tag.js');
+			expect(token.scopes).not.toContain('punctuation.definition.tag.begin.js');
+			expect(token.scopes).not.toContain('entity.name.tag.js');
+			expect(token.scopes).not.toContain('meta.jsx.children.js');
+		}
+	});
+
+	it('preserves representative @if and @for directive scopes', () => {
+		const tokens = tokenize(
+			[
+				'function App(items) @{',
+				'  @if (items.length > 0) {',
+				'    <div />',
+				'  }',
+				'  @for (const item of items) {',
+				'    <span>{item}</span>',
+				'  }',
+				'}',
+			].join('\n'),
+		);
+
+		expect(find(tokens, '@').scopes).toContain('keyword.control.directive.tsrx');
+		expect(find(tokens, 'if').scopes).toContain('keyword.control.directive.tsrx');
+		expect(find(tokens, '@', 1).scopes).toContain('keyword.control.directive.tsrx');
+		expect(find(tokens, 'for').scopes).toContain('keyword.control.directive.tsrx');
+		expect(find(tokens, 'item', 1).scopes).toContain('meta.embedded.expression.js');
+	});
+});

--- a/packages/vscode-plugin/tests/grammar.test.js
+++ b/packages/vscode-plugin/tests/grammar.test.js
@@ -245,9 +245,13 @@ describe('TSRX TextMate grammar: JSX expression boundaries', () => {
 				'const less = a < b;',
 				'const lessOrEqual = a <= b;',
 				'const shifted = a << b;',
+				'const chained = a < b && c > d;',
+				'const arithmetic = a < b + c;',
+				'const between = a < b > c;',
 				'const called = fn<T>(x);',
 				'const identity = <T,>(value: T): T => value;',
 				'type Box<T> = { value: T };',
+				'const next = value.method();',
 			].join('\n'),
 		);
 
@@ -257,6 +261,17 @@ describe('TSRX TextMate grammar: JSX expression boundaries', () => {
 			expect(token.scopes).not.toContain('entity.name.tag.js');
 			expect(token.scopes).not.toContain('meta.jsx.children.js');
 		}
+		expect(find(tokens, 'method').scopes).toContain('entity.name.function.js');
+	});
+
+	it('keeps tag-shaped comparisons in directive conditions outside JSX', () => {
+		const tokens = tokenize(
+			['function App() @{', '  @if (a < b && c > d) {', '    <div />', '  }', '}'].join('\n'),
+		);
+
+		expect(find(tokens, 'b').scopes).not.toContain('meta.tag.js');
+		expect(find(tokens, 'b').scopes).not.toContain('entity.name.tag.js');
+		expect(find(tokens, 'div').scopes).toContain('entity.name.tag.js');
 	});
 
 	it('preserves representative @if and @for directive scopes', () => {


### PR DESCRIPTION
## Summary

TSRX files now preserve shared TSX highlighting roles across JSX structure and embedded members in WebStorm, including JSX reached after multiline expression boundaries. Guarded grammar entry keeps comparison, shift, generic-call, generic-arrow, and type syntax out of JSX while a narrow IntelliJ adapter closes the member-role gap without requiring the JavaScript plugin.

This is the syntax-color parity slice of issue 100. Rainbow Brackets support remains separate follow-up work.

## Design decisions

- The canonical TextMate grammar remains the source of JSX recognition for every editor consumer.
- IntelliJ remaps only property and method leaf scopes inside TSRX JSX expressions, delegates every unrelated token, and uses theme keys rather than hard-coded colors.
- Automated parity compares real fallback-key identities for WebStorm roles; lexical scope assertions remain in the shared grammar suite.

## Validation

- VS Code grammar project: 2 files, 15 tests passed, including multiline JSX and tag-shaped comparison regressions.
- IntelliJ package project: 1 file, 11 tests passed.
- Gradle `test`, `verifyPluginProjectConfiguration`, `buildPlugin`, `verifyPluginStructure`, and `verifyPlugin` passed; Plugin Verifier reports compatibility with WS-252.27397.92.
- TextMate plist regeneration produced the same SHA-256 twice: `c2f3adf79c8b8c88af2e2457e23918a6de8ee89326bb87ded5d3580878a80f48`.
- Changeset checks and focused formatting checks passed.

## Unapplied review findings

- [ ] Install the built ZIP in WebStorm 2025.2.4 under Darcula and compare the paired issue fixtures. The automated environment had no safe scriptable GUI profile; `packages/intellij-plugin/DEVELOPMENT.md` records the exact side-by-side procedure.

Related: tsrx-org/tsrx#100

Session-settled decisions carried from planning: syntax-color parity first (user-approved, over bundling Rainbow Brackets); token-role parity within one theme (user-approved, over pixel-identical native semantic highlighting).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to TextMate scopes and an IntelliJ syntax-highlighter adapter with broad automated tests; no runtime, auth, or data-path impact.
> 
> **Overview**
> Improves **TSRX JSX syntax-color parity with TSX** (issue #100) by fixing TextMate recognition of JSX after multiline expression boundaries and tightening how member calls vs standalone calls are scoped inside `{…}`.
> 
> The shared grammar now wires JSX tag rules into `expressionWithoutIdentifiers` and tags dotted callees with `meta.method-call.js` so `map`-style members differ from bare `format()` calls. VS Code gets expanded grammar tests for multiline JSX, comparison/generic false positives, and method vs function roles.
> 
> **IntelliJ/WebStorm** no longer uses the stock TextMate highlighter alone: `TsrxSyntaxHighlighterFactory` delegates to TextMate but **only** augments property/method tokens inside JSX embedded expressions with WebStorm theme keys (`TS.INSTANCE_MEMBER_*`), leaving other tokens unchanged. Plugin docs add a manual Darcula side-by-side check against paired `issue-100` fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16949e38a9b86eb3c12853c37e3257e1cf363167. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->